### PR TITLE
samd21 hardware UART implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 # Changelog
 
+## [1.3.rc] - unreleased
+
+Version 1.3 is a major revision an targets add SAMD21 (Arduino Zero and M0) support.
+Release Candidate fixes the following issue:
+
+### Added
+  - implemented Hardware UART in SAMD21 (#75)
+
+### Changed
+  - modified some NVIC IRQ and global interrupt enable and disable inside ISR code in STM32 and SAMD21 (#75)
+  - modified RTC to prevent reentrancy inside ISR code in STM32 and SAMD21 (#75)
+
+### Fixed
+  - fixed issue with active CS_RES input that caused resume condition (delay) without active hold present (#75)
+
 ## [1.3.b2] - 2021-12-14
 
 Version 1.3 is a major revision an targets add SAMD21 (Arduino Zero and M0) support.
@@ -339,6 +354,7 @@ Version 1.1.0 comes with many added features and improvements over the previous 
 
 ### Initial release
 
+[1.3.rc]: https://github.com/Paciente8159/uCNC/releases/tag/v1.3.rc
 [1.3.b2]: https://github.com/Paciente8159/uCNC/releases/tag/v1.3.b2
 [1.3.b]: https://github.com/Paciente8159/uCNC/releases/tag/v1.3.b
 [1.2.4]: https://github.com/Paciente8159/uCNC/releases/tag/v1.2.4

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ TODO List of G-Codes in µCNC future releases:
 
 I used several UNO emulators but debugging was not easy. So a kind of virtual board (Windows PC) was created to test µCNC core code independently.
 It can run on:
-  - Arduino UNO
-  - Arduino MEGA
-  - STM32F1 Blue Pill
+  - AVR (Arduino UNO/MEGA)
+  - SAMD21 (Arduino Zero/M0)
+  - STM32F1 (Bluepill)
   - Windows PC (used for simulation only - ISR on Windows doesn't allow to use it a real alternative)
 
 ### µCNC roadmap

--- a/makefiles/samd21/Makefile
+++ b/makefiles/samd21/Makefile
@@ -14,13 +14,13 @@
 # target
 ######################################
 TARGET = uCNC
-USE_USB = TRUE
+#USE_USB = TRUE
 
 ######################################
 # building variables
 ######################################
 # debug build?
-DEBUG = 0
+DEBUG = 1
 # optimization
 ifeq ($(DEBUG), 1)
 OPT = -Og

--- a/makefiles/samd21/Makefile
+++ b/makefiles/samd21/Makefile
@@ -14,7 +14,7 @@
 # target
 ######################################
 TARGET = uCNC
-#USE_USB = TRUE
+USE_USB = TRUE
 
 ######################################
 # building variables

--- a/makefiles/samd21/Makefile
+++ b/makefiles/samd21/Makefile
@@ -20,7 +20,7 @@ TARGET = uCNC
 # building variables
 ######################################
 # debug build?
-DEBUG = 1
+DEBUG = 0
 # optimization
 ifeq ($(DEBUG), 1)
 OPT = -Og

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -354,7 +354,8 @@ extern "C"
             }
         }
 
-        if (CHECKFLAG(statemask, EXEC_HOLD))
+        //if releasing from a HOLD state with and active delay in exec
+        if (CHECKFLAG(statemask, EXEC_HOLD) && CHECKFLAG(cnc_state.exec_state, EXEC_HOLD))
         {
             SETFLAG(cnc_state.exec_state, EXEC_RESUMING);
             CLEARFLAG(cnc_state.exec_state, EXEC_HOLD);

--- a/src/cnc_build.h
+++ b/src/cnc_build.h
@@ -25,7 +25,7 @@ extern "C"
 #endif
 
 #define CNC_MAJOR_MINOR_VERSION "1.3."
-#define CNC_PATCH_VERSION "b2"
+#define CNC_PATCH_VERSION "rc"
 
 #define CNC_VERSION CNC_MAJOR_MINOR_VERSION CNC_PATCH_VERSION
 

--- a/src/cnc_config.h
+++ b/src/cnc_config.h
@@ -42,6 +42,17 @@ extern "C"
 //#define ENABLE_SYNC_TX
 //#define ENABLE_SYNC_RX
 
+//uncomment to enable USB VCP instead of serial hardware
+//#define USB_VCP
+#ifdef USB_VCP
+#ifndef ENABLE_SYNC_TX
+#define ENABLE_SYNC_TX
+#endif
+#ifndef ENABLE_SYNC_RX
+#define ENABLE_SYNC_RX
+#endif
+#endif
+
 /*
 	Choose the board
 	Check boardss.h for list of available/supported boards

--- a/src/hal/boards/samd21/boardmap_mzero.h
+++ b/src/hal/boards/samd21/boardmap_mzero.h
@@ -102,6 +102,7 @@ extern "C"
 #define TX_PAD 2
 #define RX_BIT 11
 #define RX_PORT A
+#define RX_MUX C
 #define RX_PAD 3
 //set COM number. By default COM0 is used
 //#define COM_NUMBER 0

--- a/src/hal/boards/samd21/boardmap_mzero.h
+++ b/src/hal/boards/samd21/boardmap_mzero.h
@@ -98,8 +98,13 @@ extern "C"
 #ifdef COM_PORT
 #define TX_BIT 10
 #define TX_PORT A
+#define TX_MUX C
+#define TX_PAD 2
 #define RX_BIT 11
 #define RX_PORT A
+#define RX_PAD 3
+//set COM number. By default COM0 is used
+//#define COM_NUMBER 0
 #else
 #ifdef USB_VCP
 #define USB_DM_BIT 24

--- a/src/hal/boards/samd21/boardmap_zero.h
+++ b/src/hal/boards/samd21/boardmap_zero.h
@@ -102,6 +102,7 @@ extern "C"
 #define TX_PAD 2
 #define RX_BIT 11
 #define RX_PORT A
+#define RX_MUX C
 #define RX_PAD 3
 //set COM number. By default COM0 is used
 //#define COM_NUMBER 0

--- a/src/hal/boards/samd21/boardmap_zero.h
+++ b/src/hal/boards/samd21/boardmap_zero.h
@@ -98,8 +98,13 @@ extern "C"
 #ifdef COM_PORT
 #define TX_BIT 10
 #define TX_PORT A
+#define TX_MUX C
+#define TX_PAD 2
 #define RX_BIT 11
 #define RX_PORT A
+#define RX_PAD 3
+//set COM number. By default COM0 is used
+//#define COM_NUMBER 0
 #else
 #ifdef USB_VCP
 #define USB_DM_BIT 24

--- a/src/hal/mcus/samd21/mcu_samd21.c
+++ b/src/hal/mcus/samd21/mcu_samd21.c
@@ -54,6 +54,13 @@ extern "C"
         //setups internal timers (all will run @ 1Mhz on GCLK4)
         static void mcu_setup_clocks(void)
         {
+                PM->CPUSEL.reg = 0;
+                PM->APBASEL.reg = 0;
+                PM->APBBSEL.reg = 0;
+                PM->APBCSEL.reg = 0;
+                PM->AHBMASK.reg |= (PM_AHBMASK_NVMCTRL);
+                PM->APBAMASK.reg |= (PM_APBAMASK_PM | PM_APBAMASK_SYSCTRL | PM_APBAMASK_GCLK | PM_APBAMASK_RTC);
+                PM->APBBMASK.reg |= (PM_APBBMASK_NVMCTRL | PM_APBBMASK_PORT | PM_APBBMASK_USB);
                 PM->APBCMASK.reg |= (PM_APBCMASK_TCC0 | PM_APBCMASK_TCC1 | PM_APBCMASK_TCC2 | PM_APBCMASK_TC3 | PM_APBCMASK_TC4 | PM_APBCMASK_TC5 | PM_APBCMASK_TC6 | PM_APBCMASK_TC7);
 
                 /* Configure GCLK4's divider - in this case, divided by 1 */
@@ -108,13 +115,93 @@ extern "C"
                         resetstep = !resetstep;
                 }
 
-                NVIC_ClearPendingIRQ(ITP_IRQ);
                 mcu_enable_global_isr();
         }
+
+#ifdef COM_PORT
+        void mcu_com_isr()
+        {
+                mcu_disable_global_isr();
+#ifndef ENABLE_SYNC_RX
+                if (COM->USART.INTFLAG.bit.RXC && COM->USART.INTENSET.bit.RXC)
+                {
+                        COM->USART.INTFLAG.bit.RXC = 1;
+                        unsigned char c = (0xff & COM_INREG);
+                        serial_rx_isr(c);
+                }
+#endif
+#ifndef ENABLE_SYNC_TX
+                if (COM->USART.INTFLAG.bit.DRE && COM->USART.INTENSET.bit.DRE)
+                {
+                        COM->USART.INTENCLR.bit.DRE = 1;
+                        serial_tx_isr();
+                }
+#endif
+                mcu_enable_global_isr();
+        }
+#endif
 
         void mcu_usart_init(void)
         {
 #ifdef COM_PORT
+                PM->APBCMASK.reg |= PM_APBCMASK_COM;
+
+                SYSCTRL->OSC8M.bit.PRESC = 0;                          // no prescaler (is 8 on reset)
+                SYSCTRL->OSC8M.reg |= 1 << SYSCTRL_OSC8M_ENABLE_Pos;   // enable source
+ 
+                GCLK->GENDIV.bit.ID = 0x03;                            // select GCLK_GEN[3]
+                GCLK->GENDIV.bit.DIV = 0;                              // no prescaler
+ 
+                GCLK->GENCTRL.bit.ID = 0x03;                           // select GCLK_GEN[3]
+                GCLK->GENCTRL.reg |= GCLK_GENCTRL_SRC_OSC8M;           // OSC8M source
+                GCLK->GENCTRL.bit.GENEN = 1;                           // enable generator
+                
+                GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID_SERCOM5_CORE;      // SERCOM5 multiplexer GCLK_PERIPHERAL[n]
+                GCLK->CLKCTRL.reg |= GCLK_CLKCTRL_GEN_GCLK3;           // select multiplexer source GCLK_GEN[3]
+                GCLK->CLKCTRL.bit.CLKEN = 1;                           // enable generic clock (for baud rate generation)
+
+                /* Setup GCLK0 SERCOMx to use GENCLK0 */
+                GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID_COM;
+                while (GCLK->STATUS.bit.SYNCBUSY)
+                        ;
+
+                // Start the Software Reset
+                COM->USART.CTRLA.bit.SWRST = 1;
+
+                while (COM->USART.SYNCBUSY.bit.SWRST)
+                        ;
+
+                COM->USART.CTRLA.bit.MODE = 1;
+                COM->USART.CTRLA.bit.SAMPR = 0;  //16x sample rate
+                COM->USART.CTRLA.bit.FORM = 0;   //no parity
+                COM->USART.CTRLA.bit.DORD = 1;  //LSB first
+                COM->USART.CTRLA.bit.RXPO = COM_RX_PAD;    // RX on PAD3
+                COM->USART.CTRLA.bit.TXPO = COM_TX_PAD;    // TX on PAD2
+                COM->USART.CTRLB.bit.SBMODE = 0; //one stop bit
+                COM->USART.CTRLB.bit.CHSIZE = 0; //8 bits
+                COM->USART.CTRLB.bit.RXEN = 1;      // enable receiver
+                COM->USART.CTRLB.bit.TXEN = 1;// enable transmitter
+
+                while (COM->USART.SYNCBUSY.bit.CTRLB)
+                        ;
+
+                uint16_t baud = (uint16_t)(65536.0f * (1.0f - (((float)BAUDRATE)/((float)(F_CPU>>4)))));
+
+                COM->USART.BAUD.reg = baud;
+                mcu_config_altfunc(TX);
+                mcu_config_altfunc(RX);
+
+#ifndef ENABLE_SYNC_RX
+                COM->USART.INTENSET.bit.RXC = 1; //enable recieved interrupt
+#endif
+                NVIC_ClearPendingIRQ(COM_IRQ);
+                NVIC_EnableIRQ(COM_IRQ);
+                NVIC_SetPriority(COM_IRQ, 10);
+
+                //enable COM
+                COM->USART.CTRLA.bit.ENABLE = 1;
+                while (COM->USART.SYNCBUSY.bit.ENABLE)
+                        ;
 
 #endif
 #ifdef USB_VCP
@@ -124,9 +211,9 @@ extern "C"
                 mcu_config_input(USB_DP);
                 mcu_config_altfunc(USB_DM);
                 mcu_config_altfunc(USB_DP);
+                NVIC_ClearPendingIRQ(USB_IRQn);
                 NVIC_EnableIRQ(USB_IRQn);
                 NVIC_SetPriority(USB_IRQn, 10);
-                NVIC_ClearPendingIRQ(USB_IRQn);
 
                 GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID_USB;
                 /* Wait for the write to complete. */
@@ -149,7 +236,6 @@ extern "C"
         {
                 mcu_disable_global_isr();
                 tud_int_handler(0);
-                NVIC_ClearPendingIRQ(USB_IRQn);
                 mcu_enable_global_isr();
         }
 #endif
@@ -163,18 +249,33 @@ extern "C"
 
         void SysTick_Handler(void)
         {
-                mcu_runtime_ms++;
-                mcu_enable_global_isr();
-                pid_update_isr();
-#ifdef LED
-                static uint32_t last_ms = 0;
-                if (mcu_runtime_ms - last_ms > 1000)
+                static bool running = false;
+                static uint32_t counter = 0;
+                mcu_disable_global_isr();
+                counter++;
+                mcu_runtime_ms = counter;
+
+                if (!running)
                 {
-                        last_ms = mcu_runtime_ms;
-                        mcu_toggle_output(LED);
-                }
+                        running = true;
+                        mcu_enable_global_isr();
+                        pid_update_isr();
+#ifdef LED
+                        if ((counter & 0x200))
+                        {
+                                mcu_set_output(LED);
+                        }
+                        else
+                        {
+                                mcu_clear_output(LED);
+                        }
+
 #endif
-                NVIC_ClearPendingIRQ(SysTick_IRQn);
+                        mcu_disable_global_isr();
+                        running = false;
+                }
+
+                mcu_enable_global_isr();
         }
 
         void mcu_tick_init()
@@ -757,6 +858,20 @@ extern "C"
                 {
                         tud_cdc_write_flush();
                 }
+#else
+#ifdef COM
+                if (c != 0)
+                {
+#ifdef ENABLE_SYNC_TX
+                        while (!mcu_tx_ready())
+                                ;
+#endif
+                        COM_OUTREG = c;
+                }
+#ifndef ENABLE_SYNC_TX
+                COM->USART.INTENSET.bit.DRE = 1; //enable recieved interrupt
+#endif
+#endif
 #endif
         }
 #endif
@@ -778,6 +893,13 @@ extern "C"
                 }
 
                 return (unsigned char)tud_cdc_read_char();
