### PR TITLE
G91 cumulative error position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - fixed fail to probe target message and alarm (#112)
   - fixed check mode position update of motion control preventing invalid target errors (#111)
   - fixed sticky check mode even after soft-reset (#111)
+  - partially reverted modifications (#98) and (#84) that caused the the machine real position to diverge due to error accumulation with G91 (relative distance) active
 
 ### Fixed
   - fixed PID settings offsets (#110)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -89,7 +89,7 @@ void cnc_init(void)
 void cnc_run(void)
 {
     cnc_reset();
-    
+
     cnc_state.loop_state = LOOP_RUNNING_FIRST_RUN;
     serial_select(SERIAL_UART);
 
@@ -183,7 +183,7 @@ bool cnc_dotasks(void)
 
     if (cnc_has_alarm())
     {
-        return !cnc_get_exec_state(EXEC_KILL|EXEC_HOMING);
+        return !cnc_get_exec_state(EXEC_KILL | EXEC_HOMING);
     }
 
     //µCNC already in error loop. No point in sending the alarms

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -254,7 +254,7 @@ void itp_run(void)
             itp_blk_data[itp_blk_data_write].backlash_comp = itp_cur_plan_block->backlash_comp;
 #endif
             itp_blk_data[itp_blk_data_write].dirbits = itp_cur_plan_block->dirbits;
-            itp_blk_data[itp_blk_data_write].total_steps = itp_cur_plan_block->total_steps;
+            itp_blk_data[itp_blk_data_write].total_steps = itp_cur_plan_block->total_steps << 1;
 
             float total_step_inv = 1.0f / (float)itp_cur_plan_block->total_steps;
             feed_convert = 60.f / (float)g_settings.step_per_mm[itp_cur_plan_block->main_stepper];
@@ -270,8 +270,8 @@ void itp_run(void)
             {
                 i--;
                 sqr_step_speed += fast_flt_pow2((float)itp_cur_plan_block->steps[i]);
-                itp_blk_data[itp_blk_data_write].errors[i] = itp_cur_plan_block->total_steps >> 1;
-                itp_blk_data[itp_blk_data_write].steps[i] = itp_cur_plan_block->steps[i];
+                itp_blk_data[itp_blk_data_write].errors[i] = itp_cur_plan_block->total_steps;
+                itp_blk_data[itp_blk_data_write].steps[i] = itp_cur_plan_block->steps[i] << 1;
 #ifdef STEP_ISR_SKIP_IDLE
                 if (!itp_cur_plan_block->steps[i])
                 {

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -605,7 +605,6 @@ uint8_t mc_probe(float *target, uint8_t flags, motion_data_t *block_data)
 #if PROBE >= 0
     uint8_t prev_state = cnc_get_exec_state(EXEC_HOLD);
     io_enable_probe();
-    block_data->feed = g_settings.homing_fast_feed_rate;
     mc_line(target, block_data);
 
     do
@@ -658,4 +657,5 @@ void mc_get_position(float *target)
 void mc_sync_position(void)
 {
     itp_get_rt_position(mc_last_step_pos);
+    parser_sync_position();
 }

--- a/uCNC/src/core/parser.h
+++ b/uCNC/src/core/parser.h
@@ -49,6 +49,7 @@ void parser_toogle_coolant(uint8_t state);
 	void parser_parameters_load(void);
 	void parser_parameters_reset(void);
 	void parser_parameters_save(void);
+	void parser_sync_position(void);
 
 #ifdef __cplusplus
 }

--- a/uCNC/src/hal/boards/samd21/boardmap_zero.h
+++ b/uCNC/src/hal/boards/samd21/boardmap_zero.h
@@ -39,11 +39,11 @@ extern "C"
 #endif
 
 //Setup step pins
-#define STEP0_BIT 14	 //assigns STEP0 pin
+#define STEP0_BIT 14 //assigns STEP0 pin
 #define STEP0_PORT A //assigns STEP0 port
 #define STEP1_BIT 9	 //assigns STEP1 pin
 #define STEP1_PORT A //assigns STEP1 port
-#define STEP2_BIT 8 //assigns STEP2 pin
+#define STEP2_BIT 8	 //assigns STEP2 pin
 #define STEP2_PORT A //assigns STEP2 port
 
 //Setup dir pins


### PR DESCRIPTION
-partially reverted modifications (#98) and (#84) that caused the the machine real position to diverge due to error accumulation with G91 (relative distance) active and also caused bresenham algorith errors