### PR TITLE
Redesign sync motions and alarm status communications

### DIFF
--- a/src/cnc.c
+++ b/src/cnc.c
@@ -112,7 +112,7 @@ extern "C"
         cnc_state.loop_state = LOOP_ERROR_RESET;
 
         serial_flush();
-        if (cnc_get_exec_state(EXEC_ALARM)) //checks if any alarm is active (except NOHOME - ignore it)
+        if (cnc_get_exec_state(EXEC_ALARM)) //checks if any alarm is active
         {
             cnc_check_fault_systems();
             protocol_send_feedback(MSG_FEEDBACK_1);

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -30,6 +30,7 @@ extern "C"
 #define RT_CMD_STARTUP_BLOCK0 1
 #define RT_CMD_STARTUP_BLOCK1 2
 #define RT_CMD_REPORT 4
+#define RT_CMD_CYCLE_START 8
 #define RT_CMD_ABORT 128
 
 //feed_ovr_cmd
@@ -63,7 +64,6 @@ extern "C"
 #define EXEC_ABORT 128													//Emergency stop
 #define EXEC_ALARM (EXEC_NOHOME | EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT) //System alarms
 #define EXEC_ALARM_ABORT (EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT)			//System alarms checked after abort
-#define EXEC_LOCKED (EXEC_ALARM | EXEC_HOLD | EXEC_HOMING | EXEC_JOG)	//Gcode is locked by an active state
 #define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG)			//Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255												//All states
 
@@ -199,6 +199,7 @@ extern "C"
 	void cnc_alarm(uint8_t code);
 	void cnc_stop(void);
 	void cnc_unlock(void);
+	void cnc_delay_ms(uint32_t miliseconds);
 
 	uint8_t cnc_get_exec_state(uint8_t statemask);
 	void cnc_set_exec_state(uint8_t statemask);

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -61,8 +61,8 @@ extern "C"
 #define EXEC_HOMING 16											// Homing in execution
 #define EXEC_LIMITS 32											// Limit switch is active or position lost
 #define EXEC_DOOR 64											// Safety door open
-#define EXEC_ABORT 128											// Emergency stop
-#define EXEC_ALARM (EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT)		// System alarms
+#define EXEC_KILL 128											// Emergency stop
+#define EXEC_ALARM (EXEC_LIMITS | EXEC_DOOR | EXEC_KILL)		// System alarms
 #define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255										// All states
 

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -53,19 +53,18 @@ extern "C"
 #define RT_CMD_COOL_MST_TOGGLE 128
 
 //current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0														// All flags cleared
-#define EXEC_RUN 1														// Motions are being executed
-#define EXEC_HOLD 2														// Feed hold is active
-#define EXEC_JOG 4														// Jogging in execution
-#define EXEC_HOMING 8													// Homing in execution
-#define EXEC_NOHOME 16													//Homing enable but home position is unkowned
-#define EXEC_LIMITS 32													//Limit switch is active
-#define EXEC_DOOR 64													//Safety door open
-#define EXEC_ABORT 128													//Emergency stop
-#define EXEC_ALARM (EXEC_NOHOME | EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT) //System alarms
-#define EXEC_ALARM_ABORT (EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT)			//System alarms checked after abort
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG)			//Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 255												//All states
+#define EXEC_IDLE 0												// All flags cleared
+#define EXEC_RUN 1												// Motions are being executed
+#define EXEC_RESUMING 2											// Motions are being resumed from a hold
+#define EXEC_HOLD 4												// Feed hold is active
+#define EXEC_JOG 8												// Jogging in execution
+#define EXEC_HOMING 16											// Homing in execution
+#define EXEC_LIMITS 32											// Limit switch is active or position lost
+#define EXEC_DOOR 64											// Safety door open
+#define EXEC_ABORT 128											// Emergency stop
+#define EXEC_ALARM (EXEC_LIMITS | EXEC_DOOR | EXEC_ABORT)		// System alarms
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 255										// All states
 
 //creates a set of helper masks used to configure the controller
 #define ESTOP_MASK 1