+#else
+#ifdef COM
+#ifdef ENABLE_SYNC_RX
+                while (!mcu_rx_ready()));
+#endif
+                return COM_INREG;
+#endif
 #endif
         }
 #endif
@@ -868,9 +990,11 @@ extern "C"
                 ITP_REG->CC[0].reg = ticks;
                 while (ITP_REG->SYNCBUSY.bit.CC0)
                         ;
-                NVIC_EnableIRQ(ITP_IRQ);
+
                 NVIC_SetPriority(ITP_IRQ, 1);
                 NVIC_ClearPendingIRQ(ITP_IRQ);
+                NVIC_EnableIRQ(ITP_IRQ);
+
                 ITP_REG->INTENSET.bit.MC0 = 1;
                 ITP_REG->CTRLA.bit.ENABLE = 1; //enable timer and also write protection
                 while (ITP_REG->SYNCBUSY.bit.ENABLE)
@@ -888,9 +1012,10 @@ extern "C"
                 ITP_REG->COUNT16.CC[0].reg = ticks;
                 while (ITP_REG->COUNT16.STATUS.bit.SYNCBUSY)
                         ;
-                NVIC_EnableIRQ(ITP_IRQ);
                 NVIC_SetPriority(ITP_IRQ, 1);
                 NVIC_ClearPendingIRQ(ITP_IRQ);
