### PR TITLE
fixes startup blocks on STM32

### DIFF
--- a/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
+++ b/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
@@ -1048,6 +1048,7 @@ extern "C"
 	void mcu_dotasks()
 	{
 #ifdef USB_VCP
+		tud_cdc_write_flush();
 		tud_task(); // tinyusb device task
 #endif
 #ifdef ENABLE_SYNC_RX

--- a/src/interface/protocol.c
+++ b/src/interface/protocol.c
@@ -470,7 +470,7 @@ extern "C"
         for (;;)
         {
             settings_load(address++, &c, 1);
-            if (c)
+            if (c > 0 && c < 128)
             {
                 serial_putc(c);
             }
@@ -486,7 +486,7 @@ extern "C"
         for (;;)
         {
             settings_load(address++, &c, 1);
-            if (c)
+            if (c > 0 && c < 128)
             {
                 serial_putc(c);
             }

--- a/src/interface/serial.c
+++ b/src/interface/serial.c
@@ -104,12 +104,13 @@ extern "C"
         case SERIAL_N0:
         case SERIAL_N1:
             c = mcu_eeprom_getc(serial_read_index++);
-            if (c)
+            if (c > 0 && c < 128)
             {
                 serial_putc(c);
             }
             else
             {
+                c = 0;
                 serial_putc(':');
                 serial_read_select = SERIAL_UART; // resets the serial select
             }
@@ -168,7 +169,8 @@ extern "C"
             break;
         case SERIAL_N0:
         case SERIAL_N1:
-            return mcu_eeprom_getc(serial_read_index);
+            c = mcu_eeprom_getc(serial_read_index);
+            return (c > 0 && c < 128) ? c : 0;
         }
         return EOL;
     }

--- a/tinyusb/src/tusb_config.h
+++ b/tinyusb/src/tusb_config.h
@@ -103,11 +103,11 @@ extern "C"
 #define CFG_TUD_VENDOR 0
 
 // CDC FIFO size of TX and RX
-#define CFG_TUD_CDC_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define CFG_TUD_CDC_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 128)
+#define CFG_TUD_CDC_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 128)
 
 // CDC Endpoint transfer buffer size, more is faster
-#define CFG_TUD_CDC_EP_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_EP_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 128)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
-STM32 EEPROM in flash unwritten values are read 0xFF. This causes startup blocks to be read incorrectly. Filters ascii between 0 and 127 to prevent errors.