--- a/src/core/interpolator.c
+++ b/src/core/interpolator.c
@@ -510,7 +510,7 @@ extern "C"
 #endif
 
         //starts the step isr if is stopped and there are segments to execute
-        if (!cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM | EXEC_RUN) && itp_sgm_data_segments) //exec state is not hold or alarm and not already running
+        if (!cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM | EXEC_RUN | EXEC_RESUMING) && itp_sgm_data_segments) //exec state is not hold or alarm and not already running
         {
             cnc_set_exec_state(EXEC_RUN); //flags that it started running
             mcu_start_itp_isr(itp_sgm_data[itp_sgm_data_read].timer_counter, itp_sgm_data[itp_sgm_data_read].timer_prescaller);

--- a/src/core/interpolator.h
+++ b/src/core/interpolator.h
@@ -38,6 +38,8 @@ extern "C"
 	void itp_get_rt_position(int32_t *position);
 	void itp_reset_rt_position(void);
 	float itp_get_rt_feed(void);
+	uint8_t itp_sync(void);
+	uint8_t itp_sync_spindle(void);
 #ifdef USE_SPINDLE
 	uint16_t itp_get_rt_spindle(void);
 #endif

--- a/src/core/io_control.c
+++ b/src/core/io_control.c
@@ -49,7 +49,7 @@ extern "C"
                     {
                         if (g_settings.homing_enabled)
                         {
-                            cnc_set_exec_state(EXEC_NOHOME); //if motions was executing flags home position lost
+                            cnc_set_exec_state(EXEC_LIMITS); //if motions was executing flags home position lost
                         }
 
                         cnc_alarm(EXEC_ALARM_HARD_LIMIT);

--- a/src/core/io_control.c
+++ b/src/core/io_control.c
@@ -47,7 +47,7 @@ extern "C"
                 {
                     if (!cnc_get_exec_state(EXEC_HOMING)) //if not in a homing motion triggers an alarm
                     {
-                        if (g_settings.homing_enabled)
+                        if (g_settings.hard_limits_enabled)
                         {
                             cnc_set_exec_state(EXEC_LIMITS); //if motions was executing flags home position lost
                         }

--- a/src/core/motion_control.c
+++ b/src/core/motion_control.c
@@ -195,118 +195,114 @@ extern "C"
         }
 
         uint8_t error = STATUS_OK;
+        int32_t step_new_pos[STEPPER_COUNT];
+        int32_t step_old_pos[STEPPER_COUNT];
+        //converts transformed target to stepper position
+        kinematics_apply_inverse(target, step_new_pos);
+        //calculates the amount of stepper motion for this motion
+        planner_get_position(step_old_pos);
 
-        if (!CHECKFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_NOMOTION))
+        uint32_t max_steps = 0;
+        block_data->dirbits = 0;
+        block_data->main_stepper = 255;
+        for (uint8_t i = STEPPER_COUNT; i != 0;)
         {
-            int32_t step_new_pos[STEPPER_COUNT];
-            int32_t step_old_pos[STEPPER_COUNT];
-            //converts transformed target to stepper position
-            kinematics_apply_inverse(target, step_new_pos);
-            //calculates the amount of stepper motion for this motion
-            planner_get_position(step_old_pos);
-
-            uint32_t max_steps = 0;
-            block_data->dirbits = 0;
-            block_data->main_stepper = 255;
-            for (uint8_t i = STEPPER_COUNT; i != 0;)
+            i--;
+            int32_t steps = step_new_pos[i] - step_old_pos[i];
+            if (steps < 0)
             {
-                i--;
-                int32_t steps = step_new_pos[i] - step_old_pos[i];
-                if (steps < 0)
-                {
-                    block_data->dirbits |= (1 << i);
-                }
-
-                steps = ABS(steps);
-                if (max_steps < steps)
-                {
-                    max_steps = steps;
-                    block_data->main_stepper = i;
-                }
+                block_data->dirbits |= (1 << i);
             }
 
-            //no significant motion will take place. don't send any thing to the planner
-            if (!max_steps)
+            steps = ABS(steps);
+            if (max_steps < steps)
             {
-                return STATUS_OK;
+                max_steps = steps;
+                block_data->main_stepper = i;
             }
+        }
 
-            //checks the amount of steps that this motion translates to
-            //if the amount of steps is higher than the limit for the 16bit bresenham algorithm
-            //splits the line into smaller segments
+        //no significant motion will take place. don't send any thing to the planner
+        if (!max_steps)
+        {
+            return STATUS_OK;
+        }
 
-            //calculates the aproximation of the inverted travelled distance
-            float inv_dist = 0;
-            float motion_segment[AXIS_COUNT];
-            for (uint8_t i = AXIS_COUNT; i != 0;)
-            {
-                i--;
-                motion_segment[i] = target[i] - prev_target[i];
-                block_data->dir_vect[i] = motion_segment[i];
-                inv_dist += fast_flt_pow2(block_data->dir_vect[i]);
-            }
+        //checks the amount of steps that this motion translates to
+        //if the amount of steps is higher than the limit for the 16bit bresenham algorithm
+        //splits the line into smaller segments
 
-            inv_dist = fast_flt_invsqrt(inv_dist);
+        //calculates the aproximation of the inverted travelled distance
+        float inv_dist = 0;
+        float motion_segment[AXIS_COUNT];
+        for (uint8_t i = AXIS_COUNT; i != 0;)
+        {
+            i--;
+            motion_segment[i] = target[i] - prev_target[i];
+            block_data->dir_vect[i] = motion_segment[i];
+            inv_dist += fast_flt_pow2(block_data->dir_vect[i]);
+        }
 
-            //calculates max junction speed factor in (axis driven). Else the cos_theta is calculated in the planner (linear actuator driven)
+        inv_dist = fast_flt_invsqrt(inv_dist);
+
+        //calculates max junction speed factor in (axis driven). Else the cos_theta is calculated in the planner (linear actuator driven)
 #ifndef ENABLE_LINACT_PLANNER
-            for (uint8_t i = AXIS_COUNT; i != 0;)
-            {
-                i--;
-                block_data->dir_vect[i] *= inv_dist;
-            }
+        for (uint8_t i = AXIS_COUNT; i != 0;)
+        {
+            i--;
+            block_data->dir_vect[i] *= inv_dist;
+        }
 #endif
 
-            //calculated the total motion execution time @ the given rate
-            float inv_delta = (!CHECKFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_INVERSEFEED) ? (block_data->feed * inv_dist) : (1.0f / block_data->feed));
-            block_data->feed = (float)max_steps * inv_delta;
+        //calculated the total motion execution time @ the given rate
+        float inv_delta = (!CHECKFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_INVERSEFEED) ? (block_data->feed * inv_dist) : (1.0f / block_data->feed));
+        block_data->feed = (float)max_steps * inv_delta;
 
