### PR TITLE
Alternative/modified CNC alarm lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@
   - added reset calls for motors encoders (#107)
   - moved encoder and PID definitions to cnc_hal_config.h (#107)
   - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>` (#109)
-  - modified alarm locking and report messages on alarm status. Soft stop alarm require unlock only. Hard stops will cause soft reset on unlock.
+  - modified alarm locking and report messages on alarm status. Soft stop alarm require unlock only. Hard stops will cause soft reset on unlock (#111)
 
 ### Fixed
   - fixed tool length offset was not affecting the `WCO` position report (#109)
   - tool length is set to 0 after reset (#109)
   - modified settings change code (smaller and more efficient) (#110)
-  - fixed check mode position update of motion control preventing invalid target errors
-  - fixed sticky check mode even after soft-reset
+  - fixed check mode position update of motion control preventing invalid target errors (#111)
+  - fixed sticky check mode even after soft-reset (#111)
 
 ### Fixed
   - fixed PID settings offsets (#110)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@
   - added reset calls for motors encoders (#107)
   - moved encoder and PID definitions to cnc_hal_config.h (#107)
   - modified removed `G43.1` command and added `G43` command has defined in the RS274NGC. A similar command to previous `G43.1` is possible with `G43 Z<value>` (#109)
+  - modified alarm locking and report messages on alarm status. Soft stop alarm require unlock only. Hard stops will cause soft reset on unlock.
 
 ### Fixed
   - fixed tool length offset was not affecting the `WCO` position report (#109)
   - tool length is set to 0 after reset (#109)
   - modified settings change code (smaller and more efficient) (#110)
+  - fixed check mode position update of motion control preventing invalid target errors
+  - fixed sticky check mode even after soft-reset
 
 ### Fixed
   - fixed PID settings offsets (#110)

--- a/makefiles/virtual/virtualserial.c
+++ b/makefiles/virtual/virtualserial.c
@@ -37,7 +37,7 @@
 #else
 #include <windows.h>
 
-HANDLE hComm = NULL;
+volatile HANDLE hComm = NULL;
 unsigned char ComPortName[] = COMPORT;
 unsigned char ComParams[] = "baud=115200 parity=N data=8 stop=1";
 

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -201,6 +201,7 @@ extern "C"
 	void cnc_scheduletasks(void);
 	void cnc_home(void);
 	void cnc_alarm(int8_t code);
+	bool cnc_has_alarm();
 	void cnc_stop(void);
 	uint8_t cnc_unlock(bool force);
 	void cnc_delay_ms(uint32_t miliseconds);

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -44,9 +44,9 @@ static uint8_t mc_last_dirbits;
 void mc_init(void)
 {
 #ifdef FORCE_GLOBALS_TO_0
-    mc_checkmode = false;
     memset(mc_last_step_pos, 0, sizeof(mc_last_step_pos));
 #endif
+    mc_checkmode = false;
     mc_sync_position();
 }
 
@@ -140,7 +140,7 @@ static uint8_t mc_line_segment(float *target, motion_data_t *block_data)
         //dwell should only execute on the first request
         block_data->dwell = 0;
     }
-    
+
     return STATUS_OK;
 }
 

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -88,56 +88,59 @@ static uint8_t mc_line_segment(float *target, motion_data_t *block_data)
     //stores current step target position
     memcpy(mc_last_step_pos, step_new_pos, sizeof(mc_last_step_pos));
 
-#ifdef ENABLE_BACKLASH_COMPENSATION
-    //checks if any of the linear actuators there is a shift in direction
-    uint8_t inverted_steps = mc_last_dirbits ^ block_data->dirbits;
-    if (inverted_steps)
+    if (!mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
     {
-        motion_data_t backlash_block_data = {0};
-        memcpy(&backlash_block_data, block_data, sizeof(motion_data_t));
-        memset(backlash_block_data.steps, 0, sizeof(backlash_block_data.steps));
-        //resets accumulator vars
-        backlash_block_data.total_steps = 0;
-        backlash_block_data.full_steps = 0;
-        backlash_block_data.feed = FLT_MAX; //max feedrate possible (same as rapid move)
-
-        SETFLAG(backlash_block_data.motion_mode, MOTIONCONTROL_MODE_BACKLASH_COMPENSATION);
-
-        for (uint8_t i = STEPPER_COUNT; i != 0;)
+#ifdef ENABLE_BACKLASH_COMPENSATION
+        //checks if any of the linear actuators there is a shift in direction
+        uint8_t inverted_steps = mc_last_dirbits ^ block_data->dirbits;
+        if (inverted_steps)
         {
-            i--;
-            if (inverted_steps & (1 << i))
+            motion_data_t backlash_block_data = {0};
+            memcpy(&backlash_block_data, block_data, sizeof(motion_data_t));
+            memset(backlash_block_data.steps, 0, sizeof(backlash_block_data.steps));
+            //resets accumulator vars
+            backlash_block_data.total_steps = 0;
+            backlash_block_data.full_steps = 0;
+            backlash_block_data.feed = FLT_MAX; //max feedrate possible (same as rapid move)
+
+            SETFLAG(backlash_block_data.motion_mode, MOTIONCONTROL_MODE_BACKLASH_COMPENSATION);
+
+            for (uint8_t i = STEPPER_COUNT; i != 0;)
             {
-                backlash_block_data.steps[i] = g_settings.backlash_steps[i];
-                backlash_block_data.full_steps += backlash_block_data.steps[i];
-                if (backlash_block_data.total_steps < backlash_block_data.steps[i])
+                i--;
+                if (inverted_steps & (1 << i))
                 {
-                    backlash_block_data.total_steps = backlash_block_data.steps[i];
-                    backlash_block_data.main_stepper = i;
+                    backlash_block_data.steps[i] = g_settings.backlash_steps[i];
+                    backlash_block_data.full_steps += backlash_block_data.steps[i];
+                    if (backlash_block_data.total_steps < backlash_block_data.steps[i])
+                    {
+                        backlash_block_data.total_steps = backlash_block_data.steps[i];
+                        backlash_block_data.main_stepper = i;
+                    }
                 }
             }
-        }
 
-        planner_add_line(&backlash_block_data);
-        //dwell should only execute on the first request
-        block_data->dwell = 0;
+            planner_add_line(&backlash_block_data);
+            //dwell should only execute on the first request
+            block_data->dwell = 0;
 
-        while (planner_buffer_is_full())
-        {
-            if (!cnc_dotasks())
+            while (planner_buffer_is_full())
             {
-                return STATUS_CRITICAL_FAIL;
+                if (!cnc_dotasks())
+                {
+                    return STATUS_CRITICAL_FAIL;
+                }
             }
-        }
 
-        mc_last_dirbits = block_data->dirbits;
-    }
+            mc_last_dirbits = block_data->dirbits;
+        }
 #endif
 
-    planner_add_line(block_data);
-    //dwell should only execute on the first request
-    block_data->dwell = 0;
-    //restores previous feed (this decouples de mm/min to step/min conversion - prevents feed modification in reused data_blocks like in arcs)
+        planner_add_line(block_data);
+        //dwell should only execute on the first request
+        block_data->dwell = 0;
+    }
+    
     return STATUS_OK;
 }
 
@@ -170,11 +173,6 @@ uint8_t mc_line(float *target, motion_data_t *block_data)
             return STATUS_TRAVEL_EXCEEDED;
         }
         cnc_alarm(EXEC_ALARM_SOFT_LIMIT);
-        return STATUS_OK;
-    }
-
-    if (mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
-    {
         return STATUS_OK;
     }
 

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -237,7 +237,7 @@ void ticksimul(void)
 {
 
 	static VIRTUAL_MAP initials = {0};
-	/*
+
 	FILE *infile = fopen("inputs.txt", "r");
 	char inputs[255];
 
@@ -253,7 +253,7 @@ void ticksimul(void)
 		{
 			isr_flags |= ISR_INPUT; //flags input isr
 		}
-	}*/
+	}
 
 	mcu_runtime++;
 }
@@ -288,7 +288,7 @@ void mcu_init(void)
 		}
 	}
 	g_cpu_freq = getCPUFreq();
-	//start_timer(1, &ticksimul);
+	start_timer(1, &ticksimul);
 	pthread_create(&thread_id, NULL, &comsimul, NULL);
 #ifdef USECONSOLE
 	pthread_create(&thread_idout, NULL, &comoutsimul, NULL);

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -170,13 +170,18 @@ void protocol_send_status(void)
     state &= filter;
 
     serial_putc('<');
-    if (!mc_get_checkmode() || cnc_get_exec_state(EXEC_ALARM))
+    if (cnc_has_alarm())
+    {
+        serial_print_str(MSG_STATUS_ALARM);
+    }
+    else if(mc_get_checkmode())
+    {
+        serial_print_str(MSG_STATUS_CHECK);
+    }
+    else
     {
         switch (state)
         {
-        case EXEC_KILL:
-            serial_print_str(MSG_STATUS_ALARM);
-            break;
         case EXEC_DOOR:
             serial_print_str(MSG_STATUS_DOOR);
             if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
@@ -231,10 +236,6 @@ void protocol_send_status(void)
             serial_print_str(MSG_STATUS_IDLE);
             break;
         }
-    }
-    else
-    {
-        serial_print_str(MSG_STATUS_CHECK);
     }
 
     serial_print_str(MSG_STATUS_MPOS);


### PR DESCRIPTION
  - modified alarm locking and report messages on alarm status. Soft stop alarm require unlock only. Hard stops will cause soft reset on unlock
  - fixed check mode position update of motion control preventing invalid target errors
  - fixed sticky check mode even after soft-reset