### PR TITLE
Improved alarm interlocking

### DIFF
--- a/src/cnc.c
+++ b/src/cnc.c
@@ -197,7 +197,7 @@ extern "C"
         {
             //disables homing and reenables alarm messages
             cnc_clear_exec_state(EXEC_HOMING);
-            cnc_alarm(error);
+            //cnc_alarm(error);
             return;
         }
 
@@ -676,7 +676,7 @@ extern "C"
             }
             else
             {
-                cnc_alarm(EXEC_ALARM_RESET); //reset or emergency stop
+                cnc_alarm(cnc_state.alarm); //reset or emergency stop or any other (software) alarm
             }
             return false;
         }
@@ -692,6 +692,10 @@ extern "C"
             if (!CHECKFLAG(cnc_state.exec_state, EXEC_HOMING) && io_get_limits()) //if a motion is being performed allow trigger the limit switch alarm
             {
                 cnc_alarm(EXEC_ALARM_HARD_LIMIT);
+            }
+            else
+            {
+                CLEARFLAG(cnc_state.exec_state, EXEC_RUN);
             }
 
             return false;

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -203,7 +203,7 @@ extern "C"
         cnc_unlock(true);
 
         float target[AXIS_COUNT];
-        motion_data_t block_data;
+        motion_data_t block_data = {0};
         mc_get_position(target);
 
         for (uint8_t i = AXIS_COUNT; i != 0;)
@@ -225,6 +225,7 @@ extern "C"
         //reset position
         itp_reset_rt_position();
         planner_sync_position();
+        mc_resync_position();
     }
 
     void cnc_alarm(uint8_t code)

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -54,6 +54,7 @@ extern "C"
         volatile uint8_t rt_cmd;
         volatile uint8_t feed_ovr_cmd;
         volatile uint8_t tool_ovr_cmd;
+        volatile uint8_t alarm;
     } cnc_state_t;
 
     static cnc_state_t cnc_state;
@@ -132,16 +133,250 @@ extern "C"
         }
 
         cnc_state.loop_state = LOOP_ERROR_RESET;
-
         serial_flush();
-        if (cnc_get_exec_state(EXEC_ALARM)) //checks if any alarm is active
+        if (cnc_state.alarm)
         {
+            protocol_send_alarm(cnc_state.alarm);
             cnc_check_fault_systems();
             do
             {
-                cnc_clear_exec_state(EXEC_KILL); //tries to clear the kill flag if possible
-            } while (!cnc_dotasks());
+                cnc_clear_exec_state(EXEC_ALARM);
+                cnc_dotasks();
+            } while (cnc_state.alarm);
         }