-            //this contains a motion. Any tool update will be done here
-            block_data->update_tools = false;
-            uint32_t line_segments = 1;
-            if (max_steps > MAX_STEPS_PER_LINE)
+        //this contains a motion. Any tool update will be done here
+        block_data->update_tools = false;
+        uint32_t line_segments = 1;
+        if (max_steps > MAX_STEPS_PER_LINE)
+        {
+            line_segments += (max_steps >> MAX_STEPS_PER_LINE_BITS);
+            float m_inv = 1.0f / (float)line_segments;
+            for (uint8_t i = AXIS_COUNT; i != 0;)
             {
-                line_segments += (max_steps >> MAX_STEPS_PER_LINE_BITS);
-                float m_inv = 1.0f / (float)line_segments;
+                i--;
+                motion_segment[i] *= m_inv;
+            }
+        }
+
+        while (line_segments--)
+        {
+            while (planner_buffer_is_full())
+            {
+                if (!cnc_dotasks())
+                {
+                    block_data->feed = feed;
+                    return STATUS_CRITICAL_FAIL;
+                }
+            }
+
+            if (line_segments)
+            {
                 for (uint8_t i = AXIS_COUNT; i != 0;)
                 {
                     i--;
-                    motion_segment[i] *= m_inv;
+                    prev_target[i] += motion_segment[i];
+                }
+
+                error = mc_line_segment(prev_target, block_data);
+                if (error)
+                {
+                    break;
                 }
             }
-
-            while (line_segments--)
+            else
             {
-                while (planner_buffer_is_full())
+                error = mc_line_segment(target, block_data);
+                if (error)
                 {
-                    if (!cnc_dotasks())
-                    {
-                        block_data->feed = feed;
-                        return STATUS_CRITICAL_FAIL;
-                    }
-                }
-
-                if (line_segments)
-                {
-                    for (uint8_t i = AXIS_COUNT; i != 0;)
-                    {
-                        i--;
-                        prev_target[i] += motion_segment[i];
-                    }
-
-                    error = mc_line_segment(prev_target, block_data);
-                    if (error)
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    error = mc_line_segment(target, block_data);
-                    if (error)
-                    {
-                        break;
-                    }
+                    break;
                 }
             }
         }
