### PR TITLE
modified tool length compensation gcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@
 
 # Changelog
 
+### Added
+  - added configurable default loading tool and tools offset
+
 ### Changed
   - modified encoder module to allow it work has a unidirectional encoder (simple counter) (#107)
   - added reset calls for motors encoders (#107)
   - moved encoder and PID definitions to cnc_hal_config.h (#107)
+  - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>` 
+
+### Fixed
+  - fixed tool length offset was not affecting the `WCO` position report
+  - fixed pid settings index
 
 ## [1.3.2] - 2022-01-05
 
@@ -21,17 +29,17 @@
   - modified SAMD21 compilation flags and board configurations (#101)
   - reviewed SAMD21 and STM32 ISR to ensure they run in block mode (only one ISR at the time). ISR unlocking is controller by µCNC to make it more predictable (#101)
   - removed duplicate tool pid call (#101)
-  - modified feed override flags so M48/M49 will only affect at code execution order (#102)
+  - modified feed override flags so `M48/M49` will only affect at code execution order (#102)
   - modified tool speed update and read functions and integrated HAL tool in the core of µCNC (#106)
 
 ### Fixed
   - fixed feed override after reaching top speed feed was reset to normal (100%) neglecting feed override value (#102)
-  - fixed M48/M49 parsing error (after calling overrides were always turned off) (#102)
+  - fixed `M48/M49` parsing error (after calling overrides were always turned off) (#102)
   - fixed spindle override max and min values (#100)
-  - fixed arc commands G2/G3 with G18 active parsing validation errors and mirrored motion error (#103)
-  - fixed motion commands (G0,G1, etc) with active offset (G92 or G5x) introduced with (#83) and a given axis is omitted was reapplying the offset (#103)
-  - fixed G4 P word was not convert from seconds to milliseconds on the parser (#103)
-  - fixed G53 with active G91 (ignores G91) and now travels to the absolute position (#103)
+  - fixed arc commands `G2/G3` with `G18` active parsing validation errors and mirrored motion error (#103)
+  - fixed motion commands (`G0`,`G1`, etc) with active offset (`G92` or `G5x`) introduced with (#83) and a given axis is omitted was reapplying the offset (#103)
+  - fixed `G4 P` word was not convert from seconds to milliseconds on the parser (#103)
+  - fixed `G53` with active `G91` (ignores `G91`) and now travels to the absolute position (#103)
   - fixed interpolator speed calculations for slow movements with instant max speed that and speed was set to 0 causing µCNC to stop generating steps and not moving (#105)
 
 ## [1.3.1] - 2022-01-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
   - fixed tool length offset was not affecting the `WCO` position report
+  - tool length is set to 0 after reset
   - fixed pid settings index
   - modified settings change code (smaller and more efficient) (#110)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,17 @@
 # Changelog
 
 ### Added
-  - added configurable default loading tool and tools offset
+  - added configurable default loading tool and tools offset (#109)
 
 ### Changed
   - modified encoder module to allow it work has a unidirectional encoder (simple counter) (#107)
   - added reset calls for motors encoders (#107)
   - moved encoder and PID definitions to cnc_hal_config.h (#107)
-  - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>` 
+  - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>` (#109)
 
 ### Fixed
-  - fixed tool length offset was not affecting the `WCO` position report
-  - tool length is set to 0 after reset
-  - fixed pid settings index
+  - fixed tool length offset was not affecting the `WCO` position report (#109)
+  - tool length is set to 0 after reset (#109)
   - modified settings change code (smaller and more efficient) (#110)
 
 ### Fixed

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1209,6 +1209,7 @@ static uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *wo
         parser_parameters.tool_length_offset = words->xyzabc[AXIS_Z];
         CLEARFLAG(cmd->words, GCODE_WORD_Z);
         words->xyzabc[AXIS_TOOL] = 0; //resets parameter so it it doen't do anything else
+        parser_wco_counter = 0;
     }
 #endif
     //15. coordinate system selection (G54, G55, G56, G57, G58, G59, G59.1, G59.2, G59.3) (OK nothing to be done)

--- a/uCNC/src/core/utils.h
+++ b/uCNC/src/core/utils.h
@@ -49,6 +49,10 @@ extern "C"
 #define ABS(a) (((a) > 0) ? (a) : -(a))
 #endif
 
+#ifndef CLAMP
+#define CLAMP(a, b, c) (MAX(b, MIN(a, c)))
+#endif
+
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define __UINT32_R0__ 0
 #define __UINT32_R1__ 1

--- a/uCNC/src/hal/tools/tool.c
+++ b/uCNC/src/hal/tools/tool.c
@@ -18,6 +18,7 @@
 */
 
 #include "../../cnc.h"
+#include "../../interface/settings.h"
 #include <stdlib.h>
 
 static tool_t tool_current;
@@ -80,7 +81,7 @@ void tool_init(void)
 	tool_current = {};
 #endif
 
-	tool_change(1);
+	tool_change(g_settings.default_tool);
 }
 
 void tool_change(uint8_t tool)

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -526,6 +526,14 @@ void protocol_send_cnc_settings(void)
     protocol_send_gcode_setting_line_flt(31, g_settings.spindle_min_rpm);
     protocol_send_gcode_setting_line_int(32, g_settings.laser_mode);
 
+#if TOOL_COUNT > 0
+    protocol_send_gcode_setting_line_int(40, g_settings.default_tool);
+    for (uint8_t i = 0; i < TOOL_COUNT; i++)
+    {
+        protocol_send_gcode_setting_line_flt(41 + i, g_settings.tool_length_offset[i]);
+    }
+#endif
+
 #ifdef ENABLE_SKEW_COMPENSATION
     protocol_send_gcode_setting_line_flt(37, g_settings.skew_xy_factor);
 #ifndef SKEW_COMPENSATION_XY_ONLY

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -525,6 +525,13 @@ void protocol_send_cnc_settings(void)
     protocol_send_gcode_setting_line_flt(30, g_settings.spindle_max_rpm);
     protocol_send_gcode_setting_line_flt(31, g_settings.spindle_min_rpm);
     protocol_send_gcode_setting_line_int(32, g_settings.laser_mode);
+#ifdef ENABLE_SKEW_COMPENSATION
+    protocol_send_gcode_setting_line_flt(37, g_settings.skew_xy_factor);
+#ifndef SKEW_COMPENSATION_XY_ONLY
+    protocol_send_gcode_setting_line_flt(38, g_settings.skew_xz_factor);
+    protocol_send_gcode_setting_line_flt(39, g_settings.skew_yz_factor);
+#endif
+#endif
 
 #if TOOL_COUNT > 0
     protocol_send_gcode_setting_line_int(40, g_settings.default_tool);
@@ -532,14 +539,6 @@ void protocol_send_cnc_settings(void)
     {
         protocol_send_gcode_setting_line_flt(41 + i, g_settings.tool_length_offset[i]);
     }
-#endif
-
-#ifdef ENABLE_SKEW_COMPENSATION
-    protocol_send_gcode_setting_line_flt(37, g_settings.skew_xy_factor);
-#ifndef SKEW_COMPENSATION_XY_ONLY
-    protocol_send_gcode_setting_line_flt(38, g_settings.skew_xz_factor);
-    protocol_send_gcode_setting_line_flt(39, g_settings.skew_yz_factor);
-#endif
 #endif
 
     for (uint8_t i = 0; i < STEPPER_COUNT; i++)
@@ -572,9 +571,9 @@ void protocol_send_cnc_settings(void)
 #if PID_CONTROLLERS > 0
     for (uint8_t i = 0; i < PID_CONTROLLERS; i++)
     {
-        protocol_send_gcode_setting_line_flt(150 + 4*i, g_settings.pid_gain[i][0]);
-        protocol_send_gcode_setting_line_flt(151 + 4*i, g_settings.pid_gain[i][1]);
-        protocol_send_gcode_setting_line_flt(152 + 4*i, g_settings.pid_gain[i][2]);
+        protocol_send_gcode_setting_line_flt(150 + 4 * i, g_settings.pid_gain[i][0]);
+        protocol_send_gcode_setting_line_flt(151 + 4 * i, g_settings.pid_gain[i][1]);
+        protocol_send_gcode_setting_line_flt(152 + 4 * i, g_settings.pid_gain[i][2]);
     }
 #endif
     protocol_busy = false;

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -173,39 +173,88 @@ const settings_t __rom__ default_settings =
         .pid_gain[0][2] = 0,
 #endif
 #if PID_CONTROLLERS > 1
-        .pid_gain[1][1] = 0,
+        .pid_gain[1][0] = 0,
         .pid_gain[1][1] = 0,
         .pid_gain[1][2] = 0,
 #endif
 #if PID_CONTROLLERS > 2
-        .pid_gain[2][2] = 0,
+        .pid_gain[2][0] = 0,
         .pid_gain[2][1] = 0,
         .pid_gain[2][2] = 0,
 #endif
 #if PID_CONTROLLERS > 3
-        .pid_gain[3][3] = 0,
+        .pid_gain[3][0] = 0,
         .pid_gain[3][1] = 0,
         .pid_gain[3][2] = 0,
 #endif
 #if PID_CONTROLLERS > 4
-        .pid_gain[4][4] = 0,
+        .pid_gain[4][0] = 0,
         .pid_gain[4][1] = 0,
         .pid_gain[4][2] = 0,
 #endif
 #if PID_CONTROLLERS > 5
-        .pid_gain[5][5] = 0,
+        .pid_gain[5][0] = 0,
         .pid_gain[5][1] = 0,
         .pid_gain[5][2] = 0,
 #endif
 #if PID_CONTROLLERS > 6
-        .pid_gain[6][6] = 0,
+        .pid_gain[6][0] = 0,
         .pid_gain[6][1] = 0,
         .pid_gain[6][2] = 0,
 #endif
 #if PID_CONTROLLERS > 7
-        .pid_gain[7][7] = 0,
+        .pid_gain[7][0] = 0,
         .pid_gain[7][1] = 0,
         .pid_gain[7][2] = 0,
+#endif
+#if TOOL_COUNT > 0
+        .default_tool = DEFAULT_STARTUP_TOOL,
+        .tool_length_offset[0] = 0,
+#endif
+#if TOOL_COUNT > 1
+        .tool_length_offset[1] = 0,
+#endif
+#if TOOL_COUNT > 2
+        .tool_length_offset[2] = 0,
+#endif
+#if TOOL_COUNT > 3
+        .tool_length_offset[3] = 0,
+#endif
+#if TOOL_COUNT > 4
+        .tool_length_offset[4] = 0,
+#endif
+#if TOOL_COUNT > 5
+        .tool_length_offset[5] = 0,
+#endif
+#if TOOL_COUNT > 6
+        .tool_length_offset[6] = 0,
+#endif
+#if TOOL_COUNT > 7
+        .tool_length_offset[7] = 0,
+#endif
+#if TOOL_COUNT > 8
+        .tool_length_offset[8] = 0,
+#endif
+#if TOOL_COUNT > 9
+        .tool_length_offset[9] = 0,
+#endif
+#if TOOL_COUNT > 10
+        .tool_length_offset[10] = 0,
+#endif
+#if TOOL_COUNT > 11
+        .tool_length_offset[11] = 0,
+#endif
+#if TOOL_COUNT > 12
+        .tool_length_offset[12] = 0,
+#endif
+#if TOOL_COUNT > 13
+        .tool_length_offset[13] = 0,
+#endif
+#if TOOL_COUNT > 14
+        .tool_length_offset[14] = 0,
+#endif
+#if TOOL_COUNT > 15
+        .tool_length_offset[15] = 0,
 #endif
 
         .step_enable_invert = DEFAULT_STEP_ENA_INV,
@@ -218,7 +267,6 @@ const settings_t __rom__ default_settings =
         .homing_offset = DEFAULT_HOMING_OFFSET,
         .g64_angle_factor = DEFAULT_G64_FACTOR,
         .arc_tolerance = DEFAULT_ARC_TOLERANCE,
-        //.tool_count = DEFAULT_STARTUP_TOOL,
         .limits_invert_mask = DEFAULT_LIMIT_INV_MASK,
         .status_report_mask = DEFAULT_STATUS_MASK,
         .control_invert_mask = DEFAULT_CONTROL_INV_MASK,
@@ -652,7 +700,20 @@ uint8_t settings_change(uint8_t setting, float value)
         g_settings.pid_gain[7][2] = value;
         break;
 #endif
+#if TOOL_COUNT > 0
+    case 40:
+        g_settings.default_tool = CLAMP(value8, 0, TOOL_COUNT);
+        break;
+#endif
     default:
+#if TOOL_COUNT > 0
+        if (setting > 40 && setting <= 46)
+        {
+            setting-=41;
+            g_settings.tool_length_offset[setting] = value;
+            break;
+        }
+#endif
         return STATUS_INVALID_STATEMENT;
     }
 

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -541,7 +541,7 @@ uint8_t settings_change(uint8_t setting, float value)
         }
 #endif
 #if TOOL_COUNT > 0
-        else if (setting > 40 && setting <= 46)
+        else if (setting > 40 && setting <= 56)
         {
             setting -= 41;
             g_settings.tool_length_offset[setting] = value;

--- a/uCNC/src/interface/settings.h
+++ b/uCNC/src/interface/settings.h
@@ -62,7 +62,10 @@ extern "C"
                 float max_feed_rate[STEPPER_COUNT];
                 float acceleration[STEPPER_COUNT];
                 float max_distance[AXIS_COUNT];
-                uint8_t tool_count;
+#if TOOL_COUNT > 0
+                uint8_t default_tool;
+                float tool_length_offset[TOOL_COUNT];
+#endif
 #ifdef ENABLE_BACKLASH_COMPENSATION
                 uint16_t backlash_steps[STEPPER_COUNT];
 #endif


### PR DESCRIPTION
  - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>`
  - added configurable default loading tool and tools offset