### PR TITLE
Added Grbl startup emulation message

### DIFF
--- a/uCNC/config.h
+++ b/uCNC/config.h
@@ -193,6 +193,11 @@
 //#define FORCE_SOFT_POLLING
 
 /*
+	Modifies the startup message to emulate Grbl (required by some programs so that uCNC is recognized a Grbl protocol controller device)
+*/
+//#define EMULATE_GRBL_STARTUP
+
+/*
 	Compilation specific options
 */
 //ensure all variables are set to 0 at start up

--- a/uCNC/grbl_interface.h
+++ b/uCNC/grbl_interface.h
@@ -123,8 +123,13 @@
 #define MSG_ERROR __romstr__("error:")
 #define MSG_ALARM __romstr__("ALARM:")
 #define MSG_ECHO __romstr__("[echo:")
+#ifndef EMULATE_GRBL_STARTUP
 #define MSG_STARTUP_START "uCNC "
 #define MSG_STARTUP_END " ['$' for help]\r\n"
+#else
+#define MSG_STARTUP_START "Grbl "
+#define MSG_STARTUP_END " ['$' for uCNC help]\r\n"
+#endif
 #define MSG_STARTUP __romstr__(MSG_STARTUP_START VERSION MSG_STARTUP_END)
 #define MSG_HELP __romstr__("[HLP:$$ $# $G $I $N $x=val $Nx=line $J=line $C $X $H ~ ! ? ctrl-x]\r\n")
 


### PR DESCRIPTION
-added configurable Grbl startup message emulation (compatibility mode). Some Grbl applications expect to get the "Grbl 1.x" message to recognize the device.