+    }
+
+    bool cnc_dotasks(void)
+    {
+        static bool lock_itp = false;
+        //run all mcu_internal tasks
+        mcu_dotasks();
+
+        //let µCNC finnish startup/reset code
+        if (cnc_state.loop_state == LOOP_STARTUP_RESET)
+        {
+            return true;
+        }
+
+#if ((LIMITEN_MASK ^ LIMITISR_MASK) || defined(FORCE_SOFT_POLLING))
+        io_limits_isr();
+#endif
+#if ((CONTROLEN_MASK ^ CONTROLISR_MASK) || defined(FORCE_SOFT_POLLING))
+        io_controls_isr();
+#endif
+
+        cnc_exec_rt_commands(); //executes all pending realtime commands
+
+        //µCNC already in error loop. No point in sending the alarms
+        if (cnc_state.loop_state == LOOP_ERROR_RESET)
+        {
+            return !cnc_get_exec_state(EXEC_KILL);
+        }
+
+        //check security interlocking for any problem
+        if (!cnc_check_interlocking())
+        {
+            return !cnc_get_exec_state(EXEC_KILL);
+        }
+
+        if (!lock_itp)
+        {
+            lock_itp = true;
+            itp_run();
+            lock_itp = false;
+        }
+
+        return !cnc_get_exec_state(EXEC_KILL);
+    }
+
+    void cnc_home(void)
+    {
+        cnc_set_exec_state(EXEC_HOMING);
+        uint8_t error = kinematics_home();
+        if (error)
+        {
+            //disables homing and reenables alarm messages
+            cnc_clear_exec_state(EXEC_HOMING);
+            cnc_alarm(error);
+            return;
+        }
+
+        //unlocks the machine to go to offset
+        cnc_unlock(true);
+
+        float target[AXIS_COUNT];
+        motion_data_t block_data;
+        mc_get_position(target);
+
+        for (uint8_t i = AXIS_COUNT; i != 0;)
+        {
+            i--;
+            target[i] += ((g_settings.homing_dir_invert_mask & (1 << i)) ? -g_settings.homing_offset : g_settings.homing_offset);
+        }
+
+        block_data.feed = g_settings.homing_fast_feed_rate;
+        block_data.spindle = 0;
+        block_data.dwell = 0;
+        //starts offset and waits to finnish
+        mc_line(target, &block_data);
+        do
+        {
+            cnc_dotasks();
+        } while (cnc_get_exec_state(EXEC_RUN));
+
+        //reset position
+        itp_reset_rt_position();
+        planner_sync_position();
+    }
+
+    void cnc_alarm(uint8_t code)
+    {
+        cnc_set_exec_state(EXEC_KILL);
+        cnc_stop();
+        cnc_state.alarm = code;
+    }
+
+    void cnc_stop(void)
+    {
+        itp_stop();
+        //stop tools
+#ifdef USE_SPINDLE
+        io_set_spindle(0, false);
+#endif
+#ifdef USE_COOLANT
+        io_set_coolant(0);
+#endif
+    }
+
+    bool cnc_unlock(bool force)
+    {
+        //tries to clear alarms or any active hold state
+        cnc_clear_exec_state(EXEC_ALARM | EXEC_HOLD);
+        //checks all interlocking again
+        cnc_check_interlocking();
+
+        //forces to clear HALT error to allow motion after limit switch trigger
+        if (force)
+        {
+            CLEARFLAG(cnc_state.exec_state, EXEC_HALT);
+        }
+
+        //if any alarm state is still active checks system faults
+        if (cnc_get_exec_state(EXEC_ALARM))
+        {
+            if (!cnc_get_exec_state(EXEC_KILL))
+            {
+                protocol_send_feedback(MSG_FEEDBACK_2);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            //on unlock any alarm caused by not having homing reference or hitting a limit switch is reset at user request
+            //this must be done directly beacuse cnc_clear_exec_state will check the limit switch state
+            //all other alarm flags remain active if any input is still active
+            CLEARFLAG(cnc_state.exec_state, EXEC_HALT);
+            //clears all other locking flags
+            cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_HOLD);
+            //signals stepper enable pins
+
+            io_set_steps(g_settings.step_invert_mask);
+            io_set_dirs(g_settings.dir_invert_mask);
+            io_enable_steps();
+        }
+
+        return true;
+    }
+
+    uint8_t cnc_get_exec_state(uint8_t statemask)
+    {
+        return CHECKFLAG(cnc_state.exec_state, statemask);
+    }
+
+    void cnc_set_exec_state(uint8_t statemask)
+    {
+        SETFLAG(cnc_state.exec_state, statemask);
+    }
+
+    void cnc_clear_exec_state(uint8_t statemask)
+    {
+        uint8_t controls = io_get_controls();
+
+#ifdef ESTOP
+        if (CHECKFLAG(controls, ESTOP_MASK)) //can't clear the alarm flag if ESTOP is active
+        {
+            CLEARFLAG(statemask, EXEC_KILL);
+        }
+#endif
+#ifdef SAFETY_DOOR
+        if (CHECKFLAG(controls, SAFETY_DOOR_MASK)) //can't clear the door flag if SAFETY_DOOR is active
+        {
+            CLEARFLAG(statemask, EXEC_DOOR | EXEC_HOLD);
+        }
+#endif
+#ifdef FHOLD
+        if (CHECKFLAG(controls, FHOLD_MASK)) //can't clear the hold flag if FHOLD is active
+        {
+            CLEARFLAG(statemask, EXEC_HOLD);
+        }
+#endif
+
+        uint8_t limits = 0;
+#if (LIMITS_MASK != 0)
+        limits = io_get_limits(); //can't clear the EXEC_HALT is any limit is triggered
+#endif
+        if (g_settings.hard_limits_enabled) //if hardlimits are enabled and limits are triggered
+        {
+            if (limits || g_settings.homing_enabled)
+            {
+                CLEARFLAG(statemask, EXEC_HALT);
+            }
+        }
+
+        if (CHECKFLAG(statemask, EXEC_HOLD))
+        {
+            SETFLAG(cnc_state.exec_state, EXEC_RESUMING);
+            CLEARFLAG(cnc_state.exec_state, EXEC_HOLD);
+            itp_sync_spindle();
+            if (!planner_buffer_is_empty())
+            {
+                cnc_delay_ms(DELAY_ON_RESUME * 1000);
+            }
+            CLEARFLAG(cnc_state.exec_state, EXEC_RESUMING);
+        }
+
+        CLEARFLAG(cnc_state.exec_state, statemask);
+    }
+
+    void cnc_delay_ms(uint32_t miliseconds)
+    {
+        uint32_t t_start = mcu_millis();
+        uint32_t t_end = mcu_millis();
+        while (t_end - t_start < miliseconds && cnc_dotasks())
+        {
+            t_end = mcu_millis();
+        }
+    }
+
+    bool cnc_reset(void)
+    {
+        cnc_state.loop_state = LOOP_STARTUP_RESET;
+        //resets all realtime command flags
+        cnc_state.rt_cmd = RT_CMD_CLEAR;
+        cnc_state.feed_ovr_cmd = RT_CMD_CLEAR;
+        cnc_state.tool_ovr_cmd = RT_CMD_CLEAR;
+        cnc_state.exec_state = EXEC_ALARM | EXEC_HOLD; //Activates all alarms and hold
+
+        //clear all systems
+        serial_rx_clear();
+        itp_clear();
+        planner_clear();
+        protocol_send_string(MSG_STARTUP);
+
+        return cnc_unlock(false);
     }
 
     void cnc_call_rt_command(uint8_t command)
@@ -154,10 +389,7 @@ extern "C"
         switch (command)
         {
         case CMD_CODE_RESET:
-            if (CHECKFLAG(cnc_state.exec_state, EXEC_KILL))
-            {
-                SETFLAG(cnc_state.rt_cmd, RT_CMD_RESET);
-            }
+            SETFLAG(cnc_state.rt_cmd, RT_CMD_RESET);
             SETFLAG(cnc_state.exec_state, EXEC_KILL);
             break;
         case CMD_CODE_FEED_HOLD:
@@ -229,234 +461,6 @@ extern "C"
         }
     }
 
