### PR TITLE
cnc delay will be executed without early exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changed
   - on parser reset next status report will print WCO
-  - modified dual endstop behavior when dual endstops option is not active
+  - modified dual endstop behavior when dual endstops option is not active (#123)
+  - modified status report to yield better refresh rate (#125)
 
 ### Fixed
   - cnc delay will be executed without exit even if there is an fault condition in dotasks loop. On input debounce the delay could be shortcuted and a fault condition could be triggered without being real (#125)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   - on parser reset next status report will print WCO
   - modified dual endstop behavior when dual endstops option is not active
 
+### Fixed
+  - cnc delay will be executed without exit even if there is an fault condition in dotasks loop. On input debounce the delay could be shortcuted and a fault condition could be triggered without being real.
+
 ## [1.3.4] - 2022-01-10
 µCNC version 1.3.4 adds a few improvements and also fixes some issues with inverse feedrate mode `G93` and realtime feed overrides.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - modified dual endstop behavior when dual endstops option is not active
 
 ### Fixed
-  - cnc delay will be executed without exit even if there is an fault condition in dotasks loop. On input debounce the delay could be shortcuted and a fault condition could be triggered without being real.
+  - cnc delay will be executed without exit even if there is an fault condition in dotasks loop. On input debounce the delay could be shortcuted and a fault condition could be triggered without being real (#125)
 
 ## [1.3.4] - 2022-01-10
 µCNC version 1.3.4 adds a few improvements and also fixes some issues with inverse feedrate mode `G93` and realtime feed overrides.

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -476,8 +476,10 @@ void cnc_clear_exec_state(uint8_t statemask)
 void cnc_delay_ms(uint32_t miliseconds)
 {
     uint32_t t_start = mcu_millis();
-    while ((mcu_millis() - t_start) < miliseconds && cnc_dotasks())
-        ;
+    while ((mcu_millis() - t_start) < miliseconds)
+    {
+        cnc_dotasks();
+    }
 }
 
 bool cnc_reset(void)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -58,6 +58,7 @@ static cnc_state_t cnc_state;
 static void cnc_check_fault_systems(void);
 static bool cnc_check_interlocking(void);
 static void cnc_exec_rt_commands(void);
+static void cnc_io_dotasks(void);
 static bool cnc_reset(void);
 static bool cnc_exec_cmd(void);
 
@@ -163,21 +164,15 @@ bool cnc_exec_cmd(void)
 bool cnc_dotasks(void)
 {
     static bool lock_itp = false;
-    //run all mcu_internal tasks
-    mcu_dotasks();
+
+    //run io basic tasks
+    cnc_io_dotasks();
 
     //let µCNC finnish startup/reset code
     if (cnc_state.loop_state == LOOP_STARTUP_RESET)
     {
-        return true;
+        return false;
     }
-
-#if ((LIMITEN_MASK ^ LIMITISR_MASK) || defined(FORCE_SOFT_POLLING))
-    io_limits_isr();
-#endif
-#if ((CONTROLEN_MASK ^ CONTROLISR_MASK) || defined(FORCE_SOFT_POLLING))
-    io_controls_isr();
-#endif
 
     cnc_exec_rt_commands(); //executes all pending realtime commands
 
@@ -478,7 +473,7 @@ void cnc_delay_ms(uint32_t miliseconds)
     uint32_t t_start = mcu_millis();
     while ((mcu_millis() - t_start) < miliseconds)
     {
-        cnc_dotasks();
+        cnc_io_dotasks();
     }
 }
 
@@ -613,29 +608,17 @@ void cnc_exec_rt_commands(void)
 
     //executes feeds override rt commands
     uint8_t cmd_mask = 0x04;
-    uint8_t command = cnc_state.rt_cmd;            //copies realtime flags states
-    CLEARFLAG(cnc_state.rt_cmd, ~(RT_CMD_REPORT)); //clears all command flags except report request
-    while (command)
+    uint8_t command = cnc_state.rt_cmd; //copies realtime flags states
+    cnc_state.rt_cmd = RT_CMD_CLEAR;
+    if (command & RT_CMD_RESET)
     {
-        switch (command & cmd_mask)
-        {
-        case RT_CMD_RESET:
-            cnc_alarm(EXEC_ALARM_SOFTRESET);
-            return;
-        case RT_CMD_REPORT:
-            if (!protocol_is_busy() && cnc_state.loop_state)
-            {
-                protocol_send_status();
-                CLEARFLAG(cnc_state.rt_cmd, RT_CMD_REPORT); //if a report request is sent, clear the respective flag
-            }
-            break;
-        case RT_CMD_CYCLE_START:
-            cnc_clear_exec_state(EXEC_HOLD);
-            break;
-        }
+        cnc_alarm(EXEC_ALARM_SOFTRESET);
+        return;
+    }
 
-        CLEARFLAG(command, cmd_mask);
-        cmd_mask >>= 1;
+    if (command & RT_CMD_CYCLE_START)
+    {
+        cnc_clear_exec_state(EXEC_HOLD);
     }
 
     //executes feeds override rt commands
@@ -869,4 +852,23 @@ bool cnc_check_interlocking(void)
     }
 
     return true;
+}
+
+void cnc_io_dotasks(void)
+{
+    //run internal mcu tasks (USB and communications)
+    mcu_dotasks();
+
+    //checks inputs and triggers ISR checks if enforced soft polling
+#if defined(FORCE_SOFT_POLLING)
+    io_limits_isr();
+    io_controls_isr();
+#endif
+
+    if (cnc_state.loop_state > LOOP_RUNNING_FIRST_RUN && CHECKFLAG(cnc_state.rt_cmd, RT_CMD_REPORT))
+    {
+        //if a report request is sent, clear the respective flag
+        CLEARFLAG(cnc_state.rt_cmd, RT_CMD_REPORT);
+        protocol_send_status();
+    }
 }

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -27,9 +27,9 @@ extern "C"
 //rt_cmd
 #define RT_CMD_CLEAR 0
 
-#define RT_CMD_REPORT 1
+#define RT_CMD_RESET 1
 #define RT_CMD_CYCLE_START 2
-#define RT_CMD_RESET 4
+#define RT_CMD_REPORT 4
 
 //feed_ovr_cmd
 #define RT_CMD_FEED_100 1

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -27,12 +27,9 @@
 #include "protocol.h"
 #include "grbl_interface.h"
 
+#ifdef ECHO_CMD
 static bool protocol_busy;
-
-bool protocol_is_busy(void)
-{
-    return protocol_busy;
-}
+#endif
 
 static void procotol_send_newline(void)
 {
@@ -41,44 +38,64 @@ static void procotol_send_newline(void)
 
 void protocol_send_ok(void)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(MSG_OK);
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_error(uint8_t error)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(MSG_ERROR);
     serial_print_int(error);
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_alarm(int8_t alarm)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(MSG_ALARM);
     serial_print_int(alarm);
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_string(const unsigned char *__s)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(__s);
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_feedback(const unsigned char *__s)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(MSG_START);
     serial_print_str(__s);
     serial_print_str(MSG_END);
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 static uint8_t protocol_get_tools(void)
@@ -146,7 +163,16 @@ static void protocol_send_status_tail(void)
 
 void protocol_send_status(void)
 {
+#ifdef ECHO_CMD
+    if (protocol_busy)
+    {
+        return;
+    }
+#endif
+
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     float axis[MAX(AXIS_COUNT, 3)];
 
     uint32_t steppos[STEPPER_COUNT];
@@ -174,7 +200,7 @@ void protocol_send_status(void)
     {
         serial_print_str(MSG_STATUS_ALARM);
     }
-    else if(mc_get_checkmode())
+    else if (mc_get_checkmode())
     {
         serial_print_str(MSG_STATUS_CHECK);
     }
@@ -316,12 +342,16 @@ void protocol_send_status(void)
 
     serial_putc('>');
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_gcode_coordsys(void)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     float axis[MAX(AXIS_COUNT, 3)];
     uint8_t coordlimit = MIN(6, COORD_SYS_COUNT);
     for (uint8_t i = 0; i < coordlimit; i++)
@@ -372,13 +402,17 @@ void protocol_send_gcode_coordsys(void)
 #endif
     protocol_send_probe_result(parser_get_probe_result());
 
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_probe_result(uint8_t val)
 {
     float axis[MAX(AXIS_COUNT, 3)];
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     serial_print_str(__romstr__("[PRB:"));
     parser_get_coordsys(255, axis);
     serial_print_fltarr(axis, AXIS_COUNT);
@@ -386,7 +420,9 @@ void protocol_send_probe_result(uint8_t val)
     serial_putc('0' + val);
     serial_putc(']');
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 static void protocol_send_parser_modalstate(unsigned char word, uint8_t val, uint8_t mantissa)
@@ -408,7 +444,9 @@ void protocol_send_gcode_modes(void)
     uint16_t spindle;
     uint8_t coolant;
 
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     parser_get_modes(modalgroups, &feed, &spindle, &coolant);
 
     serial_print_str(__romstr__("[GC:"));
@@ -445,7 +483,9 @@ void protocol_send_gcode_modes(void)
 
     serial_putc(']');
     procotol_send_newline();
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 static void protocol_send_gcode_setting_line_int(uint8_t setting, uint16_t value)
@@ -468,7 +508,9 @@ static void protocol_send_gcode_setting_line_flt(uint8_t setting, float value)
 
 void protocol_send_start_blocks(void)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     unsigned char c = 0;
     uint16_t address = STARTUP_BLOCK0_ADDRESS_OFFSET;
     serial_print_str(__romstr__("$N0="));
@@ -501,12 +543,16 @@ void protocol_send_start_blocks(void)
             break;
         }
     }
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 void protocol_send_cnc_settings(void)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     protocol_send_gcode_setting_line_flt(0, (1000000.0f / g_settings.max_step_rate));
 #ifdef EMULATE_GRBL_STARTUP
     // just adds this for compatibility
@@ -585,13 +631,17 @@ void protocol_send_cnc_settings(void)
         protocol_send_gcode_setting_line_flt(152 + 4 * i, g_settings.pid_gain[i][2]);
     }
 #endif
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 
 #ifdef ENABLE_SETTING_EXTRA_CMDS
 void protocol_send_pins_states(void)
 {
+#ifdef ECHO_CMD
     protocol_busy = true;
+#endif
     for (uint8_t i = 0; i < 98; i++)
     {
         int16_t val = io_get_pinvalue(i);
@@ -637,6 +687,8 @@ void protocol_send_pins_states(void)
     }
 #endif
 
+#ifdef ECHO_CMD
     protocol_busy = false;
+#endif
 }
 #endif

--- a/uCNC/src/interface/protocol.h
+++ b/uCNC/src/interface/protocol.h
@@ -27,7 +27,6 @@ extern "C"
 #include <stdint.h>
 #include <stdarg.h>
 
-	bool protocol_is_busy(void);
 	void protocol_send_ok(void);
 	void protocol_send_error(uint8_t error);
 	void protocol_send_alarm(int8_t alarm);


### PR DESCRIPTION
  - cnc delay will be executed without exit even if there is an fault condition in dotasks loop. On input debounce the delay could be shortcuted and a fault condition could be triggered without being real.