@@ -449,23 +445,42 @@ extern "C"
 
     uint8_t mc_dwell(motion_data_t *block_data)
     {
-        if (mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
+        if (!mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
         {
-            return STATUS_OK;
+            mc_update_tools(block_data);
+            cnc_delay_ms(block_data->dwell);
         }
 
-        while (planner_buffer_is_full())
+        return STATUS_OK;
+    }
+
+    uint8_t mc_pause(void)
+    {
+        if (!mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
         {
-            if (!cnc_dotasks())
+            if (itp_sync())
             {
                 return STATUS_CRITICAL_FAIL;
             }
         }
 
-        //send dwell (planner linear motion with distance == 0)
-        SETFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_NOMOTION);
-        planner_add_line(NULL, block_data);
-        CLEARFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_NOMOTION);
+        cnc_set_exec_state(EXEC_HOLD);
+        return STATUS_OK;
+    }
+
+    uint8_t mc_update_tools(motion_data_t *block_data)
+    {
+        if (!mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
+        {
+            if (itp_sync())
+            {
+                return STATUS_CRITICAL_FAIL;
+            }
+            //synchronizes the tools
+            planner_sync_tools(block_data);
+            itp_sync_spindle();
+        }
+
         return STATUS_OK;
     }
 
@@ -503,7 +518,7 @@ extern "C"
         {
             max_home_dist = -max_home_dist;
         }
-        planner_resync_position();
+        planner_sync_position();
         mc_resync_position();
         mc_get_position(target);
         target[axis] += max_home_dist;
@@ -537,7 +552,7 @@ extern "C"
             return EXEC_ALARM_HOMING_FAIL_RESET;
         }
 
-        mcu_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
+        cnc_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
         limits_flags = io_get_limits();
 
         //the wrong switch was activated bails
@@ -550,7 +565,7 @@ extern "C"
         max_home_dist = g_settings.homing_offset * 5.0f;
 
         //sync's the planner and motion control done when clearing the planner
-        //planner_resync_position();
+        //planner_sync_position();
         mc_resync_position();
         mc_get_position(target);
         if (g_settings.homing_dir_invert_mask & axis_mask)
@@ -578,7 +593,7 @@ extern "C"
             }
         } while (cnc_get_exec_state(EXEC_RUN));
 
-        mcu_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
+        cnc_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
         //resets limit mask
         g_settings.limits_invert_mask ^= axis_limit;
         //stops, flushes buffers and clears the hold if active
@@ -592,7 +607,7 @@ extern "C"
             return EXEC_ALARM_HOMING_FAIL_RESET;
         }
 
-        mcu_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
+        cnc_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
         limits_flags = io_get_limits();
 
         if (CHECKFLAG(limits_flags, axis_limit))
