### PR TITLE
SAMD21 control/limit ISR masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - fixed input/limits/control ISR reentrancy in SAMD21 and STM32 (#94)
   - call missing encoder update on input isr callback (#94)
   - return argument on get_encoder_pos (#94)
+  - enforced soft polling of inputs and controls on cnc_dotasks. collision between LIMIT_Y and ESTOP shared exti(2) was preventing ESTOP from triggering actions (#99)
 
 ## [1.3.0] - 2021-12-30
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -163,12 +163,12 @@ bool cnc_dotasks(void)
         return true;
     }
 
-#if ((LIMITEN_MASK ^ LIMITISR_MASK) || defined(FORCE_SOFT_POLLING))
+// #if ((LIMITEN_MASK ^ LIMITISR_MASK) || defined(FORCE_SOFT_POLLING))
     io_limits_isr();
-#endif
-#if ((CONTROLEN_MASK ^ CONTROLISR_MASK) || defined(FORCE_SOFT_POLLING))
+// #endif
+// #if ((CONTROLEN_MASK ^ CONTROLISR_MASK) || defined(FORCE_SOFT_POLLING))
     io_controls_isr();
-#endif
+// #endif
 
     cnc_exec_rt_commands(); //executes all pending realtime commands
 

--- a/uCNC/src/hal/boards/samd21/boardmap_mzero.h
+++ b/uCNC/src/hal/boards/samd21/boardmap_mzero.h
@@ -68,9 +68,10 @@ extern "C"
 #define LIMIT_Z_PULLUP
 
 //Enable limits switch interrupt
-#define LIMIT_X_ISR
-#define LIMIT_Y_ISR
-#define LIMIT_Z_ISR
+//REMOVED-LIMIT_Y and ESTOP share the same exti(2)
+// #define LIMIT_X_ISR
+// #define LIMIT_Y_ISR
+// #define LIMIT_Z_ISR
 
 //Setup control input pins
 #define ESTOP_BIT 2

--- a/uCNC/src/hal/mcus/samd21/mcu_samd21.c
+++ b/uCNC/src/hal/mcus/samd21/mcu_samd21.c
@@ -48,7 +48,7 @@
 volatile bool samd21_global_isr_enabled;
 
 //setups internal timers (all will run @ 1Mhz on GCLK4)
-#define MAIN_CLOCK_DIV ((uint16_t)(F_CPU/1000000))
+#define MAIN_CLOCK_DIV ((uint16_t)(F_CPU / 1000000))
 static void mcu_setup_clocks(void)
 {
         PM->CPUSEL.reg = 0;
@@ -93,18 +93,23 @@ static void mcu_setup_clocks(void)
 
 #if (SAMD21_EIC_MASK != 0)
         GCLK->CLKCTRL.reg = (uint16_t)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID_EIC);
-        EIC->CTRL.bit.ENABLE = 1;
+        EIC->CTRL.bit.SWRST = 1;
         while (EIC->STATUS.bit.SYNCBUSY)
                 ;
         /*all external interrupts will be on pin change with filter*/
-        EIC->CONFIG[0].reg = 0xbbbbbbbb;
-        EIC->CONFIG[1].reg = 0xbbbbbbbb;
+        EIC->CONFIG[0].reg = (EIC_CONFIG_SENSE0_BOTH | EIC_CONFIG_FILTEN0 | EIC_CONFIG_SENSE1_BOTH | EIC_CONFIG_FILTEN1 | EIC_CONFIG_SENSE2_BOTH | EIC_CONFIG_FILTEN2 | EIC_CONFIG_SENSE3_BOTH | EIC_CONFIG_FILTEN3 | EIC_CONFIG_SENSE4_BOTH | EIC_CONFIG_FILTEN4 | EIC_CONFIG_SENSE5_BOTH | EIC_CONFIG_FILTEN5 | EIC_CONFIG_SENSE6_BOTH | EIC_CONFIG_FILTEN6 | EIC_CONFIG_SENSE7_BOTH | EIC_CONFIG_FILTEN7);
+        EIC->CONFIG[1].reg = (EIC_CONFIG_SENSE0_BOTH | EIC_CONFIG_FILTEN0 | EIC_CONFIG_SENSE1_BOTH | EIC_CONFIG_FILTEN1 | EIC_CONFIG_SENSE2_BOTH | EIC_CONFIG_FILTEN2 | EIC_CONFIG_SENSE3_BOTH | EIC_CONFIG_FILTEN3 | EIC_CONFIG_SENSE4_BOTH | EIC_CONFIG_FILTEN4 | EIC_CONFIG_SENSE5_BOTH | EIC_CONFIG_FILTEN5 | EIC_CONFIG_SENSE6_BOTH | EIC_CONFIG_FILTEN6 | EIC_CONFIG_SENSE7_BOTH | EIC_CONFIG_FILTEN7);
         NVIC_SetPriority(EIC_IRQn, 6);
         NVIC_ClearPendingIRQ(EIC_IRQn);
         NVIC_EnableIRQ(EIC_IRQn);
         EIC->EVCTRL.reg = 0;
         EIC->INTFLAG.reg = SAMD21_EIC_MASK;
-        EIC->INTENSET.reg = SAMD21_EIC_MASK;  
+        EIC->INTENSET.reg = SAMD21_EIC_MASK;
+        while (EIC->STATUS.bit.SYNCBUSY)
+                ;
+        EIC->CTRL.bit.ENABLE = 1;
+        while (EIC->STATUS.bit.SYNCBUSY)
+                ;
 #endif
         //ADC clock
         GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK4 | GCLK_CLKCTRL_ID_ADC;


### PR DESCRIPTION
removed soft pooling option from cnc_dotasks since a collision in ISR config (like SAMD21 LimitY and ESTOP share the same Interrupt channel)
removed ISR from LIMITS on SAMD21