### PR TITLE
Sync serial optimization

### DIFF
--- a/makefiles/avr/makefile
+++ b/makefiles/avr/makefile
@@ -3,7 +3,7 @@
 MCU 	 = atmega328p
 CC       = avr-gcc
 LIBS     = -w -Os -gdwarf-2 -flto -fuse-linker-plugin -Wl,--gc-sections,--relax -mmcu=$(MCU)
-CFLAGS   = -I"../../src/" -Os -Wall -Wextra -D__DEBUG__ -Os -gdwarf-2 -w -std=gnu99 -ffunction-sections -fdata-sections -mcall-prologues -mrelax -MMD -flto -fno-fat-lto-objects -mmcu=$(MCU) -DF_CPU=16000000L
+CFLAGS   = -I"../../src/" -Os -Wall -Wextra -gdwarf-2 -w -std=gnu99 -ffunction-sections -fdata-sections -mcall-prologues -mrelax -MMD -flto -fno-fat-lto-objects -mmcu=$(MCU) -DF_CPU=16000000L
 BIN      = $(BUILDDIR)/uCNC.elf
 HEX      = $(BIN:.elf=.hex)
 SOURCEDIR= ../../src

--- a/makefiles/stm32f103/Makefile
+++ b/makefiles/stm32f103/Makefile
@@ -14,7 +14,7 @@
 # target
 ######################################
 TARGET = uCNC
-USE_USB = TRUE
+#USE_USB = TRUE
 
 ######################################
 # building variables

--- a/src/hal/mcus/avr/mcumap_avr.h
+++ b/src/hal/mcus/avr/mcumap_avr.h
@@ -3595,8 +3595,8 @@ extern "C"
 		ADCH;                                           \
 	})
 #ifdef PROBE_ISR
-#define mcu_enable_probe_isr() SETFLAG(PROBE_ISRREG, PROBE_ISR_MASK)
-#define mcu_disable_probe_isr() CLEARFLAG(PROBE_ISRREG, PROBE_ISR_MASK)
+#define mcu_enable_probe_isr() (SETFLAG(PROBE_ISRREG, PROBE_ISR_MASK))
+#define mcu_disable_probe_isr() (CLEARFLAG(PROBE_ISRREG, PROBE_ISR_MASK))
 #else
 #define mcu_enable_probe_isr()
 #define mcu_disable_probe_isr()
@@ -3605,13 +3605,8 @@ extern "C"
 #define mcu_enable_global_isr sei
 #define mcu_disable_global_isr cli
 
-#ifndef ENABLE_SYNC_TX
-#define mcu_enable_tx_isr() SETBIT(UCSRB, UDRIE)
-#define mcu_disable_tx_isr() CLEARBIT(UCSRB, UDRIE)
-#else
-#define mcu_enable_tx_isr()
-#define mcu_disable_tx_isr()
-#endif
+#define mcu_tx_ready() (CHECKBIT(UCSRA, UDRE))
+#define mcu_rx_ready() (CHECKBIT(UCSRA, RX))
 
 #ifdef __cplusplus
 }

--- a/src/hal/mcus/mcu.h
+++ b/src/hal/mcus/mcu.h
@@ -123,19 +123,17 @@ extern "C"
 #endif
 
 /**
- * enables the uart TX mcu isr when the tx register is empty (or in alternative transmition is completed)
- * can be defined either as a function or a macro call
+ * checks if the serial hardware of the MCU is ready do send the next char
  * */
-#ifndef mcu_enable_tx_isr
-	void mcu_enable_tx_isr(void); //Start async send
+#ifndef mcu_tx_ready
+	bool mcu_tx_ready(void); //Start async send
 #endif
 
 /**
- * disables the uart TX mcu isr when the tx register is empty (or in alternative transmition is completed)
- * can be defined either as a function or a macro call
+ * checks if the serial hardware of the MCU has a new char ready to be read
  * */