+                NVIC_EnableIRQ(ITP_IRQ);
+
                 ITP_REG->COUNT16.INTENSET.bit.MC0 = 1;
                 ITP_REG->COUNT16.CTRLA.bit.ENABLE = 1; //enable timer and also write protection
                 while (ITP_REG->COUNT16.STATUS.bit.SYNCBUSY)
@@ -942,6 +1067,7 @@ extern "C"
                 while (ITP_REG->COUNT16.STATUS.bit.SYNCBUSY)
                         ;
 #endif
+                ITP_REG->COUNT16.INTENCLR.bit.MC0 = 1;
                 NVIC_DisableIRQ(ITP_IRQ);
         }
 
@@ -995,10 +1121,10 @@ extern "C"
                 NVMCTRL->STATUS.reg |= NVMCTRL_STATUS_MASK;
                 while (!NVMCTRL->INTFLAG.bit.READY)
                         ;
-                
+
                 for (uint32_t i = 0; i != NVM_EEPROM_SIZE;)
                 {
-                        uint16_t data = NVM_MEMORY[((NVM_EEPROM_BASE + i)/2)];
+                        uint16_t data = NVM_MEMORY[((NVM_EEPROM_BASE + i) / 2)];
                         samd21_eeprom_sram[i] = (data & 0xff);
                         samd21_eeprom_sram[i + 1] = (data >> 8);
                         i += 2;
@@ -1108,7 +1234,7 @@ extern "C"
                                 for (uint16_t p = 0; p < NVM_ROW_PAGES; p++)
                                 {
                                         uint32_t page_offset = eeprom_offset + (p * NVM_PAGE_SIZE);
-                                        for (uint16_t o = 0; o < NVM_PAGE_SIZE; o+=2)
+                                        for (uint16_t o = 0; o < NVM_PAGE_SIZE; o += 2)
                                         {
                                                 uint32_t offset = page_offset + o;
                                                 uint16_t data = NVM_MEMORY[(NVM_EEPROM_BASE + offset) / 2];

--- a/src/hal/mcus/samd21/mcumap_samd21.h
+++ b/src/hal/mcus/samd21/mcumap_samd21.h
@@ -1008,7 +1008,7 @@ extern "C"
 #define COM_IRQ __helper__(SERCOM, COM_NUMBER, _IRQn)
 #define mcu_com_isr __helper__(SERCOM, COM_NUMBER, _Handler)
 #define COM_OUTREG (COM->USART.DATA.reg)
-#define COM_INREG ((volatile uint16_t)COM->USART.DATA.reg)
+#define COM_INREG (COM->USART.DATA.reg)
 #define COM_TX_PAD sercompad(_TX,TX_PAD)
 #define COM_RX_PAD sercompad(_RX,RX_PAD)
 #endif


### PR DESCRIPTION
- implemented Hardware UART in SAMD21
- modified some NVIC IRQ and global interrupt enable and disable inside ISR code in STM32 and SAMD21
- modified RTC to prevent reentrancy inside ISR code in STM32 and SAMD21
- fixed issue with active CS_RES input that caused resume condition (delay) without active hold present