### PR TITLE
No acceleration for slow motions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - fixed motion commands (G0,G1, etc) with active offset (G92 or G5x) introduced with (#83) and a given axis is omitted was reapplying the offset (#103)
   - fixed G4 P word was not convert from seconds to milliseconds on the parser (#103)
   - fixed G53 with active G91 (ignores G91) and now travels to the absolute position (#103)
+  - fixed interpolator speed calculations for slow movements with instant max speed that and speed was set to 0 (#105)
 
 ## [1.3.1] - 2022-01-02
 µCNC version 1.3.1 has the following modifications:

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -327,18 +327,12 @@ void itp_run(void)
                 accel_until -= floorf(accel_dist);
                 //initial_accel_negative = (junction_speed_sqr < itp_cur_plan_block->entry_feed_sqr);
             }
-            else
-            {
-                //it's already travelling at higher speeed than it should
-                //use this value to calculate the deacceleration
-                itp_cur_plan_block->entry_feed_sqr = junction_speed_sqr;
-            }
 
             //if entry speed already a junction speed updates it.
-            /*if (accel_until == remaining_steps)
-                {
-                    itp_cur_plan_block->entry_feed_sqr = junction_speed_sqr;
-                }*/
+            if (accel_until == remaining_steps)
+            {
+                itp_cur_plan_block->entry_feed_sqr = junction_speed_sqr;
+            }
 
             if (junction_speed_sqr > exit_speed_sqr)
             {


### PR DESCRIPTION
  - fixed interpolator speed calculations for slow movements with instant max speed that and speed was set to 0