### PR TITLE
fix cycle start resuming infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Changelog
 
+## [1.3.b2] - 2021-12-14
+
+Version 1.3 is a major revision an targets add SAMD21 (Arduino Zero and M0) support.
+Beta2 fixes the following issue:
+
+### Changed
+  - cnc spindle speed and resume delay baypass if set to 0 (#73)
+
+### Fixed
+  - while executing real time commands with the CS_RES pin always active caused and infinite loop inside the tool delay (caused stack overflow error on SAMD21) (#73)
+
 ## [1.3.b] - 2021-12-13
 
 Version 1.3 is a major revision an targets add SAMD21 (Arduino Zero and M0) support.
@@ -322,6 +333,7 @@ Version 1.1.0 comes with many added features and improvements over the previous 
 
 ### Initial release
 
+[1.3.b2]: https://github.com/Paciente8159/uCNC/releases/tag/v1.3.b2
 [1.3.b]: https://github.com/Paciente8159/uCNC/releases/tag/v1.3.b
 [1.2.4]: https://github.com/Paciente8159/uCNC/releases/tag/v1.2.4
 [1.2.3]: https://github.com/Paciente8159/uCNC/releases/tag/v1.2.3

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -365,7 +365,9 @@ extern "C"
             itp_sync_spindle();
             if (!planner_buffer_is_empty())
             {
+#if (DELAY_ON_RESUME > 0)
                 cnc_delay_ms(DELAY_ON_RESUME * 1000);
+#endif
             }
 #endif
             CLEARFLAG(cnc_state.exec_state, EXEC_RESUMING);
@@ -430,7 +432,11 @@ extern "C"
             SETFLAG(cnc_state.rt_cmd, RT_CMD_REPORT);
             break;
         case CMD_CODE_CYCLE_START:
-            SETFLAG(cnc_state.rt_cmd, RT_CMD_CYCLE_START); //tries to clear hold if possible
+            //prevents loop if cycle start is always pressed or unconnected (during cnc_dotasks)
+            if (!CHECKFLAG(cnc_state.exec_state, EXEC_RESUMING))
+            {
+                SETFLAG(cnc_state.rt_cmd, RT_CMD_CYCLE_START); //tries to clear hold if possible
+            }
             break;
         case CMD_CODE_SAFETY_DOOR:
             SETFLAG(cnc_state.exec_state, (EXEC_HOLD | EXEC_DOOR));

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -1085,7 +1085,9 @@ extern "C"
             if (!g_settings.laser_mode)
             {
 #endif
+#if (DELAY_ON_SPINDLE_SPEED_CHANGE > 0)
                 block_data.dwell = (uint16_t)roundf(DELAY_ON_SPINDLE_SPEED_CHANGE * 1000);
+#endif
 #ifdef LASER_MODE
             }
 #endif


### PR DESCRIPTION
-fix cycle start resuming infinite loop. If CS_RES is active during a resume the cnc spindle resume delay causes an infinite loop (reentrancy via exec_rt_commands in cnc_dotasks)
-if spindle resume/change are set to 0 skips cnc delay call