-#ifndef mcu_disable_tx_isr
-	void mcu_disable_tx_isr(void); //Stop async send
+#ifndef mcu_rx_ready
+	bool mcu_rx_ready(void); //Stop async send
 #endif
 
 /**

--- a/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
+++ b/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
@@ -190,14 +190,12 @@ extern "C"
 		{
 			unsigned char c = COM_INREG;
 			serial_rx_isr(c);
-			COM_USART->SR &= ~USART_SR_RXNE;
 		}
 #endif
 
 #ifndef ENABLE_SYNC_TX
 		if (COM_USART->SR & (USART_SR_TXE | USART_SR_TC))
 		{
-			COM_USART->SR &= ~(USART_SR_TXE | USART_SR_TC);
 			COM_USART->CR1 &= ~(USART_CR1_TXEIE);
 			serial_tx_isr();
 		}
@@ -889,6 +887,10 @@ extern "C"
 		COM_USART->CR1 |= USART_CR1_RXNEIE; // enable RXNEIE
 #endif
 		COM_USART->CR1 |= USART_CR1_UE; //Enable UART
+#ifdef ENABLE_SYNC_TX
+		//this null char is needed to set TXE bit by the harware
+		COM_OUTREG = 0;
+#endif
 #else
 		//configure USB as Virtual COM port
 		RCC->APB1ENR &= ~RCC_APB1ENR_USBEN;

--- a/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
+++ b/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
@@ -50,10 +50,9 @@ extern "C"
 #define rom_memcpy memcpy
 #define rom_read_byte *
 
-//on this MCU force sync TX (async does not work well in UART)
-#define ENABLE_SYNC_TX
 #ifdef USB_VCP
 //if USB VCP is used force RX sync also
+#define ENABLE_SYNC_TX
 #define ENABLE_SYNC_RX
 #endif
 

--- a/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
+++ b/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
@@ -3149,17 +3149,26 @@ extern "C"
 #define mcu_enable_global_isr __enable_irq
 #define mcu_disable_global_isr __disable_irq
 
+// #ifdef COM_PORT
+// #ifndef ENABLE_SYNC_TX
+// #define mcu_enable_tx_isr() (COM_USART->CR1 |= (USART_CR1_TXEIE))
+// #define mcu_disable_tx_isr() (COM_USART->CR1 &= ~(USART_CR1_TXEIE))
+// #else
+// #define mcu_enable_tx_isr()
+// #define mcu_disable_tx_isr()
+// #endif
+// #else
+// #define mcu_enable_tx_isr()
+// #define mcu_disable_tx_isr()
+// #endif
 #ifdef COM_PORT
-#ifndef ENABLE_SYNC_TX
-#define mcu_enable_tx_isr() (COM_USART->CR1 |= (USART_CR1_TXEIE))
-#define mcu_disable_tx_isr() (COM_USART->CR1 &= ~(USART_CR1_TXEIE))
+#define mcu_rx_ready() (COM_USART->SR & USART_SR_RXNE)
+#define mcu_tx_ready() (COM_USART->SR & USART_SR_TXE)
 #else
-#define mcu_enable_tx_isr()
-#define mcu_disable_tx_isr()
+#ifdef USB_VCP
+#define mcu_rx_ready() tud_cdc_available()
+#define mcu_tx_ready() tud_cdc_write_available()
 #endif
-#else
-#define mcu_enable_tx_isr()
-#define mcu_disable_tx_isr()
 #endif
 
 #define GPIO_RESET 0xfU

--- a/src/hal/mcus/virtual/mcu_virtual.c
+++ b/src/hal/mcus/virtual/mcu_virtual.c
@@ -556,12 +556,6 @@ void mcu_dotasks(void)
 		serial_rx_isr(c);
 	}
 #endif
-#ifdef ENABLE_SYNC_TX
-	if (!serial_tx_is_empty())
-	{
-		serial_tx_isr();
-	}
-#endif
 }
 
 #endif

--- a/src/hal/mcus/virtual/mcumap_virtual.h
+++ b/src/hal/mcus/virtual/mcumap_virtual.h
@@ -90,6 +90,10 @@ extern virtports_t virtualports;
 #define COM_INREG virtualports->uart
 #define COM_OUTREG virtualports->uart
 
-#define mcu_dealy_ms(x) delay(x)
+//just to compile
+#define mcu_tx_ready() true
+#define mcu_rx_ready() true
+
+#define mcu_delay_ms(x) delay(x)
 
 #endif

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -121,6 +121,7 @@ extern "C"
 #define EXEC_ALARM_HOMING_FAIL_APPROACH 9
 #define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10
 #define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11
+#define EXEC_ALARM_STARTUP 255 //this is a special alarm that signals µCNC is starting up. It's not a real alarm.
 
 //formated messages
 #define STR_EOL "\r\n"

--- a/src/interface/serial.c
+++ b/src/interface/serial.c
@@ -32,10 +32,11 @@ extern "C"
     static volatile uint8_t serial_rx_read;
     static volatile uint8_t serial_rx_write;
     static volatile uint8_t serial_rx_overflow;
-
+#ifndef ENABLE_SYNC_TX
     static unsigned char serial_tx_buffer[TX_BUFFER_SIZE];
     static volatile uint8_t serial_tx_read;
     static volatile uint8_t serial_tx_write;
+#endif
 
     static uint8_t serial_read_select;
     static uint16_t serial_read_index;
@@ -47,13 +48,13 @@ extern "C"
 #ifdef FORCE_GLOBALS_TO_0
         serial_rx_write = 0;
         serial_rx_read = 0;
+        memset(serial_rx_buffer, 0, sizeof(serial_rx_buffer));
 
+#ifndef ENABLE_SYNC_TX
         serial_tx_read = 0;
         serial_tx_write = 0;
-
-        //resets buffers
-        memset(serial_rx_buffer, 0, sizeof(serial_rx_buffer));
         memset(serial_tx_buffer, 0, sizeof(serial_tx_buffer));
+#endif
 #endif
     }
 
@@ -69,11 +70,6 @@ extern "C"
         }
 
         return true;
-    }
-
-    bool serial_tx_is_empty(void)
-    {
-        return (serial_tx_write == serial_tx_read);
     }
 
     unsigned char serial_getc(void)
@@ -198,6 +194,7 @@ extern "C"
 
     void serial_putc(unsigned char c)
     {
+#ifndef ENABLE_SYNC_TX
         uint8_t write = serial_tx_write;
         if (++write == TX_BUFFER_SIZE)
         {
@@ -205,9 +202,6 @@ extern "C"
         }
         while (write == serial_tx_read)
         {
-#ifndef ENABLE_SYNC_TX
-            mcu_enable_tx_isr(); //starts async send and loops while buffer full
-#endif
             if (!cnc_dotasks()) //on any alarm abort
             {
                 return;
@@ -216,8 +210,19 @@ extern "C"
 
         serial_tx_buffer[serial_tx_write] = c;
         serial_tx_write = write;
-#ifndef ENABLE_SYNC_TX
-        mcu_enable_tx_isr();
+        if (c == '\n')
+        {
+            serial_flush();
+        }
+#else
+    while (!mcu_tx_ready())
+    {
+        if (!cnc_dotasks()) //on any alarm abort
+        {
+            return;
+        }
+    }
+    mcu_putc(c);
 #endif
     }
 
@@ -296,20 +301,6 @@ extern "C"
         } while (i);
     }
 #endif
-    /*
-void serial_print_int(uint16_t num)
-{
-	char buffer[6];
-	sprintf(buffer, MSG_INT, num);
-
-	uint8_t i = 0;
-	do
-	{
-		serial_putc(buffer[i]);
-		i++;
-	} while(buffer[i] != 0);
-
-}*/
 
     void serial_print_flt(float num)
     {
@@ -399,16 +390,16 @@ void serial_print_int(uint16_t num)
 
     void serial_flush(void)
     {
+#ifndef ENABLE_SYNC_TX
         while (serial_tx_write != serial_tx_read)
         {
-#ifndef ENABLE_SYNC_TX
-            mcu_enable_tx_isr();
-#endif
+            mcu_putc(0);
             if (!cnc_dotasks())
             {
                 return;
             }
         }
+#endif
     }
 
     //ISR
@@ -455,6 +446,7 @@ void serial_print_int(uint16_t num)
 
     void serial_tx_isr(void)
     {
+#ifndef ENABLE_SYNC_TX
         uint8_t read = serial_tx_read;
         if (read == serial_tx_write)
         {
@@ -467,13 +459,8 @@ void serial_print_int(uint16_t num)
             read = 0;
         }
         serial_tx_read = read;
-#ifndef ENABLE_SYNC_TX
-        if (read == serial_tx_write)
-        {
-            mcu_disable_tx_isr();
-        }
-#endif
         mcu_putc(c);
+#endif
     }
 
     void serial_rx_clear(void)

--- a/src/interface/serial.c
+++ b/src/interface/serial.c
@@ -29,13 +29,13 @@ extern "C"
 #include "interface/serial.h"
 
     static unsigned char serial_rx_buffer[RX_BUFFER_SIZE];
-    static volatile uint8_t serial_rx_read;
+    static uint8_t serial_rx_read;
     static volatile uint8_t serial_rx_write;
     static volatile uint8_t serial_rx_overflow;
 #ifndef ENABLE_SYNC_TX
     static unsigned char serial_tx_buffer[TX_BUFFER_SIZE];
     static volatile uint8_t serial_tx_read;
-    static volatile uint8_t serial_tx_write;
+    static uint8_t serial_tx_write;
 #endif
 
     static uint8_t serial_read_select;
@@ -75,7 +75,6 @@ extern "C"
     unsigned char serial_getc(void)
     {
         unsigned char c;
-        uint8_t read;
         switch (serial_read_select)
         {
         case SERIAL_UART:
@@ -87,13 +86,11 @@ extern "C"
                 }
             }
 
-            read = serial_rx_read;
-            c = serial_rx_buffer[read];
-            if (++read == RX_BUFFER_SIZE)
+            c = serial_rx_buffer[serial_rx_read];
+            if (++serial_rx_read == RX_BUFFER_SIZE)
             {
-                read = 0;
+                serial_rx_read = 0;
             }
-            serial_rx_read = read;
 
             switch (c)
             {

--- a/src/interface/serial.h
+++ b/src/interface/serial.h
@@ -54,7 +54,6 @@ extern "C"
 	void serial_rx_clear(void);
 	void serial_select(uint8_t source);
 
-	bool serial_tx_is_empty(void);
 	void serial_putc(unsigned char c);
 	void serial_print_str(const unsigned char *__s);
 	void serial_print_int(int16_t num);


### PR DESCRIPTION
-removed unneeded volatile attributes of some variables
-optimization for synchronous serial TX with direct serial output without buffer
-modified HAL for MCU for both serial TX and RX
-TX ISR must now disabled before putc. MCU putc enables ISR everytime.
-added initial NULL char sending after configuration of UART to force TXE hardware set for STM32
-deleted duplicate SYNC TX config for STM32