-    bool cnc_dotasks(void)
-    {
-        static bool lock_itp = false;
-        //run all mcu_internal tasks
-        mcu_dotasks();
-
-        //let µCNC finnish startup/reset code
-        if (cnc_state.loop_state == LOOP_STARTUP_RESET)
-        {
-            return true;
-        }
-
-#if ((LIMITEN_MASK ^ LIMITISR_MASK) || defined(FORCE_SOFT_POLLING))
-        io_limits_isr();
-#endif
-#if ((CONTROLEN_MASK ^ CONTROLISR_MASK) || defined(FORCE_SOFT_POLLING))
-        io_controls_isr();
-#endif
-
-        cnc_exec_rt_commands(); //executes all pending realtime commands
-
-        //check security interlocking for any problem
-        if (!cnc_check_interlocking())
-        {
-            return !cnc_get_exec_state(EXEC_KILL);
-        }
-
-        if (!lock_itp)
-        {
-            lock_itp = true;
-            itp_run();
-            lock_itp = false;
-        }
-
-        return !cnc_get_exec_state(EXEC_KILL);
-    }
-
-    void cnc_home(void)
-    {
-        cnc_set_exec_state(EXEC_HOMING);
-        uint8_t error = kinematics_home();
-        if (error)
-        {
-            //disables homing and reenables alarm messages
-            cnc_clear_exec_state(EXEC_HOMING);
-            cnc_alarm(error);
-            return;
-        }
-
-        //unlocks the machine to go to offset
-        cnc_unlock();
-
-        float target[AXIS_COUNT];
-        motion_data_t block_data;
-        mc_get_position(target);
-
-        for (uint8_t i = AXIS_COUNT; i != 0;)
-        {
-            i--;
-            target[i] += ((g_settings.homing_dir_invert_mask & (1 << i)) ? -g_settings.homing_offset : g_settings.homing_offset);
-        }
-
-        block_data.feed = g_settings.homing_fast_feed_rate;
-        block_data.spindle = 0;
-        block_data.dwell = 0;
-        //starts offset and waits to finnish
-        mc_line(target, &block_data);
-        do
-        {
-            cnc_dotasks();
-        } while (cnc_get_exec_state(EXEC_RUN));
-
-        //reset position
-        itp_reset_rt_position();
-        planner_sync_position();
-    }
-
-    void cnc_alarm(uint8_t code)
-    {
-        cnc_set_exec_state(EXEC_KILL);
-        cnc_stop();
-        if (code)
-        {
-            protocol_send_alarm(code);
-        }
-    }
-
-    void cnc_stop(void)
-    {
-        //halt is active and was running flags it lost home position
-        if (cnc_get_exec_state(EXEC_RUN) && g_settings.homing_enabled)
-        {
-            cnc_set_exec_state(EXEC_LIMITS);
-        }
-        itp_stop();
-        //stop tools
-#ifdef USE_SPINDLE
-        io_set_spindle(0, false);
-#endif
-#ifdef USE_COOLANT
-        io_set_coolant(0);
-#endif
-    }
-
-    void cnc_unlock(void)
-    {
-        //on unlock any alarm caused by not having homing reference or hitting a limit switch is reset at user request
-        //this must be done directly beacuse cnc_clear_exec_state will check the limit switch state
-        //all other alarm flags remain active if any input is still active
-        CLEARFLAG(cnc_state.exec_state, EXEC_LIMITS);
-        //clears all other locking flags
-        cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_HOLD);
-        //signals stepper enable pins
-
-        io_set_steps(g_settings.step_invert_mask);
-        io_set_dirs(g_settings.dir_invert_mask);
-        io_enable_steps();
-    }
-
-    uint8_t cnc_get_exec_state(uint8_t statemask)
-    {
-        return CHECKFLAG(cnc_state.exec_state, statemask);
-    }
-
-    void cnc_set_exec_state(uint8_t statemask)
-    {
-        SETFLAG(cnc_state.exec_state, statemask);
-    }
-
-    void cnc_clear_exec_state(uint8_t statemask)
-    {
-        uint8_t controls = io_get_controls();
-
-#ifdef ESTOP
-        if (CHECKFLAG(controls, ESTOP_MASK)) //can't clear the alarm flag if ESTOP is active
-        {
-            CLEARFLAG(statemask, EXEC_KILL);
-        }
-#endif
-#ifdef SAFETY_DOOR
-        if (CHECKFLAG(controls, SAFETY_DOOR_MASK)) //can't clear the door flag if SAFETY_DOOR is active
-        {
-            CLEARFLAG(statemask, EXEC_DOOR | EXEC_HOLD);
-        }
-#endif
-#ifdef FHOLD
-        if (CHECKFLAG(controls, FHOLD_MASK)) //can't clear the hold flag if FHOLD is active
-        {
-            CLEARFLAG(statemask, EXEC_HOLD);
-        }
-#endif
-
-        uint8_t limits = 0;
-#if (LIMITS_MASK != 0)
-        limits = io_get_limits(); //can't clear the EXEC_LIMITS is any limit is triggered
-#endif
-        if (g_settings.hard_limits_enabled) //if hardlimits are enabled and limits are triggered
-        {
-            if (limits || g_settings.homing_enabled)
-            {
-                CLEARFLAG(statemask, EXEC_LIMITS);
-            }
-        }
-
-        if (CHECKFLAG(statemask, EXEC_HOLD))
-        {
-            SETFLAG(cnc_state.exec_state, EXEC_RESUMING);
-            CLEARFLAG(cnc_state.exec_state, EXEC_HOLD);
-            itp_sync_spindle();
-            if (!planner_buffer_is_empty())
-            {
-                cnc_delay_ms(DELAY_ON_RESUME * 1000);
-            }
-            CLEARFLAG(cnc_state.exec_state, EXEC_RESUMING);
-        }
-
-        CLEARFLAG(cnc_state.exec_state, statemask);
-    }
-
-    void cnc_delay_ms(uint32_t miliseconds)
-    {
-        uint32_t t_start = mcu_millis();
-        uint32_t t_end = mcu_millis();
-        while (t_end - t_start < miliseconds && cnc_dotasks())
-        {
-            t_end = mcu_millis();
-        }
-    }
-
-    bool cnc_reset(void)
-    {
-        cnc_state.loop_state = LOOP_STARTUP_RESET;
-        //resets all realtime command flags
-        cnc_state.rt_cmd = RT_CMD_CLEAR;
-        cnc_state.feed_ovr_cmd = RT_CMD_CLEAR;
-        cnc_state.tool_ovr_cmd = RT_CMD_CLEAR;
-        cnc_state.exec_state = EXEC_ALARM | EXEC_HOLD; //Activates all alarms and hold
-
-        //clear all systems
-        serial_rx_clear();
-        itp_clear();
-        planner_clear();
-        protocol_send_string(MSG_STARTUP);
-
-        //tries to clear alarms or any active hold state
-        cnc_clear_exec_state(EXEC_ALARM | EXEC_HOLD);
-
-        //if any alarm state is still active checks system faults
-        if (cnc_get_exec_state(EXEC_ALARM))
-        {
-            //cnc_check_fault_systems();
-            if (!cnc_get_exec_state(EXEC_KILL))
-            {
-                protocol_send_feedback(MSG_FEEDBACK_2);
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else
-        {
-            cnc_unlock();
-        }
-
-        return true;
-    }
-
     //Executes pending realtime commands
     //Realtime commands are split in to 3 groups
     //  -operation commands
@@ -470,19 +474,15 @@ extern "C"
 
         //executes feeds override rt commands
         uint8_t cmd_mask = 0x04;
-        uint8_t command = cnc_state.rt_cmd;          //copies realtime flags states
-        CLEARFLAG(cnc_state.rt_cmd, ~RT_CMD_REPORT); //clears all command flags except report request
+        uint8_t command = cnc_state.rt_cmd;            //copies realtime flags states
+        CLEARFLAG(cnc_state.rt_cmd, ~(RT_CMD_REPORT)); //clears all command flags except report request
         while (command)
         {
             switch (command & cmd_mask)
             {
             case RT_CMD_RESET:
-                cnc_clear_exec_state(EXEC_KILL);
-                if (cnc_get_exec_state(EXEC_KILL))
-                {
-                    cnc_check_fault_systems();
-                }
-                break;
+                cnc_alarm(EXEC_ALARM_RESET);
+                return;
             case RT_CMD_REPORT:
                 if (!protocol_is_busy() && !(cnc_state.loop_state & LOOP_STARTUP))
                 {
@@ -619,19 +619,19 @@ extern "C"
 
     void cnc_check_fault_systems(void)
     {
-        bool fail = false;
-        uint8_t inputs = io_get_controls();
+        uint8_t inputs;
+#ifdef CONTROLS_MASK
+        inputs = io_get_controls();
+#endif
 #ifdef ESTOP
         if (CHECKFLAG(inputs, ESTOP_MASK)) //fault on emergency stop
         {
-            fail = true;
             protocol_send_feedback(MSG_FEEDBACK_12);
         }
 #endif
 #ifdef SAFETY_DOOR
         if (CHECKFLAG(inputs, SAFETY_DOOR_MASK)) //fault on safety door
         {
-            fail = true;
             protocol_send_feedback(MSG_FEEDBACK_6);
         }
 #endif
@@ -641,13 +641,12 @@ extern "C"
             inputs = io_get_limits();
             if (CHECKFLAG(inputs, LIMITS_MASK))
             {
-                fail = true;
                 protocol_send_feedback(MSG_FEEDBACK_7);
             }
         }
 #endif
 
-        if (fail)
+        if (cnc_get_exec_state(EXEC_KILL))
         {
             protocol_send_feedback(MSG_FEEDBACK_1);
         }
@@ -659,6 +658,14 @@ extern "C"
         //if kill leave
         if (CHECKFLAG(cnc_state.exec_state, EXEC_KILL))
         {
+#ifdef ESTOP
+            //the emergency stop is pressed.
+            if (io_get_controls() & ESTOP_MASK)
+            {
+                cnc_alarm(EXEC_ALARM_EMERGENCY_STOP);
+                return false;
+            }
+#endif
             if (CHECKFLAG(cnc_state.exec_state, EXEC_HOMING)) //reset or emergency stop during a homing cycle
             {
                 cnc_alarm(EXEC_ALARM_HOMING_FAIL_RESET);
@@ -674,15 +681,15 @@ extern "C"
             return false;
         }
 
-        if (CHECKFLAG(cnc_state.exec_state, EXEC_DOOR) & CHECKFLAG(cnc_state.exec_state, EXEC_HOMING)) //door opened during a homing cycle
+        if (CHECKFLAG(cnc_state.exec_state, EXEC_DOOR) && CHECKFLAG(cnc_state.exec_state, EXEC_HOMING)) //door opened during a homing cycle
         {
             cnc_alarm(EXEC_ALARM_HOMING_FAIL_DOOR);
             return false;
         }
 
-        if (CHECKFLAG(cnc_state.exec_state, EXEC_LIMITS))
+        if (CHECKFLAG(cnc_state.exec_state, EXEC_HALT) && CHECKFLAG(cnc_state.exec_state, EXEC_RUN))
         {
-            if (CHECKFLAG(cnc_state.exec_state, EXEC_RUN)) //if a motion is being performed allow trigger the limit switch alarm
+            if (!CHECKFLAG(cnc_state.exec_state, EXEC_HOMING) && io_get_limits()) //if a motion is being performed allow trigger the limit switch alarm
             {
                 cnc_alarm(EXEC_ALARM_HARD_LIMIT);
             }
@@ -690,8 +697,8 @@ extern "C"
             return false;
         }
 
-        //opened door or hold with the machine still
-        if (CHECKFLAG(cnc_state.exec_state, EXEC_DOOR | EXEC_HOLD) & !CHECKFLAG(cnc_state.exec_state, EXEC_RUN))
+        //opened door or hold with the machine still moving
+        if (CHECKFLAG(cnc_state.exec_state, EXEC_DOOR | EXEC_HOLD) && !CHECKFLAG(cnc_state.exec_state, EXEC_RUN))
         {
             itp_stop();
             if (CHECKFLAG(cnc_state.exec_state, EXEC_DOOR))

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -29,7 +29,7 @@ extern "C"
 
 #define RT_CMD_REPORT 1
 #define RT_CMD_CYCLE_START 2
-#define RT_CMD_ABORT 128
+#define RT_CMD_RESET 4
 
 //feed_ovr_cmd
 #define RT_CMD_FEED_100 1

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -195,7 +195,7 @@ extern "C"
 	void cnc_home(void);
 	void cnc_alarm(uint8_t code);
 	void cnc_stop(void);
-	bool cnc_unlock(bool force);
+	uint8_t cnc_unlock(bool force);
 	void cnc_delay_ms(uint32_t miliseconds);
 
 	uint8_t cnc_get_exec_state(uint8_t statemask);

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -57,10 +57,10 @@ extern "C"
 #define EXEC_HOLD 4												// Feed hold is active
 #define EXEC_JOG 8												// Jogging in execution
 #define EXEC_HOMING 16											// Homing in execution
-#define EXEC_LIMITS 32											// Limit switch is active or position lost
+#define EXEC_HALT 32											// Limit switch is active or position lost due to abrupt stop
 #define EXEC_DOOR 64											// Safety door open
 #define EXEC_KILL 128											// Emergency stop
-#define EXEC_ALARM (EXEC_LIMITS | EXEC_DOOR | EXEC_KILL)		// System alarms
+#define EXEC_ALARM (EXEC_HALT | EXEC_DOOR | EXEC_KILL)			// System alarms
 #define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255										// All states
 
@@ -195,7 +195,7 @@ extern "C"
 	void cnc_home(void);
 	void cnc_alarm(uint8_t code);
 	void cnc_stop(void);
-	void cnc_unlock(void);
+	bool cnc_unlock(bool force);
 	void cnc_delay_ms(uint32_t miliseconds);
 
 	uint8_t cnc_get_exec_state(uint8_t statemask);

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -193,7 +193,7 @@ extern "C"
 	//do events returns true if all OK and false if an ABORT alarm is reached
 	bool cnc_dotasks(void);
 	void cnc_home(void);
-	void cnc_alarm(uint8_t code);
+	void cnc_alarm(int8_t code);
 	void cnc_stop(void);
 	uint8_t cnc_unlock(bool force);
 	void cnc_delay_ms(uint32_t miliseconds);

--- a/src/core/interpolator.c
+++ b/src/core/interpolator.c
@@ -527,7 +527,6 @@ extern "C"
     {
         io_set_steps(g_settings.step_invert_mask);
         io_set_dirs(g_settings.dir_invert_mask);
-        cnc_clear_exec_state(EXEC_RUN);
 #ifdef LASER_MODE
         if (g_settings.laser_mode)
         {
@@ -764,7 +763,8 @@ extern "C"
             {
                 mcu_disable_global_isr();
                 itp_busy = false;
-                itp_stop(); //the buffer is empty. The ISR can stop
+                itp_stop();                     //the buffer is empty. The ISR can stop
+                cnc_clear_exec_state(EXEC_RUN); //this naturally clears the RUN flag. Any other ISR stop does not clear the flag.
                 return;
             }
         }

--- a/src/core/interpolator.c
+++ b/src/core/interpolator.c
@@ -488,6 +488,11 @@ extern "C"
 
     void itp_stop(void)
     {
+        // any stop command while running triggers an HALT alarm
+        if (cnc_get_exec_state(EXEC_RUN))
+        {
+            cnc_set_exec_state(EXEC_HALT);
+        }
         io_set_steps(g_settings.step_invert_mask);
         io_set_dirs(g_settings.dir_invert_mask);
 #ifdef LASER_MODE
@@ -712,8 +717,8 @@ extern "C"
             {
                 mcu_disable_global_isr();
                 itp_busy = false;
-                itp_stop();                     //the buffer is empty. The ISR can stop
                 cnc_clear_exec_state(EXEC_RUN); //this naturally clears the RUN flag. Any other ISR stop does not clear the flag.
+                itp_stop();                     //the buffer is empty. The ISR can stop
                 return;
             }
         }

--- a/src/core/io_control.c
+++ b/src/core/io_control.c
@@ -481,7 +481,7 @@ extern "C"
 #endif
     }
 
-    void io_enable_steps(void)
+    void io_disable_steppers(void)
     {
 #ifdef STEPPER_ENABLE
         mcu_set_output(STEPPER_ENABLE);
@@ -500,6 +500,28 @@ extern "C"
 #endif
 #ifdef STEPPER5_ENABLE
         mcu_set_output(STEPPER5_ENABLE);
+#endif
+    }
+
+    void io_enable_steppers(void)
+    {
+#ifdef STEPPER_ENABLE
+        mcu_clear_output(STEPPER_ENABLE);
+#endif
+#ifdef STEPPER1_ENABLE
+        mcu_clear_output(STEPPER1_ENABLE);
+#endif
+#ifdef STEPPER2_ENABLE
+        mcu_clear_output(STEPPER2_ENABLE);
+#endif
+#ifdef STEPPER3_ENABLE
+        mcu_clear_output(STEPPER3_ENABLE);
+#endif
+#ifdef STEPPER4_ENABLE
+        mcu_clear_output(STEPPER4_ENABLE);
+#endif
+#ifdef STEPPER5_ENABLE
+        mcu_clear_output(STEPPER5_ENABLE);
 #endif
     }
 

--- a/src/core/io_control.c
+++ b/src/core/io_control.c
@@ -43,44 +43,32 @@ extern "C"
         {
             if (limits)
             {
-                if (cnc_get_exec_state(EXEC_RUN))
-                {
-                    if (!cnc_get_exec_state(EXEC_HOMING)) //if not in a homing motion triggers an alarm
-                    {
-                        if (g_settings.hard_limits_enabled)
-                        {
-                            cnc_set_exec_state(EXEC_LIMITS); //if motions was executing flags home position lost
-                        }
-
-                        cnc_alarm(EXEC_ALARM_HARD_LIMIT);
-                    }
 #ifdef ENABLE_DUAL_DRIVE_AXIS
-                    else
-                    {
+                if (cnc_get_exec_state(EXEC_RUN) & cnc_get_exec_state(EXEC_HOMING))
+                {
 //if homing and dual drive axis are enabled
 #ifdef DUAL_DRIVE_AXIS0
-                        if ((limits & (LIMIT_DUAL0 | LIMITS_DUAL_MASK) & io_limits_homing_filter)) //the limit triggered matches the first dual drive axis
-                        {
-                            itp_lock_stepper((limits & LIMITS_LIMIT1_MASK) ? STEP6_MASK : STEP_DUAL0);
+                    if ((limits & (LIMIT_DUAL0 | LIMITS_DUAL_MASK) & io_limits_homing_filter)) //the limit triggered matches the first dual drive axis
+                    {
+                        itp_lock_stepper((limits & LIMITS_LIMIT1_MASK) ? STEP6_MASK : STEP_DUAL0);
 
-                            if ((limits & LIMITS_DUAL_MASK) != LIMITS_DUAL_MASK) //but not both
-                            {
-                                return; //exits and doesn't trip the alarm
-                            }
+                        if ((limits & LIMITS_DUAL_MASK) != LIMITS_DUAL_MASK) //but not both
+                        {
+                            return; //exits and doesn't trip the alarm
                         }
+                    }
 #endif
 #ifdef DUAL_DRIVE_AXIS1
-                        if (limits & LIMIT_DUAL1 & io_limits_homing_filter) //the limit triggered matches the second dual drive axis
+                    if (limits & LIMIT_DUAL1 & io_limits_homing_filter) //the limit triggered matches the second dual drive axis
+                    {
+                        if ((limits & LIMITS_DUAL_MASK) != LIMITS_DUAL_MASK) //but not both
                         {
-                            if ((limits & LIMITS_DUAL_MASK) != LIMITS_DUAL_MASK) //but not both
-                            {
-                                itp_lock_stepper((limits & LIMITS_LIMIT1_MASK) ? STEP7_MASK : STEP_DUAL1);
-                            }
+                            itp_lock_stepper((limits & LIMITS_LIMIT1_MASK) ? STEP7_MASK : STEP_DUAL1);
                         }
-#endif
                     }
 #endif
                 }
+#endif
 #ifdef ENABLE_DUAL_DRIVE_AXIS
                 itp_lock_stepper(0); //unlocks axis
 #endif

--- a/src/core/io_control.c
+++ b/src/core/io_control.c
@@ -72,8 +72,8 @@ extern "C"
 #ifdef ENABLE_DUAL_DRIVE_AXIS
                 itp_lock_stepper(0); //unlocks axis
 #endif
-                cnc_set_exec_state(EXEC_LIMITS);
                 itp_stop();
+                cnc_set_exec_state(EXEC_HALT);
             }
         }
     }
@@ -85,7 +85,7 @@ extern "C"
 #ifdef ESTOP
         if (CHECKFLAG(controls, ESTOP_MASK))
         {
-            cnc_call_rt_command(CMD_CODE_RESET);
+            cnc_set_exec_state(EXEC_KILL);
             return; //forces exit
         }
 #endif
@@ -93,13 +93,13 @@ extern "C"
         if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
         {
             //safety door activates hold simultaneously to start the controlled stop
-            cnc_call_rt_command(CMD_CODE_SAFETY_DOOR);
+            cnc_set_exec_state(EXEC_DOOR | EXEC_HOLD);
         }
 #endif
 #ifdef FHOLD
         if (CHECKFLAG(controls, FHOLD_MASK))
         {
-            cnc_call_rt_command(CMD_CODE_FEED_HOLD);
+            cnc_set_exec_state(EXEC_HOLD);
         }
 #endif
 #ifdef CS_RES

--- a/src/core/io_control.h
+++ b/src/core/io_control.h
@@ -217,7 +217,8 @@ extern "C"
 	void io_toggle_steps(uint8_t mask);
 	void io_set_dirs(uint8_t mask);
 
-	void io_enable_steps(void);
+	void io_enable_steppers(void);
+	void io_disable_steppers(void);
 
 #ifdef USE_SPINDLE
 	void io_set_spindle(uint8_t value, bool invert);

--- a/src/core/motion_control.c
+++ b/src/core/motion_control.c
@@ -500,7 +500,7 @@ extern "C"
 #endif
 #endif
 
-        cnc_unlock();
+        cnc_unlock(true);
 
         //if HOLD or ALARM are still active or any limit switch is not cleared fails to home
         if (cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM) || CHECKFLAG(io_get_limits(), LIMITS_MASK))
@@ -530,7 +530,7 @@ extern "C"
         block_data.spindle = 0;
         block_data.dwell = 0;
         block_data.motion_mode = MOTIONCONTROL_MODE_FEED;
-        cnc_unlock();
+        cnc_unlock(true);
         mc_line(target, &block_data);
         //flags homing clear by the unlock
         cnc_set_exec_state(EXEC_HOMING);
@@ -546,11 +546,6 @@ extern "C"
         itp_stop();
         itp_clear();
         planner_clear();
-
-        if (cnc_get_exec_state(EXEC_KILL))
-        {
-            return EXEC_ALARM_HOMING_FAIL_RESET;
-        }
 
         cnc_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
         limits_flags = io_get_limits();
@@ -577,11 +572,11 @@ extern "C"
         block_data.feed = g_settings.homing_slow_feed_rate;
         block_data.total_steps = ABS(max_home_dist);
         block_data.steps[axis] = max_home_dist;
-        //unlocks the machine for next motion (this will clear the EXEC_LIMITS flag
+        //unlocks the machine for next motion (this will clear the EXEC_HALT flag
         //temporary inverts the limit mask to trigger ISR on switch release
         g_settings.limits_invert_mask ^= axis_limit;
         //io_set_homing_limits_filter(LIMITS_DUAL_MASK);//if axis pin goes off triggers
-        cnc_unlock();
+        cnc_unlock(true);
         mc_line(target, &block_data);
         //flags homing clear by the unlock
         cnc_set_exec_state(EXEC_HOMING);
@@ -601,11 +596,6 @@ extern "C"
         //clearing the interpolator unlockes any locked stepper
         itp_clear();
         planner_clear();
-
-        if (cnc_get_exec_state(EXEC_KILL))
-        {
-            return EXEC_ALARM_HOMING_FAIL_RESET;
-        }
 
         cnc_delay_ms(g_settings.debounce_ms); //adds a delay before reading io pin (debounce)
         limits_flags = io_get_limits();

--- a/src/core/motion_control.c
+++ b/src/core/motion_control.c
@@ -566,7 +566,7 @@ extern "C"
         max_home_dist = g_settings.homing_offset * 5.0f;
 
         //sync's the planner and motion control done when clearing the planner
-        //planner_sync_position();
+        planner_sync_position();
         mc_resync_position();
         mc_get_position(target);
         if (g_settings.homing_dir_invert_mask & axis_mask)

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -620,7 +620,7 @@ extern "C"
             protocol_send_feedback(MSG_FEEDBACK_9);
             return STATUS_OK;
         case GRBL_UNLOCK:
-            cnc_unlock();
+            cnc_unlock(true);
             if (cnc_get_exec_state(EXEC_DOOR))
             {
                 return STATUS_CHECK_DOOR;
@@ -633,7 +633,7 @@ extern "C"
                 return STATUS_SETTING_DISABLED;
             }
 
-            cnc_unlock();
+            cnc_unlock(true);
             if (cnc_get_exec_state(EXEC_DOOR))
             {
                 return STATUS_CHECK_DOOR;

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -1462,7 +1462,7 @@ extern "C"
                     parser_parameters.last_probe_ok = 0;
                     if (!(new_state->groups.motion & 0x01))
                     {
-                        cnc_alarm(probe_error);
+                        return probe_error;
                     }
                 }
                 parser_parameters.last_probe_ok = 1;

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -256,6 +256,7 @@ extern "C"
     static parser_parameters_t parser_parameters;
     static uint8_t parser_wco_counter;
     static float g92permanentoffset[AXIS_COUNT];
+    static int32_t rt_probe_step_pos[STEPPER_COUNT];
 
     static unsigned char parser_get_next_preprocessed(bool peek);
     FORCEINLINE static uint8_t parser_get_comment(void);
@@ -423,7 +424,13 @@ extern "C"
 
     void parser_sync_probe(void)
     {
-        itp_get_rt_position(parser_parameters.last_probe_position);
+        itp_get_rt_position(rt_probe_step_pos);
+    }
+
+    void parser_update_probe_pos(void)
+    {
+        kinematics_apply_forward(rt_probe_step_pos, parser_parameters.last_probe_position);
+        kinematics_apply_reverse_transform(parser_parameters.last_probe_position);
     }
 
     static uint8_t parser_grbl_command(void)

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -44,6 +44,7 @@ void parser_update_coolant(uint8_t state);
 void parser_toogle_coolant(uint8_t state);
 #endif*/
 	void parser_sync_probe(void);
+	void parser_update_probe_pos(void);
 	uint8_t parser_get_probe_result(void);
 	void parser_parameters_load(void);
 	void parser_parameters_reset(void);

--- a/src/core/planner.c
+++ b/src/core/planner.c
@@ -356,8 +356,6 @@ extern "C"
 #endif
         //resyncs position with interpolator
         planner_sync_position();
-        //forces motion control to resync postition after clearing the planner buffer
-        mc_resync_position();
     }
 
     planner_block_t *planner_get_block(void)
@@ -583,6 +581,8 @@ extern "C"
     {
         //resyncs the position with the interpolator
         itp_get_rt_position(planner_step_pos);
+        //forces the motion control to resync as well
+        mc_resync_position();
     }
 
     void planner_sync_tools(motion_data_t *block_data)

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -112,7 +112,7 @@ extern "C"
 #define GRBL_JOG_CMD (GRBL_SYSTEM_CMD + 9)
 
 #define EXEC_ALARM_RESET 0
-// Grbl alarm codes. Valid values (1-255). Zero is reserved.
+// Grbl alarm codes. Valid values (1-255). Zero is reserved for the reset alarm.
 #define EXEC_ALARM_HARD_LIMIT 1
 #define EXEC_ALARM_SOFT_LIMIT 2
 #define EXEC_ALARM_ABORT_CYCLE 3
@@ -124,6 +124,7 @@ extern "C"
 #define EXEC_ALARM_HOMING_FAIL_APPROACH 9
 #define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10
 #define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11
+#define EXEC_ALARM_EMERGENCY_STOP 12
 
 //formated messages
 #define STR_EOL "\r\n"

--- a/src/interface/grbl_interface.h
+++ b/src/interface/grbl_interface.h
@@ -111,6 +111,7 @@ extern "C"
 #define GRBL_HELP (GRBL_SYSTEM_CMD + 8)
 #define GRBL_JOG_CMD (GRBL_SYSTEM_CMD + 9)
 
+#define EXEC_ALARM_EMERGENCY_STOP -1
 #define EXEC_ALARM_RESET 0
 // Grbl alarm codes. Valid values (1-255). Zero is reserved for the reset alarm.
 #define EXEC_ALARM_HARD_LIMIT 1
@@ -124,7 +125,6 @@ extern "C"
 #define EXEC_ALARM_HOMING_FAIL_APPROACH 9
 #define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10
 #define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11
-#define EXEC_ALARM_EMERGENCY_STOP 12
 
 //formated messages
 #define STR_EOL "\r\n"

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -60,7 +60,7 @@ extern "C"
         protocol_busy = false;
     }
 
-    void protocol_send_alarm(uint8_t alarm)
+    void protocol_send_alarm(int8_t alarm)
     {
         protocol_busy = true;
         serial_print_str(MSG_ALARM);

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -163,6 +163,7 @@ extern "C"
 #endif
         uint8_t controls = io_get_controls();
         uint8_t limits = io_get_limits();
+        bool probe = io_get_probe();
         uint8_t state = cnc_get_exec_state(0xFF);
         uint8_t filter = 0x80;
         while (!(state & filter) && filter)
@@ -259,7 +260,7 @@ extern "C"
         serial_print_long(itp_get_rt_line_number());
 #endif
 
-        if (CHECKFLAG(controls, (ESTOP_MASK | SAFETY_DOOR_MASK | FHOLD_MASK)) | CHECKFLAG(limits, LIMITS_MASK))
+        if (CHECKFLAG(controls, (ESTOP_MASK | SAFETY_DOOR_MASK | FHOLD_MASK)) || CHECKFLAG(limits, LIMITS_MASK) || probe)
         {
             serial_print_str(MSG_STATUS_PIN);
 
@@ -278,7 +279,7 @@ extern "C"
                 serial_putc('H');
             }
 
-            if (io_get_probe())
+            if (probe)
             {
                 serial_putc('P');
             }

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -206,7 +206,7 @@ extern "C"
                     }
                 }
                 break;
-            case EXEC_LIMITS:
+            case EXEC_HALT:
                 serial_print_str(MSG_STATUS_ALARM);
                 break;
             case EXEC_HOLD:

--- a/src/interface/protocol.h
+++ b/src/interface/protocol.h
@@ -30,7 +30,7 @@ extern "C"
 	bool protocol_is_busy(void);
 	void protocol_send_ok(void);
 	void protocol_send_error(uint8_t error);
-	void protocol_send_alarm(uint8_t alarm);
+	void protocol_send_alarm(int8_t alarm);
 	void protocol_send_status(void);
 	void protocol_send_string(const unsigned char *__s);
 	void protocol_send_feedback(const unsigned char *__s);

--- a/src/interface/serial.c
+++ b/src/interface/serial.c
@@ -80,10 +80,7 @@ extern "C"
         case SERIAL_UART:
             while (serial_rx_write == serial_rx_read)
             {
-                if (!cnc_dotasks())
-                {
-                    return STATUS_CRITICAL_FAIL;
-                }
+                cnc_dotasks();
             }
 
             c = serial_rx_buffer[serial_rx_read];
@@ -154,10 +151,7 @@ extern "C"
         case SERIAL_UART:
             while (serial_rx_write == serial_rx_read)
             {
-                if (!cnc_dotasks())
-                {
-                    return STATUS_CRITICAL_FAIL;
-                }
+                cnc_dotasks();
             }
             c = serial_rx_buffer[serial_rx_read];
             switch (c)
@@ -199,10 +193,7 @@ extern "C"
         }
         while (write == serial_tx_read)
         {
-            if (!cnc_dotasks()) //on any alarm abort
-            {
-                return;
-            }
+            cnc_dotasks();
         } //while buffer is full
 
         serial_tx_buffer[serial_tx_write] = c;
@@ -214,10 +205,7 @@ extern "C"
 #else
     while (!mcu_tx_ready())
     {
-        if (!cnc_dotasks()) //on any alarm abort
-        {
-            return;
-        }
+        cnc_dotasks();
     }
     mcu_putc(c);
 #endif
@@ -352,10 +340,7 @@ extern "C"
         while (serial_tx_write != serial_tx_read)
         {
             mcu_putc(0);
-            if (!cnc_dotasks())
-            {
-                return;
-            }
+            cnc_dotasks();
         }
 #endif
     }


### PR DESCRIPTION
-complete alarm and interlocking revision
-added ALARM -1 for emergency stop button press
-only hard/soft limit alarms now force reset like defined by Grbl
-startup blocks blocks will now only run on the first successful unlock after a reset to prevent unwanted startup block calls
-fixed step enabling logic (negative logic)
-stepper enabling now only happens after correct reset
-recoded homing and probe to match interlocking changes
-fixed after homing axis drifting on motions before first specific axis coordinate is set
-fixed hidden probe report alarm (only showed if other input pin alarms were active)
-fixed probing coordinates storing (was saving step count and not machine coordinates)