### PR TITLE
stm32 tinyusb functions fix

### DIFF
--- a/makefiles/stm32f103/Makefile
+++ b/makefiles/stm32f103/Makefile
@@ -14,7 +14,7 @@
 # target
 ######################################
 TARGET = uCNC
-#USE_USB = TRUE
+USE_USB = TRUE
 
 ######################################
 # building variables

--- a/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
+++ b/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
@@ -38,7 +38,7 @@ extern "C"
 #define F_CPU 72000000UL
 #endif
 //defines the maximum and minimum step rates
-#define F_STEP_MAX 30000
+#define F_STEP_MAX 100000
 #define F_STEP_MIN 4
 //defines special mcu to access flash strings and arrays
 #define __rom__
@@ -3185,8 +3185,8 @@ extern "C"
 #define mcu_tx_ready() (COM_USART->SR & USART_SR_TXE)
 #else
 #ifdef USB_VCP
-#define mcu_rx_ready() tud_cdc_available()
-#define mcu_tx_ready() tud_cdc_write_available()
+#define mcu_rx_ready() tud_cdc_n_available(0)
+#define mcu_tx_ready() tud_cdc_n_write_available(0)
 #endif
 #endif
 

--- a/tinyusb/README.md
+++ b/tinyusb/README.md
@@ -7,5 +7,5 @@
 µCNC uses [tinyUSB](https://github.com/hathach/tinyusb) to provide the stackframe to use the USB port (if the MCU has one) as a virtual COM port
 
 ## How to use tinyUSB
-Just extract the contents of [tinyUSB](https://github.com/hathach/tinyusb) here and compile the code for your board/MCU following the instructions for that specific board/MCU. This directory should contain at least the src directory of the tinyUSB source code.
+Just extract the contents of [tinyUSB](https://github.com/hathach/tinyusb) here and compile the code for your board/MCU following the instructions for that specific board/MCU. This directory should contain at least the src and hw directories of the tinyUSB source code project.
 


### PR DESCRIPTION
-function calls to check if write/read chars were available were pointing to static inline only visible within the same compilation unit) versions of the library and causing the build to fail.
-small update to tinyUSB readme file