@@ -600,26 +615,6 @@ extern "C"
             return EXEC_ALARM_HOMING_FAIL_APPROACH;
         }
 
-        return STATUS_OK;
-    }
-
-    uint8_t mc_update_tools(motion_data_t *block_data)
-    {
-        if (mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
-        {
-            return STATUS_OK;
-        }
-
-        while (planner_buffer_is_full())
-        {
-            if (!cnc_dotasks())
-            {
-                return STATUS_CRITICAL_FAIL;
-            }
-        }
-
-        SETFLAG(block_data->motion_mode, MOTIONCONTROL_MODE_NOMOTION);
-        planner_add_line(NULL, block_data);
         return STATUS_OK;
     }
 
@@ -652,7 +647,7 @@ extern "C"
         itp_clear();
         planner_clear();
         cnc_clear_exec_state(~prev_state & EXEC_HOLD); //restores HOLD previous state
-        mcu_delay_ms(g_settings.debounce_ms);          //adds a delay before reading io pin (debounce)
+        cnc_delay_ms(g_settings.debounce_ms);          //adds a delay before reading io pin (debounce)
         bool probe_notok = (!invert_probe) ? io_get_probe() : !io_get_probe();
         if (probe_notok)
         {

--- a/src/core/motion_control.c
+++ b/src/core/motion_control.c
@@ -547,7 +547,7 @@ extern "C"
         itp_clear();
         planner_clear();
 
-        if (cnc_get_exec_state(EXEC_ABORT))
+        if (cnc_get_exec_state(EXEC_KILL))
         {
             return EXEC_ALARM_HOMING_FAIL_RESET;
         }
@@ -602,7 +602,7 @@ extern "C"
         itp_clear();
         planner_clear();
 
-        if (cnc_get_exec_state(EXEC_ABORT))
+        if (cnc_get_exec_state(EXEC_KILL))
         {
             return EXEC_ALARM_HOMING_FAIL_RESET;
         }

--- a/src/core/motion_control.h
+++ b/src/core/motion_control.h
@@ -28,11 +28,10 @@ extern "C"
 #include <stdbool.h>
 
 #define MOTIONCONTROL_MODE_FEED 0
-#define MOTIONCONTROL_MODE_NOMOTION 1
-#define MOTIONCONTROL_MODE_INVERSEFEED 2
-#define MOTIONCONTROL_MODE_BACKLASH_COMPENSATION 4
-#define MOTIONCONTROL_MODE_PAUSEPROGRAM 8
-#define MOTIONCONTROL_MODE_PAUSEPROGRAM_CONDITIONAL 16
+#define MOTIONCONTROL_MODE_INVERSEFEED 1
+#define MOTIONCONTROL_MODE_BACKLASH_COMPENSATION 2
+#define MOTIONCONTROL_MODE_PAUSEPROGRAM 4
+#define MOTIONCONTROL_MODE_PAUSEPROGRAM_CONDITIONAL 8
 
         typedef struct
         {
@@ -58,12 +57,20 @@ extern "C"
         void mc_init(void);
         bool mc_get_checkmode(void);
         bool mc_toogle_checkmode(void);
+
+        //async motions
         uint8_t mc_line(float *target, motion_data_t *block_data);
         uint8_t mc_arc(float *target, float center_offset_a, float center_offset_b, float radius, uint8_t axis_0, uint8_t axis_1, bool isclockwise, motion_data_t *block_data);
+
+        //sync motions
         uint8_t mc_dwell(motion_data_t *block_data);
-        uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit);
+        uint8_t mc_pause(void);
         uint8_t mc_update_tools(motion_data_t *block_data);
+
+        //mixed/special motions
+        uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit);
         uint8_t mc_probe(float *target, bool invert_probe, motion_data_t *block_data);
+
         void mc_get_position(float *target);
         void mc_resync_position(void);
 

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -312,12 +312,12 @@ extern "C"
 
         if (error == GRBL_JOG_CMD)
         {
-            if (cnc_get_exec_state(EXEC_GCODE_LOCKED & ~EXEC_JOG))
+            if (cnc_get_exec_state(~EXEC_JOG))
             {
                 return STATUS_SYSTEM_GC_LOCK;
             }
         }
-        else if (cnc_get_exec_state(EXEC_GCODE_LOCKED))
+        else if (cnc_get_exec_state(~EXEC_RUN))
         {
             return STATUS_SYSTEM_GC_LOCK;
         }

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -317,7 +317,7 @@ extern "C"
                 return STATUS_SYSTEM_GC_LOCK;
             }
         }
