### PR TITLE
moved RTC function to cnc compilation unit and small atomic block fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ RC adds/fixes the following issue:
   - new AVR make file (#82)
   - modified/simplified parser G90/G91 (absolute/relative coordinates) (#83)
   - removed planner position tracking. Modified/simplified position tracking inside motion control. This is more memory effective and prevents desynchronization problems between the motion controller and the interpolator (#84)
+  - moved scheduled code running from hardware implementation to cnc (common) compilation unit. Makes code (pid update or other) architecture agnostic. (#86)
 
 ### Fixed
   - fixed issue with active CS_RES input that caused resume condition (delay) without active hold present (#75)

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -199,6 +199,38 @@ extern "C"
         return !cnc_get_exec_state(EXEC_KILL);
     }
 
+    //this function is executed every millisecond
+    void cnc_scheduletasks(void)
+    {
+        static bool running = false;
+        static uint32_t counter = 0;
+        mcu_disable_global_isr();
+        counter++;
+
+        if (!running)
+        {
+            running = true;
+            mcu_enable_global_isr();
+            pid_update();
+#ifdef LED
+            //this blinks aprox. once every 1024ms
+            if ((counter & 0x200))
+            {
+                io_set_output(LED);
+            }
+            else
+            {
+                io_set_output(LED);
+            }
+
+#endif
+            mcu_disable_global_isr();
+            running = false;
+        }
+
+        mcu_enable_global_isr();
+    }
+
     void cnc_home(void)
     {
         cnc_set_exec_state(EXEC_HOMING);

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -216,11 +216,11 @@ extern "C"
             //this blinks aprox. once every 1024ms
             if ((counter & 0x200))
             {
-                io_set_output(LED);
+                io_set_output(LED, true);
             }
             else
             {
-                io_set_output(LED);
+                io_set_output(LED, false);
             }
 
 #endif

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -194,6 +194,7 @@ extern "C"
 	void cnc_run(void);
 	//do events returns true if all OK and false if an ABORT alarm is reached
 	bool cnc_dotasks(void);
+	void cnc_scheduletasks(void);
 	void cnc_home(void);
 	void cnc_alarm(int8_t code);
 	void cnc_stop(void);

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -188,7 +188,7 @@ extern "C"
 		}
 	}
 
-#define __ATOMIC__ for (bool __restore_atomic__ __attribute__((__cleanup__(__atomic_out))) = mcu_get_global_isr, __AtomLock = __atomic_in(); __AtomLock; __AtomLock = 0)
+#define __ATOMIC__ for (bool __restore_atomic__ __attribute__((__cleanup__(__atomic_out))) = mcu_get_global_isr(), __AtomLock = __atomic_in(); __AtomLock; __AtomLock = 0)
 
 #ifdef __cplusplus
 }

--- a/src/hal/mcus/avr/mcu_avr.c
+++ b/src/hal/mcus/avr/mcu_avr.c
@@ -39,7 +39,6 @@ extern "C"
 #include "interface/serial.h"
 #include "core/interpolator.h"
 #include "core/io_control.h"
-#include "modules/pid_controller.h"
 
 #include <math.h>
 #include <inttypes.h>
@@ -70,10 +69,7 @@ extern "C"
         ISR(RTC_COMPA_vect, ISR_BLOCK)
         {
                 mcu_runtime_ms++;
-#if PID_CONTROLLERS > 0
-                mcu_enable_global_isr();
-                pid_update_isr();
-#endif
+		cnc_scheduletasks();
         }
 
         ISR(ITP_COMPA_vect, ISR_BLOCK)

--- a/src/hal/mcus/avr/mcumap_avr.h
+++ b/src/hal/mcus/avr/mcumap_avr.h
@@ -3603,7 +3603,7 @@ extern "C"
 
 #define mcu_enable_global_isr sei
 #define mcu_disable_global_isr cli
-#define mcu_get_global_isr (SREG && 0x80)
+#define mcu_get_global_isr() ({ (SREG && 0x80); })
 
 #define mcu_tx_ready() (CHECKBIT(UCSRA, UDRE))
 #define mcu_rx_ready() (CHECKBIT(UCSRA, RX))

--- a/src/hal/mcus/samd21/mcumap_samd21.h
+++ b/src/hal/mcus/samd21/mcumap_samd21.h
@@ -32,6 +32,7 @@ extern "C"
 	MCU specific definitions and replacements
 */
 #include "sam.h"
+#include <stdbool.h>
 
 //defines the frequency of the mcu
 #ifndef F_CPU
@@ -1910,9 +1911,10 @@ extern "C"
 #endif
 #endif
 */
-#define mcu_enable_global_isr __enable_irq
-#define mcu_disable_global_isr __disable_irq
-#define mcu_get_global_isr (__get_PRIMASK == 0)
+extern volatile bool samd21_global_isr_enabled;
+#define mcu_enable_global_isr() ({__enable_irq(); samd21_global_isr_enabled = true;})
+#define mcu_disable_global_isr() ({samd21_global_isr_enabled = false; __disable_irq(); })
+#define mcu_get_global_isr() ({ samd21_global_isr_enabled; })
 
 #ifdef COM_PORT
 #define mcu_rx_ready() (COM->USART.INTFLAG.bit.RXC)

--- a/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
+++ b/src/hal/mcus/stm32f10x/mcu_stm32f10x.c
@@ -30,7 +30,6 @@ extern "C"
 #include "interface/serial.h"
 #include "core/interpolator.h"
 #include "core/io_control.h"
-#include "modules/pid_controller.h"
 
 #ifdef USB_VCP
 #include "tusb_config.h"
@@ -118,6 +117,7 @@ extern "C"
 	 * Can count up to almost 50 days
 	 **/
 	static volatile uint32_t mcu_runtime_ms;
+	volatile bool stm32_global_isr_enabled;
 
 #define mcu_config_output(diopin)                                                                                           \
 	{                                                                                                                       \
@@ -320,33 +320,8 @@ extern "C"
 
 	void SysTick_Handler(void)
 	{
-		static bool running = false;
-		static uint32_t counter = 0;
-		mcu_disable_global_isr();
-		counter++;
-		mcu_runtime_ms = counter;
-
-		if (!running)
-		{
-			running = true;
-			mcu_enable_global_isr();
-			pid_update_isr();
-#ifdef LED
-			if ((counter & 0x200))
-			{
-				mcu_set_output(LED);
-			}
-			else
-			{
-				mcu_clear_output(LED);
-			}
-
-#endif
-			mcu_disable_global_isr();
-			running = false;
-		}
-
-		mcu_enable_global_isr();
+		mcu_runtime_ms++;
+		cnc_scheduletasks();
 	}
 
 	/**
@@ -361,6 +336,7 @@ extern "C"
 
 	void mcu_init(void)
 	{
+		stm32_global_isr_enabled = false;
 #if STEP0 >= 0
 		mcu_config_output(STEP0);
 #endif

--- a/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
+++ b/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
@@ -32,6 +32,7 @@ extern "C"
 	MCU specific definitions and replacements
 */
 #include "stm32f10x.h"
+#include <stdbool.h>
 
 //defines the frequency of the mcu
 #ifndef F_CPU

--- a/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
+++ b/src/hal/mcus/stm32f10x/mcumap_stm32f10x.h
@@ -3257,9 +3257,10 @@ extern "C"
 #endif
 #endif
 
-#define mcu_enable_global_isr __enable_irq
-#define mcu_disable_global_isr __disable_irq
-#define mcu_get_global_isr (__get_PRIMASK == 0)
+extern volatile bool stm32_global_isr_enabled;
+#define mcu_enable_global_isr() ({__enable_irq(); stm32_global_isr_enabled = true;})
+#define mcu_disable_global_isr() ({stm32_global_isr_enabled = false; __disable_irq(); })
+#define mcu_get_global_isr() ({ stm32_global_isr_enabled; })
 
 // #ifdef COM_PORT
 // #ifndef ENABLE_SYNC_TX

--- a/src/modules/pid_controller.c
+++ b/src/modules/pid_controller.c
@@ -179,7 +179,7 @@ extern "C"
 #endif
     }
 
-    void pid_update_isr(void)
+    void pid_update(void)
     {
         tool_pid_update();
         

--- a/src/modules/pid_controller.h
+++ b/src/modules/pid_controller.h
@@ -137,7 +137,7 @@ extern "C"
 #define PID_OUTPUT_MIN 0
 
 	void pid_init(void);
-	void pid_update_isr(void);
+	void pid_update(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
-moved RTC function to cnc compilation unit. This keeps the code more uniform since implementation is done in a hardware agnostic compilation unit
-small atomic block fixes for STM32 and SAMD21 (uses internal flag to keep state of global interrupts)
-pid function renaming