-        else if (cnc_get_exec_state(~EXEC_RUN))
+        else if (cnc_get_exec_state(~(EXEC_RUN | EXEC_HOLD | EXEC_RESUMING)))
         {
             return STATUS_SYSTEM_GC_LOCK;
         }

--- a/src/core/planner.h
+++ b/src/core/planner.h
@@ -60,7 +60,6 @@ extern "C"
 #ifdef USE_COOLANT
         uint8_t coolant;
 #endif
-        uint16_t dwell;
 #ifdef ENABLE_BACKLASH_COMPENSATION
         bool backlash_comp;
 #endif
@@ -88,7 +87,8 @@ extern "C"
     void planner_add_analog_output(uint8_t output, uint8_t value);
     void planner_add_digital_output(uint8_t output, uint8_t value);
     void planner_get_position(int32_t *steps);
-    void planner_resync_position(void);
+    void planner_sync_position(void);
+    void planner_sync_tools(motion_data_t *block_data);
 
     //overrides
     void planner_toggle_overrides(void);

--- a/src/hal/mcus/mcu.h
+++ b/src/hal/mcus/mcu.h
@@ -205,20 +205,6 @@ extern "C"
 	 * */
 	void mcu_dotasks(void);
 
-	/**
-	 * generates a delay in ms.
-	 * */
-	static void mcu_delay_ms(uint32_t miliseconds)
-	{
-		uint32_t t_start = mcu_millis();
-		uint32_t t_end = mcu_millis();
-		while (t_end - t_start < miliseconds)
-		{
-			mcu_dotasks();
-			t_end = mcu_millis();
-		}
-	}
-
 	//Non volatile memory
 	/**
 	 * gets a byte at the given EEPROM (or other non volatile memory) address of the MCU.

--- a/src/hal/mcus/virtual/mcumap_virtual.h
+++ b/src/hal/mcus/virtual/mcumap_virtual.h
@@ -94,6 +94,4 @@ extern virtports_t virtualports;
 #define mcu_tx_ready() true
 #define mcu_rx_ready() true
 
-#define mcu_delay_ms(x) delay(x)
-
 #endif

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -111,6 +111,10 @@ extern "C"
 #define GRBL_HELP (GRBL_SYSTEM_CMD + 8)
 #define GRBL_JOG_CMD (GRBL_SYSTEM_CMD + 9)
 
+#define LOOP_STARTUP 0
+#define LOOP_RUNNING 1
+#define LOOP_ERROR_RESET 2
+
 #define EXEC_ALARM_RESET 0
 // Grbl alarm codes. Valid values (1-255). Zero is reserved.
 #define EXEC_ALARM_HARD_LIMIT 1
@@ -124,7 +128,6 @@ extern "C"
 #define EXEC_ALARM_HOMING_FAIL_APPROACH 9
 #define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10
 #define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11
-#define EXEC_ALARM_STARTUP 255 //this is a special alarm that signals µCNC is starting up. It's not a real alarm.
 
 //formated messages
 #define STR_EOL "\r\n"

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -164,6 +164,24 @@ extern "C"
 /*NEW*/
 #define MSG_FEEDBACK_12 __romstr__("Check Emergency stop")
 
+#define MSG_STATUS_ALARM __romstr__("Alarm")
+#define MSG_STATUS_DOOR __romstr__("Door:")
+#define MSG_STATUS_HOLD __romstr__("Hold:")
+#define MSG_STATUS_HOME __romstr__("Home")
+#define MSG_STATUS_JOG __romstr__("Jog")
+#define MSG_STATUS_RUN __romstr__("Run")
+#define MSG_STATUS_IDLE __romstr__("Idle")
+#define MSG_STATUS_CHECK __romstr__("Check")
+
+#define MSG_STATUS_MPOS __romstr__("|MPos:")
+#define MSG_STATUS_FS __romstr__("|FS:")
+#define MSG_STATUS_F __romstr__("|F:")
+#define MSG_STATUS_WCO __romstr__("|WCO:")
+#define MSG_STATUS_OVR __romstr__("|Ov:")
+#define MSG_STATUS_TOOL __romstr__("|A:")
+#define MSG_STATUS_LINE __romstr__("|Ln:")
+#define MSG_STATUS_PIN __romstr__("|Pn:")
+
 	//#define MSG_INT "%d"
 	//#define MSG_FLT "%0.3f"
 	//#define MSG_FLT_IMPERIAL "%0.5f"

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -111,10 +111,6 @@ extern "C"
 #define GRBL_HELP (GRBL_SYSTEM_CMD + 8)
 #define GRBL_JOG_CMD (GRBL_SYSTEM_CMD + 9)
 
-#define LOOP_STARTUP 0
-#define LOOP_RUNNING 1
-#define LOOP_ERROR_RESET 2
-
 #define EXEC_ALARM_RESET 0
 // Grbl alarm codes. Valid values (1-255). Zero is reserved.
 #define EXEC_ALARM_HARD_LIMIT 1
@@ -149,7 +145,6 @@ extern "C"
 //Non query feedback messages
 #define MSG_START __romstr__("[MSG:")
 #define MSG_END __romstr__("]" STR_EOL)
-#define MSG_FEEDBACK_1 __romstr__("Reset to continue")
 #define MSG_FEEDBACK_1 __romstr__("Reset to continue")
 #define MSG_FEEDBACK_2 __romstr__("'$H'|'$X' to unlock")
 #define MSG_FEEDBACK_3 __romstr__("Caution: Unlocked")

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -177,7 +177,7 @@ extern "C"
         {
             switch (state)
             {
-            case EXEC_ABORT:
+            case EXEC_KILL:
                 serial_print_str(__romstr__("Abort"));
                 break;
             case EXEC_DOOR:

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -108,7 +108,7 @@ extern "C"
         float axis[MAX(AXIS_COUNT, 3)];
         if (parser_get_wco(axis))
         {
-            serial_print_str(__romstr__("|WCO:"));
+            serial_print_str(MSG_STATUS_WCO);
             serial_print_fltarr(axis, AXIS_COUNT);
             return;
         }
@@ -116,7 +116,7 @@ extern "C"
         uint8_t ovr[3];
         if (planner_get_overflows(ovr))
         {
-            serial_print_str(__romstr__("|Ov:"));
+            serial_print_str(MSG_STATUS_OVR);
             serial_print_int(ovr[0]);
             serial_putc(',');
             serial_print_int(ovr[1]);
@@ -125,7 +125,7 @@ extern "C"
             uint8_t tools = protocol_get_tools();
             if (tools)
             {
-                serial_print_str(__romstr__("|A:"));
+                serial_print_str(MSG_STATUS_TOOL);
                 if (CHECKFLAG(tools, 4))
                 {
                     serial_putc('S');
@@ -178,10 +178,10 @@ extern "C"
             switch (state)
             {
             case EXEC_KILL:
-                serial_print_str(__romstr__("Abort"));
+                serial_print_str(MSG_STATUS_ALARM);
                 break;
             case EXEC_DOOR:
-                serial_print_str(__romstr__("Door:"));
+                serial_print_str(MSG_STATUS_DOOR);
                 if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
                 {
 
@@ -207,10 +207,10 @@ extern "C"
                 }
                 break;
             case EXEC_LIMITS:
-                serial_print_str(__romstr__("Alarm"));
+                serial_print_str(MSG_STATUS_ALARM);
                 break;
             case EXEC_HOLD:
-                serial_print_str(__romstr__("Hold:"));
+                serial_print_str(MSG_STATUS_HOLD);
                 if (cnc_get_exec_state(EXEC_RUN))
                 {
                     serial_putc('1');
@@ -221,32 +221,32 @@ extern "C"
                 }
                 break;
             case EXEC_HOMING:
-                serial_print_str(__romstr__("Home"));
+                serial_print_str(MSG_STATUS_HOME);
                 break;
             case EXEC_JOG:
-                serial_print_str(__romstr__("Jog"));
+                serial_print_str(MSG_STATUS_JOG);
                 break;
             case EXEC_RESUMING:
             case EXEC_RUN:
-                serial_print_str(__romstr__("Run"));
+                serial_print_str(MSG_STATUS_RUN);
                 break;
             default:
-                serial_print_str(__romstr__("Idle"));
+                serial_print_str(MSG_STATUS_IDLE);
                 break;
             }
         }
         else
         {
-            serial_print_str(__romstr__("Check"));
+            serial_print_str(MSG_STATUS_CHECK);
         }
 
-        serial_print_str(__romstr__("|MPos:"));
+        serial_print_str(MSG_STATUS_MPOS);
         serial_print_fltarr(axis, AXIS_COUNT);
 
 #ifdef USE_SPINDLE
-        serial_print_str(__romstr__("|FS:"));
+        serial_print_str(MSG_STATUS_FS);
 #else
-    serial_print_str(__romstr__("|F:"));
+    serial_print_str(MSG_STATUS_F);
 #endif
         serial_print_int((uint16_t)feed);
 #ifdef USE_SPINDLE
@@ -255,13 +255,13 @@ extern "C"
 #endif
 
 #ifdef GCODE_PROCESS_LINE_NUMBERS
-        serial_print_str(__romstr__("|Ln:"));
+        serial_print_str(MSG_STATUS_LINE);
         serial_print_long(itp_get_rt_line_number());
 #endif
 
         if (CHECKFLAG(controls, (ESTOP_MASK | SAFETY_DOOR_MASK | FHOLD_MASK)) | CHECKFLAG(limits, LIMITS_MASK))
         {
-            serial_print_str(__romstr__("|Pn:"));
+            serial_print_str(MSG_STATUS_PIN);
 
             if (CHECKFLAG(controls, ESTOP_MASK))
             {

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -207,7 +207,6 @@ extern "C"
                 }
                 break;
             case EXEC_LIMITS:
-            case EXEC_NOHOME:
                 serial_print_str(__romstr__("Alarm"));
                 break;
             case EXEC_HOLD:
@@ -227,6 +226,7 @@ extern "C"
             case EXEC_JOG:
                 serial_print_str(__romstr__("Jog"));
                 break;
+            case EXEC_RESUMING:
             case EXEC_RUN:
                 serial_print_str(__romstr__("Run"));
                 break;


### PR DESCRIPTION
-moved delay from mcu to cnc to allow cnc tasks to run will in the delay loop
-removed all non motion gcodes and actions from pipeline. These are now executed at the motion control level. This lead to a small code footprint reduction.
-non motion or sync actions now cause the planner and interpolation to get empty before executing.
-delay on resume now working properly though it needs improving
-changed virtual mcu to support these changes (stalled on delays)
-internal alarms renaming and reworking
-reviewed interlocking to reduce code size
-reviewed alarm code flow
-modified reset loop condition checking. If kill condition is not enforced (emergency stop), allows reset.
-replaced Abort (non Grbl) state by Alarm (Grbl) to improve software compatibility
-fixed limit switch condition checking before clear
-moved some ROM strings to grbl_inferface file
-fixed execution state checking while parsing gcode that was throwing errors on HOLD state
-fixed startup messages format by blocking status reports until startup blocks are sent