### PR TITLE
Fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
   - added missing globals to init functions with FORCE_GLOBALS_TO_0 enabled (#147)
   - fixed PWM config macro (was unstable on Mega boards) (#147)
   - fixed set PWM macro for AVR (cause issues on Mega boards)
+  - fixed several C99/GNU99 compliance warnings
+  - fixed dir mask implementation ($2)
+  - fixed settings crc calculation (without lookup table)
+  - fixed output pin toggle macro for AVR
+  - fixed AVR RX pin setup
+  - fixed BYTE_OPS redefinition 
 
 
 ## [1.4.0-alpha] - 2022-02-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,13 @@
 ### Fixed
   - added missing globals to init functions with FORCE_GLOBALS_TO_0 enabled (#147)
   - fixed PWM config macro (was unstable on Mega boards) (#147)
-  - fixed set PWM macro for AVR (cause issues on Mega boards)
-  - fixed several C99/GNU99 compliance warnings
-  - fixed dir mask implementation ($2)
-  - fixed settings crc calculation (without lookup table)
-  - fixed output pin toggle macro for AVR
-  - fixed AVR RX pin setup
-  - fixed BYTE_OPS redefinition 
-
+  - fixed set PWM macro for AVR (cause issues on Mega boards) (#148)
+  - fixed several C99/GNU99 compliance warnings (#148)
+  - fixed dir mask implementation ($2) (#148)
+  - fixed settings crc calculation (without lookup table) (#148)
+  - fixed output pin toggle macro for AVR (#148)
+  - fixed AVR RX pin setup (#148)
+  - fixed BYTE_OPS redefinition (#148)
 
 ## [1.4.0-alpha] - 2022-02-25
 µCNC version 1.4.0 packs lots of new features as well as the initial support for SMT32F4 core MCU's. The features are:

--- a/makefiles/avr/makefile
+++ b/makefiles/avr/makefile
@@ -109,9 +109,9 @@ C_INCLUDES =  \
 C_INCLUDES += $(foreach d,$(C_HEADERS),$(addsuffix $(dir $(d)),"-I"))
 
 # compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) -w $(OPT) -gdwarf-2 -flto -fuse-linker-plugin -Wl,--gc-sections,--relax
+ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -Wextra -gdwarf-2 -flto -fuse-linker-plugin -Wl,--gc-sections,--relax
 
-CFLAGS = $(MCU) -DF_CPU=$(FREQ) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wextra -w -std=gnu99 -ffunction-sections -fdata-sections -mcall-prologues -mrelax -flto -fno-fat-lto-objects -fno-tree-scev-cprop
+CFLAGS = $(MCU) -DF_CPU=$(FREQ) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wextra -std=gnu99 -ffunction-sections -fdata-sections -mcall-prologues -mrelax -flto -fno-fat-lto-objects -fno-tree-scev-cprop
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g3 -ggdb3 -gdwarf-2
@@ -122,7 +122,7 @@ endif
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 
 # default action: build all
-all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex
+all: $(BUILD_DIR) $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex
 
 
 #######################################

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -52,7 +52,7 @@ static void cnc_check_fault_systems(void);
 static bool cnc_check_interlocking(void);
 static void cnc_exec_rt_commands(void);
 static void cnc_io_dotasks(void);
-static bool cnc_reset(void);
+static void cnc_reset(void);
 static bool cnc_exec_cmd(void);
 
 void cnc_init(void)
@@ -358,7 +358,6 @@ uint8_t cnc_unlock(bool force)
         // signals stepper enable pins
 
         io_set_steps(g_settings.step_invert_mask);
-        io_set_dirs(g_settings.dir_invert_mask);
         io_enable_steppers(g_settings.step_enable_invert);
         parser_reset();
 
@@ -393,6 +392,7 @@ void cnc_set_exec_state(uint8_t statemask)
 
 void cnc_clear_exec_state(uint8_t statemask)
 {
+#ifndef DISABLE_ALL_CONTROLS
     uint8_t controls = io_get_controls();
 
 #if (ESTOP >= 0)
@@ -412,6 +412,7 @@ void cnc_clear_exec_state(uint8_t statemask)
     {
         CLEARFLAG(statemask, EXEC_HOLD);
     }
+#endif
 #endif
 
     // has a pending (not cleared by user) alarm
@@ -476,7 +477,7 @@ void cnc_delay_ms(uint32_t miliseconds)
     }
 }
 
-bool cnc_reset(void)
+void cnc_reset(void)
 {
     cnc_state.loop_state = LOOP_STARTUP_RESET;
     // resets all realtime command flags

--- a/uCNC/src/cnc_config_helper.h
+++ b/uCNC/src/cnc_config_helper.h
@@ -884,6 +884,19 @@ extern "C"
 #define DIO57 -1
 #endif
 
+// if the pins are undefined turn on option
+#if (ESTOP < 0 && SAFETY_DOOR < 0 && FHOLD < 0 && CS_RES < 0 && !defined(DISABLE_ALL_CONTROLS))
+#define DISABLE_ALL_CONTROLS
+#endif
+
+#if (LIMIT_X < 0 && LIMIT_X2 < 0 && LIMIT_Y < 0 && LIMIT_Y2 < 0 && LIMIT_Z < 0 && LIMIT_Z2 < 0 && LIMIT_A < 0 && LIMIT_B < 0 && LIMIT_C < 0 && !defined(DISABLE_ALL_LIMITS))
+#define DISABLE_ALL_LIMITS
+#endif
+
+#if (PROBE < 0 && !defined(DISABLE_PROBE))
+#define DISABLE_PROBE
+#endif
+
 #if SERVO0 >= 0
 #define SERVO0_MASK (1U << 0)
 #define SERVO0_FRAME 0

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -277,7 +277,7 @@ void itp_run(void)
 #ifdef ENABLE_BACKLASH_COMPENSATION
             itp_blk_data[itp_blk_data_write].backlash_comp = itp_cur_plan_block->backlash_comp;
 #endif
-            itp_blk_data[itp_blk_data_write].dirbits = itp_cur_plan_block->dirbits;
+            itp_blk_data[itp_blk_data_write].dirbits = itp_cur_plan_block->dirbits ^ g_settings.dir_invert_mask;
             itp_blk_data[itp_blk_data_write].total_steps = itp_cur_plan_block->total_steps << 1;
 
             float total_step_inv = 1.0f / (float)itp_cur_plan_block->total_steps;
@@ -642,7 +642,7 @@ void itp_run(void)
 #ifdef ENABLE_BACKLASH_COMPENSATION
             itp_blk_data[itp_blk_data_write].backlash_comp = itp_cur_plan_block->backlash_comp;
 #endif
-            itp_blk_data[itp_blk_data_write].dirbits = itp_cur_plan_block->dirbits;
+            itp_blk_data[itp_blk_data_write].dirbits = itp_cur_plan_block->dirbits ^ g_settings.dir_invert_mask;
             itp_blk_data[itp_blk_data_write].total_steps = itp_cur_plan_block->total_steps << 1;
 
             float total_step_inv = 1.0f / (float)itp_cur_plan_block->total_steps;
@@ -917,7 +917,6 @@ void itp_stop(void)
         cnc_set_exec_state(EXEC_HALT);
     }
     io_set_steps(g_settings.step_invert_mask);
-    io_set_dirs(g_settings.dir_invert_mask);
 #if TOOL_COUNT > 0
     if (g_settings.laser_mode)
     {
@@ -951,6 +950,8 @@ int32_t itp_get_rt_position_index(int8_t index)
     {
         return itp_rt_step_pos[index];
     }
+
+    return 0;
 }
 
 void itp_reset_rt_position(void)

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -91,7 +91,7 @@ void mcu_controls_changed_cb(void)
 {
 #ifdef DISABLE_ALL_CONTROLS
     return;
-#endif
+#else
     uint8_t controls = io_get_controls();
 
 #if (ESTOP >= 0)
@@ -119,6 +119,7 @@ void mcu_controls_changed_cb(void)
     {
         cnc_call_rt_command(CMD_CODE_CYCLE_START);
     }
+#endif
 #endif
 }
 
@@ -903,6 +904,8 @@ uint8_t io_get_analog(uint8_t pin)
         return mcu_get_analog(ANALOG15);
 #endif
     }
+
+    return 0;
 }
 
 int16_t io_get_pinvalue(uint8_t pin)

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -63,8 +63,8 @@ static uint8_t mc_line_segment(float *target, motion_data_t *block_data)
     for (uint8_t i = STEPPER_COUNT; i != 0;)
     {
         i--;
-        int32_t steps = step_new_pos[i] - mc_last_step_pos[i];
-        steps = ABS(steps);
+        int32_t s = step_new_pos[i] - mc_last_step_pos[i];
+        uint32_t steps = (uint32_t)ABS(s);
         block_data->steps[i] = (step_t)steps;
 
         block_data->full_steps += steps;
@@ -179,7 +179,6 @@ uint8_t mc_line(float *target, motion_data_t *block_data)
     // calculates the amount of stepper motion for this motion
 
     uint32_t max_steps = 0;
-    block_data->dirbits = 0;
     block_data->main_stepper = 255;
     for (uint8_t i = STEPPER_COUNT; i != 0;)
     {
@@ -191,7 +190,7 @@ uint8_t mc_line(float *target, motion_data_t *block_data)
         }
 
         steps = ABS(steps);
-        if (max_steps < steps)
+        if (max_steps < (uint32_t)steps)
         {
             max_steps = steps;
             block_data->main_stepper = i;
@@ -334,7 +333,6 @@ uint8_t mc_arc(float *target, float center_offset_a, float center_offset_b, floa
     float diameter = fast_flt_mul2(radius);
     uint16_t segment_count = floor(fabs(radiusangle) / sqrt(g_settings.arc_tolerance * (diameter - g_settings.arc_tolerance)));
     float arc_per_sgm = (segment_count != 0) ? arc_angle / segment_count : arc_angle;
-    float dist_sgm = 0;
 
     // for all other axis finds the linear motion distance
     float increment[AXIS_COUNT];

--- a/uCNC/src/core/planner.h
+++ b/uCNC/src/core/planner.h
@@ -1,20 +1,20 @@
 /*
-	Name: planner.h
-	Description: Chain planner for linear motions and acceleration/deacceleration profiles.
+    Name: planner.h
+    Description: Chain planner for linear motions and acceleration/deacceleration profiles.
         It uses a similar algorithm to Grbl.
 
-	Copyright: Copyright (c) João Martins
-	Author: João Martins
-	Date: 24/09/2019
+    Copyright: Copyright (c) João Martins
+    Author: João Martins
+    Date: 24/09/2019
 
-	µCNC is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+    µCNC is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version. Please see <http://www.gnu.org/licenses/>
 
-	µCNC is distributed WITHOUT ANY WARRANTY;
-	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the	GNU General Public License for more details.
+    µCNC is distributed WITHOUT ANY WARRANTY;
+    Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the	GNU General Public License for more details.
 */
 
 #ifndef PLANNER_H
@@ -32,11 +32,11 @@ extern "C"
 #define PLANNER_BUFFER_SIZE 15
 #endif
 
-#define PLANNER_MOTION_EXACT_PATH 32 //default (not used)
+#define PLANNER_MOTION_EXACT_PATH 32 // default (not used)
 #define PLANNER_MOTION_EXACT_STOP 64
 #define PLANNER_MOTION_CONTINUOUS 128
 
-    typedef struct
+    typedef struct planner_block_
     {
 #ifdef GCODE_PROCESS_LINE_NUMBERS
         uint32_t line;
@@ -57,17 +57,18 @@ extern "C"
 #endif
 
         uint8_t action;
-        union
+        union flags_u_
         {
-            struct
+            struct flags_t_
             {
                 uint8_t coolant : 2;
                 uint8_t optimal : 1;
                 uint8_t feed_override : 1;
                 uint8_t backlash_comp : 1;
-            };
+            } flags_t;
             uint8_t flags;
-        };
+        } flags_u;
+
     } planner_block_t;
 
     void planner_init(void);
@@ -89,7 +90,7 @@ extern "C"
     void planner_add_digital_output(uint8_t output, uint8_t value);
     void planner_sync_tools(motion_data_t *block_data);
 
-    //overrides
+    // overrides
     void planner_feed_ovr_reset(void);
     void planner_feed_ovr_inc(uint8_t value);
 

--- a/uCNC/src/hal/mcus/avr/mcu_avr.c
+++ b/uCNC/src/hal/mcus/avr/mcu_avr.c
@@ -449,13 +449,14 @@ ISR(COM_TX_vect, ISR_BLOCK)
 #define mcu_config_pullup(x) SETBIT(__indirect__(x, OUTREG), __indirect__(x, BIT))
 #define mcu_config_input_isr(x) SETFLAG(__indirect__(x, ISRREG), __indirect__(x, ISR_MASK))
 
-#define mcu_config_pwm(x) ({                                     \
-        SETBIT(__indirect__(x, DIRREG), __indirect__(x, BIT));   \
-        CLEARBIT(__indirect__(x, OUTREG), __indirect__(x, BIT)); \
-        __indirect__(x, TMRAREG) |= __indirect__(x, MODE);       \
-        __indirect__(x, TMRBREG) = __indirect__(x, PRESCALLER);  \
-        __indirect__(x, OCRREG) = 0;                             \
-})
+#define mcu_config_pwm(x)                                                \
+        {                                                                \
+                SETBIT(__indirect__(x, DIRREG), __indirect__(x, BIT));   \
+                CLEARBIT(__indirect__(x, OUTREG), __indirect__(x, BIT)); \
+                __indirect__(x, TMRAREG) |= __indirect__(x, MODE);       \
+                __indirect__(x, TMRBREG) = __indirect__(x, PRESCALLER);  \
+                __indirect__(x, OCRREG) = 0;                             \
+        }
 
 static void mcu_start_rtc();
 

--- a/uCNC/src/hal/mcus/avr/mcu_avr.c
+++ b/uCNC/src/hal/mcus/avr/mcu_avr.c
@@ -943,7 +943,8 @@ void mcu_init(void)
 #endif
 #endif
 #if RX >= 0
-        mcu_config_output(RX);
+        mcu_config_input(RX);
+        mcu_config_pullup(RX);
 #endif
 
         // Set COM port

--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -3598,10 +3598,11 @@ extern "C"
 #define __indirect__(X, Y) __indirect__ex__(X, Y)
 
 #ifndef BYTE_OPS
-#define SETBIT(x, y) ((x) |= (1 << (y)))	/* Set bit y in byte x*/
-#define CLEARBIT(x, y) ((x) &= ~(1 << (y))) /* Clear bit y in byte x*/
-#define CHECKBIT(x, y) ((x) & (1 << (y)))	/* Check bit y in byte x*/
-#define TOGGLEBIT(x, y) ((x) ^= (1 << (y))) /* Toggle bit y in byte x*/
+#define BYTE_OPS
+#define SETBIT(x, y) ((x) |= (1U << (y)))	 /* Set bit y in byte x*/
+#define CLEARBIT(x, y) ((x) &= ~(1U << (y))) /* Clear bit y in byte x*/
+#define CHECKBIT(x, y) ((x) & (1U << (y)))	 /* Check bit y in byte x*/
+#define TOGGLEBIT(x, y) ((x) ^= (1U << (y))) /* Toggle bit y in byte x*/
 
 #define SETFLAG(x, y) ((x) |= (y))	  /* Set byte y in byte x*/
 #define CLEARFLAG(x, y) ((x) &= ~(y)) /* Clear byte y in byte x*/
@@ -3613,7 +3614,8 @@ extern "C"
 #define mcu_get_output(diopin) CHECKBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT))
 #define mcu_set_output(diopin) SETBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT))
 #define mcu_clear_output(diopin) CLEARBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT))
-#define mcu_toggle_output(diopin) SETBIT(__indirect__(diopin, INREG), __indirect__(diopin, BIT))
+#define mcu_toggle_output(diopin) (__indirect__(diopin, INREG) = (1U << __indirect__(diopin, BIT)))
+
 #define mcu_set_pwm(diopin, pwmvalue)                                                    \
 	{                                                                                    \
 		__indirect__(diopin, OCRREG) = (uint16_t)pwmvalue;                               \
@@ -3624,7 +3626,6 @@ extern "C"
 		else                                                                             \
 		{                                                                                \
 			CLEARFLAG(__indirect__(diopin, TMRAREG), __indirect__(diopin, ENABLE_MASK)); \
-			CLEARBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT));           \
 		}                                                                                \
 	}
 #define mcu_get_pwm(diopin) (__indirect__(diopin, OCRREG))

--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -3614,18 +3614,19 @@ extern "C"
 #define mcu_set_output(diopin) SETBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT))
 #define mcu_clear_output(diopin) CLEARBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT))
 #define mcu_toggle_output(diopin) SETBIT(__indirect__(diopin, INREG), __indirect__(diopin, BIT))
-#define mcu_set_pwm(diopin, pwmvalue) ({                                             \
-	__indirect__(diopin, OCRREG) = (uint16_t)pwmvalue;                               \
-	if (pwmvalue != 0)                                                               \
-	{                                                                                \
-		SETFLAG(__indirect__(diopin, TMRAREG), __indirect__(diopin, ENABLE_MASK));   \
-	}                                                                                \
-	else                                                                             \
-	{                                                                                \
-		CLEARFLAG(__indirect__(diopin, TMRAREG), __indirect__(diopin, ENABLE_MASK)); \
-		CLEARBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT));           \
-	}                                                                                \
-})
+#define mcu_set_pwm(diopin, pwmvalue)                                                    \
+	{                                                                                    \
+		__indirect__(diopin, OCRREG) = (uint16_t)pwmvalue;                               \
+		if (pwmvalue != 0)                                                               \
+		{                                                                                \
+			SETFLAG(__indirect__(diopin, TMRAREG), __indirect__(diopin, ENABLE_MASK));   \
+		}                                                                                \
+		else                                                                             \
+		{                                                                                \
+			CLEARFLAG(__indirect__(diopin, TMRAREG), __indirect__(diopin, ENABLE_MASK)); \
+			CLEARBIT(__indirect__(diopin, OUTREG), __indirect__(diopin, BIT));           \
+		}                                                                                \
+	}
 #define mcu_get_pwm(diopin) (__indirect__(diopin, OCRREG))
 
 #define _min(a, b) (((a) < (b)) ? (a) : (b))
@@ -3636,14 +3637,14 @@ extern "C"
 #define F_CPU 16000000UL
 #endif
 #define ADC_PRESC (_min(7, (0xff & ((uint8_t)((float)(F_CPU / 100000) / LOG2)))))
-#define mcu_get_analog(diopin) (                        \
+#define mcu_get_analog(diopin)                          \
 	{                                                   \
 		ADMUX = (0x60 | __indirect__(diopin, CHANNEL)); \
 		ADCSRA = (0xC0 | ADC_PRESC);                    \
 		while (ADCSRA & 0x40)                           \
 			;                                           \
 		ADCH;                                           \
-	})
+	}
 
 #ifdef PROBE_ISR
 #define mcu_enable_probe_isr() (SETFLAG(PROBE_ISRREG, PROBE_ISR_MASK))
@@ -3655,7 +3656,7 @@ extern "C"
 
 #define mcu_enable_global_isr sei
 #define mcu_disable_global_isr cli
-#define mcu_get_global_isr() ({ (SREG && 0x80); })
+#define mcu_get_global_isr() (SREG & 0x80)
 
 #define mcu_delay_us _delay_loop_1
 

--- a/uCNC/src/hal/mcus/samd21/mcumap_samd21.h
+++ b/uCNC/src/hal/mcus/samd21/mcumap_samd21.h
@@ -1341,7 +1341,7 @@ extern "C"
 #define PWM0_PMUXVAL (pinmuxval(PWM0_MUX))
 #if (PWM0_TIMER < 3)
 #define PWM0_TMR __helper__(TCC, PWM0_TIMER, )
-#define PWM0_CONFIG (                         \
+#define PWM0_CONFIG                           \
 	{                                         \
 		PWM0_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM0_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1356,11 +1356,11 @@ extern "C"
 		PWM0_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM0_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM0_DUTYCYCLE (PWM0_TMR->CC[PWM0_CHANNEL].bit.CC)
 #else
 #define PWM0_TMR __helper__(TC, PWM0_TIMER, )
-#define PWM0_CONFIG (                                \
+#define PWM0_CONFIG                                  \
 	{                                                \
 		PWM0_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM0_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1376,7 +1376,7 @@ extern "C"
 		PWM0_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM0_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM0_DUTYCYCLE (PWM0_TMR->COUNT8.CC[PWM0_CHANNEL].reg)
 #endif
 #define DIO20_PMUX PWM0_PMUX
@@ -1391,7 +1391,7 @@ extern "C"
 #define PWM1_PMUXVAL (pinmuxval(PWM1_MUX))
 #if (PWM1_TIMER < 3)
 #define PWM1_TMR __helper__(TCC, PWM1_TIMER, )
-#define PWM1_CONFIG (                         \
+#define PWM1_CONFIG                           \
 	{                                         \
 		PWM1_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM1_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1406,11 +1406,11 @@ extern "C"
 		PWM1_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM1_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM1_DUTYCYCLE (PWM1_TMR->CC[PWM1_CHANNEL].bit.CC)
 #else
 #define PWM1_TMR __helper__(TC, PWM1_TIMER, )
-#define PWM1_CONFIG (                                \
+#define PWM1_CONFIG                                  \
 	{                                                \
 		PWM1_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM1_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1426,7 +1426,7 @@ extern "C"
 		PWM1_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM1_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM1_DUTYCYCLE (PWM1_TMR->COUNT8.CC[PWM1_CHANNEL].reg)
 #endif
 #define DIO21_PMUX PWM1_PMUX
@@ -1441,7 +1441,7 @@ extern "C"
 #define PWM2_PMUXVAL (pinmuxval(PWM2_MUX))
 #if (PWM2_TIMER < 3)
 #define PWM2_TMR __helper__(TCC, PWM2_TIMER, )
-#define PWM2_CONFIG (                         \
+#define PWM2_CONFIG                           \
 	{                                         \
 		PWM2_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM2_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1456,11 +1456,11 @@ extern "C"
 		PWM2_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM2_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM2_DUTYCYCLE (PWM2_TMR->CC[PWM2_CHANNEL].bit.CC)
 #else
 #define PWM2_TMR __helper__(TC, PWM2_TIMER, )
-#define PWM2_CONFIG (                                \
+#define PWM2_CONFIG                                  \
 	{                                                \
 		PWM2_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM2_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1476,7 +1476,7 @@ extern "C"
 		PWM2_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM2_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM2_DUTYCYCLE (PWM2_TMR->COUNT8.CC[PWM2_CHANNEL].reg)
 #endif
 #define DIO22_PMUX PWM2_PMUX
@@ -1491,7 +1491,7 @@ extern "C"
 #define PWM3_PMUXVAL (pinmuxval(PWM3_MUX))
 #if (PWM3_TIMER < 3)
 #define PWM3_TMR __helper__(TCC, PWM3_TIMER, )
-#define PWM3_CONFIG (                         \
+#define PWM3_CONFIG                           \
 	{                                         \
 		PWM3_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM3_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1506,11 +1506,11 @@ extern "C"
 		PWM3_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM3_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM3_DUTYCYCLE (PWM3_TMR->CC[PWM3_CHANNEL].bit.CC)
 #else
 #define PWM3_TMR __helper__(TC, PWM3_TIMER, )
-#define PWM3_CONFIG (                                \
+#define PWM3_CONFIG                                  \
 	{                                                \
 		PWM3_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM3_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1526,7 +1526,7 @@ extern "C"
 		PWM3_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM3_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM3_DUTYCYCLE (PWM3_TMR->COUNT8.CC[PWM3_CHANNEL].reg)
 #endif
 #define DIO23_PMUX PWM3_PMUX
@@ -1541,7 +1541,7 @@ extern "C"
 #define PWM4_PMUXVAL (pinmuxval(PWM4_MUX))
 #if (PWM4_TIMER < 3)
 #define PWM4_TMR __helper__(TCC, PWM4_TIMER, )
-#define PWM4_CONFIG (                         \
+#define PWM4_CONFIG                           \
 	{                                         \
 		PWM4_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM4_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1556,11 +1556,11 @@ extern "C"
 		PWM4_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM4_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM4_DUTYCYCLE (PWM4_TMR->CC[PWM4_CHANNEL].bit.CC)
 #else
 #define PWM4_TMR __helper__(TC, PWM4_TIMER, )
-#define PWM4_CONFIG (                                \
+#define PWM4_CONFIG                                  \
 	{                                                \
 		PWM4_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM4_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1576,7 +1576,7 @@ extern "C"
 		PWM4_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM4_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM4_DUTYCYCLE (PWM4_TMR->COUNT8.CC[PWM4_CHANNEL].reg)
 #endif
 #define DIO24_PMUX PWM4_PMUX
@@ -1591,7 +1591,7 @@ extern "C"
 #define PWM5_PMUXVAL (pinmuxval(PWM5_MUX))
 #if (PWM5_TIMER < 3)
 #define PWM5_TMR __helper__(TCC, PWM5_TIMER, )
-#define PWM5_CONFIG (                         \
+#define PWM5_CONFIG                           \
 	{                                         \
 		PWM5_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM5_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1606,11 +1606,11 @@ extern "C"
 		PWM5_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM5_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM5_DUTYCYCLE (PWM5_TMR->CC[PWM5_CHANNEL].bit.CC)
 #else
 #define PWM5_TMR __helper__(TC, PWM5_TIMER, )
-#define PWM5_CONFIG (                                \
+#define PWM5_CONFIG                                  \
 	{                                                \
 		PWM5_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM5_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1626,7 +1626,7 @@ extern "C"
 		PWM5_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM5_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM5_DUTYCYCLE (PWM5_TMR->COUNT8.CC[PWM5_CHANNEL].reg)
 #endif
 #define DIO25_PMUX PWM5_PMUX
@@ -1641,7 +1641,7 @@ extern "C"
 #define PWM6_PMUXVAL (pinmuxval(PWM6_MUX))
 #if (PWM6_TIMER < 3)
 #define PWM6_TMR __helper__(TCC, PWM6_TIMER, )
-#define PWM6_CONFIG (                         \
+#define PWM6_CONFIG                           \
 	{                                         \
 		PWM6_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM6_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1656,11 +1656,11 @@ extern "C"
 		PWM6_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM6_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM6_DUTYCYCLE (PWM6_TMR->CC[PWM6_CHANNEL].bit.CC)
 #else
 #define PWM6_TMR __helper__(TC, PWM6_TIMER, )
-#define PWM6_CONFIG (                                \
+#define PWM6_CONFIG                                  \
 	{                                                \
 		PWM6_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM6_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1676,7 +1676,7 @@ extern "C"
 		PWM6_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM6_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM6_DUTYCYCLE (PWM6_TMR->COUNT8.CC[PWM6_CHANNEL].reg)
 #endif
 #define DIO26_PMUX PWM6_PMUX
@@ -1691,7 +1691,7 @@ extern "C"
 #define PWM7_PMUXVAL (pinmuxval(PWM7_MUX))
 #if (PWM7_TIMER < 3)
 #define PWM7_TMR __helper__(TCC, PWM7_TIMER, )
-#define PWM7_CONFIG (                         \
+#define PWM7_CONFIG                           \
 	{                                         \
 		PWM7_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM7_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1706,11 +1706,11 @@ extern "C"
 		PWM7_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM7_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM7_DUTYCYCLE (PWM7_TMR->CC[PWM7_CHANNEL].bit.CC)
 #else
 #define PWM7_TMR __helper__(TC, PWM7_TIMER, )
-#define PWM7_CONFIG (                                \
+#define PWM7_CONFIG                                  \
 	{                                                \
 		PWM7_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM7_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1726,7 +1726,7 @@ extern "C"
 		PWM7_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM7_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM7_DUTYCYCLE (PWM7_TMR->COUNT8.CC[PWM7_CHANNEL].reg)
 #endif
 #define DIO27_PMUX PWM7_PMUX
@@ -1741,7 +1741,7 @@ extern "C"
 #define PWM8_PMUXVAL (pinmuxval(PWM8_MUX))
 #if (PWM8_TIMER < 3)
 #define PWM8_TMR __helper__(TCC, PWM8_TIMER, )
-#define PWM8_CONFIG (                         \
+#define PWM8_CONFIG                           \
 	{                                         \
 		PWM8_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM8_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1756,11 +1756,11 @@ extern "C"
 		PWM8_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM8_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM8_DUTYCYCLE (PWM8_TMR->CC[PWM8_CHANNEL].bit.CC)
 #else
 #define PWM8_TMR __helper__(TC, PWM8_TIMER, )
-#define PWM8_CONFIG (                                \
+#define PWM8_CONFIG                                  \
 	{                                                \
 		PWM8_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM8_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1776,7 +1776,7 @@ extern "C"
 		PWM8_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM8_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM8_DUTYCYCLE (PWM8_TMR->COUNT8.CC[PWM8_CHANNEL].reg)
 #endif
 #define DIO28_PMUX PWM8_PMUX
@@ -1791,7 +1791,7 @@ extern "C"
 #define PWM9_PMUXVAL (pinmuxval(PWM9_MUX))
 #if (PWM9_TIMER < 3)
 #define PWM9_TMR __helper__(TCC, PWM9_TIMER, )
-#define PWM9_CONFIG (                         \
+#define PWM9_CONFIG                           \
 	{                                         \
 		PWM9_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM9_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1806,11 +1806,11 @@ extern "C"
 		PWM9_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM9_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                 \
-	})
+	}
 #define PWM9_DUTYCYCLE (PWM9_TMR->CC[PWM9_CHANNEL].bit.CC)
 #else
 #define PWM9_TMR __helper__(TC, PWM9_TIMER, )
-#define PWM9_CONFIG (                                \
+#define PWM9_CONFIG                                  \
 	{                                                \
 		PWM9_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM9_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1826,7 +1826,7 @@ extern "C"
 		PWM9_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM9_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                        \
-	})
+	}
 #define PWM9_DUTYCYCLE (PWM9_TMR->COUNT8.CC[PWM9_CHANNEL].reg)
 #endif
 #define DIO29_PMUX PWM9_PMUX
@@ -1841,7 +1841,7 @@ extern "C"
 #define PWM10_PMUXVAL (pinmuxval(PWM10_MUX))
 #if (PWM10_TIMER < 3)
 #define PWM10_TMR __helper__(TCC, PWM10_TIMER, )
-#define PWM10_CONFIG (                         \
+#define PWM10_CONFIG                           \
 	{                                          \
 		PWM10_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM10_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1856,11 +1856,11 @@ extern "C"
 		PWM10_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM10_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM10_DUTYCYCLE (PWM10_TMR->CC[PWM10_CHANNEL].bit.CC)
 #else
 #define PWM10_TMR __helper__(TC, PWM10_TIMER, )
-#define PWM10_CONFIG (                                \
+#define PWM10_CONFIG                                  \
 	{                                                 \
 		PWM10_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM10_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1876,7 +1876,7 @@ extern "C"
 		PWM10_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM10_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM10_DUTYCYCLE (PWM10_TMR->COUNT8.CC[PWM10_CHANNEL].reg)
 #endif
 #define DIO30_PMUX PWM10_PMUX
@@ -1891,7 +1891,7 @@ extern "C"
 #define PWM11_PMUXVAL (pinmuxval(PWM11_MUX))
 #if (PWM11_TIMER < 3)
 #define PWM11_TMR __helper__(TCC, PWM11_TIMER, )
-#define PWM11_CONFIG (                         \
+#define PWM11_CONFIG                           \
 	{                                          \
 		PWM11_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM11_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1906,11 +1906,11 @@ extern "C"
 		PWM11_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM11_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM11_DUTYCYCLE (PWM11_TMR->CC[PWM11_CHANNEL].bit.CC)
 #else
 #define PWM11_TMR __helper__(TC, PWM11_TIMER, )
-#define PWM11_CONFIG (                                \
+#define PWM11_CONFIG                                  \
 	{                                                 \
 		PWM11_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM11_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1926,7 +1926,7 @@ extern "C"
 		PWM11_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM11_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM11_DUTYCYCLE (PWM11_TMR->COUNT8.CC[PWM11_CHANNEL].reg)
 #endif
 #define DIO31_PMUX PWM11_PMUX
@@ -1941,7 +1941,7 @@ extern "C"
 #define PWM12_PMUXVAL (pinmuxval(PWM12_MUX))
 #if (PWM12_TIMER < 3)
 #define PWM12_TMR __helper__(TCC, PWM12_TIMER, )
-#define PWM12_CONFIG (                         \
+#define PWM12_CONFIG                           \
 	{                                          \
 		PWM12_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM12_TMR->SYNCBUSY.bit.SWRST)  \
@@ -1956,11 +1956,11 @@ extern "C"
 		PWM12_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM12_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM12_DUTYCYCLE (PWM12_TMR->CC[PWM12_CHANNEL].bit.CC)
 #else
 #define PWM12_TMR __helper__(TC, PWM12_TIMER, )
-#define PWM12_CONFIG (                                \
+#define PWM12_CONFIG                                  \
 	{                                                 \
 		PWM12_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM12_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -1976,7 +1976,7 @@ extern "C"
 		PWM12_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM12_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM12_DUTYCYCLE (PWM12_TMR->COUNT8.CC[PWM12_CHANNEL].reg)
 #endif
 #define DIO32_PMUX PWM12_PMUX
@@ -1991,7 +1991,7 @@ extern "C"
 #define PWM13_PMUXVAL (pinmuxval(PWM13_MUX))
 #if (PWM13_TIMER < 3)
 #define PWM13_TMR __helper__(TCC, PWM13_TIMER, )
-#define PWM13_CONFIG (                         \
+#define PWM13_CONFIG                           \
 	{                                          \
 		PWM13_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM13_TMR->SYNCBUSY.bit.SWRST)  \
@@ -2006,11 +2006,11 @@ extern "C"
 		PWM13_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM13_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM13_DUTYCYCLE (PWM13_TMR->CC[PWM13_CHANNEL].bit.CC)
 #else
 #define PWM13_TMR __helper__(TC, PWM13_TIMER, )
-#define PWM13_CONFIG (                                \
+#define PWM13_CONFIG                                  \
 	{                                                 \
 		PWM13_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM13_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -2026,7 +2026,7 @@ extern "C"
 		PWM13_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM13_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM13_DUTYCYCLE (PWM13_TMR->COUNT8.CC[PWM13_CHANNEL].reg)
 #endif
 #define DIO33_PMUX PWM13_PMUX
@@ -2041,7 +2041,7 @@ extern "C"
 #define PWM14_PMUXVAL (pinmuxval(PWM14_MUX))
 #if (PWM14_TIMER < 3)
 #define PWM14_TMR __helper__(TCC, PWM14_TIMER, )
-#define PWM14_CONFIG (                         \
+#define PWM14_CONFIG                           \
 	{                                          \
 		PWM14_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM14_TMR->SYNCBUSY.bit.SWRST)  \
@@ -2056,11 +2056,11 @@ extern "C"
 		PWM14_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM14_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM14_DUTYCYCLE (PWM14_TMR->CC[PWM14_CHANNEL].bit.CC)
 #else
 #define PWM14_TMR __helper__(TC, PWM14_TIMER, )
-#define PWM14_CONFIG (                                \
+#define PWM14_CONFIG                                  \
 	{                                                 \
 		PWM14_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM14_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -2076,7 +2076,7 @@ extern "C"
 		PWM14_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM14_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM14_DUTYCYCLE (PWM14_TMR->COUNT8.CC[PWM14_CHANNEL].reg)
 #endif
 #define DIO34_PMUX PWM14_PMUX
@@ -2091,7 +2091,7 @@ extern "C"
 #define PWM15_PMUXVAL (pinmuxval(PWM15_MUX))
 #if (PWM15_TIMER < 3)
 #define PWM15_TMR __helper__(TCC, PWM15_TIMER, )
-#define PWM15_CONFIG (                         \
+#define PWM15_CONFIG                           \
 	{                                          \
 		PWM15_TMR->CTRLA.bit.SWRST = 1;        \
 		while (PWM15_TMR->SYNCBUSY.bit.SWRST)  \
@@ -2106,11 +2106,11 @@ extern "C"
 		PWM15_TMR->CTRLA.bit.ENABLE = 1;       \
 		while (PWM15_TMR->SYNCBUSY.bit.ENABLE) \
 			;                                  \
-	})
+	}
 #define PWM15_DUTYCYCLE (PWM15_TMR->CC[PWM15_CHANNEL].bit.CC)
 #else
 #define PWM15_TMR __helper__(TC, PWM15_TIMER, )
-#define PWM15_CONFIG (                                \
+#define PWM15_CONFIG                                  \
 	{                                                 \
 		PWM15_TMR->COUNT8.CTRLA.bit.SWRST = 1;        \
 		while (PWM15_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
@@ -2126,7 +2126,7 @@ extern "C"
 		PWM15_TMR->COUNT8.CTRLA.bit.ENABLE = 1;       \
 		while (PWM15_TMR->COUNT8.STATUS.bit.SYNCBUSY) \
 			;                                         \
-	})
+	}
 #define PWM15_DUTYCYCLE (PWM15_TMR->COUNT8.CC[PWM15_CHANNEL].reg)
 #endif
 #define DIO35_PMUX PWM15_PMUX
@@ -2364,44 +2364,44 @@ extern "C"
 #define TOGGLEFLAG(x, y) ((x) ^= (y))
 #endif
 
-#define mcu_config_output(diopin) (                                            \
+#define mcu_config_output(diopin)                                              \
 	{                                                                          \
 		SETBIT(__indirect__(diopin, GPIO).DIR.reg, __indirect__(diopin, BIT)); \
 		__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg = 0;  \
-	})
-#define mcu_config_input(diopin) (                                                   \
+	}
+#define mcu_config_input(diopin)                                                     \
 	{                                                                                \
 		CLEARBIT(__indirect__(diopin, GPIO).DIR.reg, __indirect__(diopin, BIT));     \
 		SETBIT(__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg, 1); \
-	})
-#define mcu_config_pullup(diopin) (                                                  \
+	}
+#define mcu_config_pullup(diopin)                                                    \
 	{                                                                                \
 		SETBIT(__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg, 2); \
 		SETBIT(__indirect__(diopin, GPIO).OUT.reg, __indirect__(diopin, BIT));       \
-	})
-#define mcu_config_analog(diopin) (                                                  \
+	}
+#define mcu_config_analog(diopin)                                                    \
 	{                                                                                \
 		CLEARBIT(__indirect__(diopin, GPIO).DIR.reg, __indirect__(diopin, BIT));     \
 		__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg = 0;        \
 		SETBIT(__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg, 0); \
 		(__indirect__(diopin, PMUX)) = __indirect__(diopin, PMUXVAL);                \
-	})
-#define mcu_config_altfunc(diopin) (                                                 \
+	}
+#define mcu_config_altfunc(diopin)                                                   \
 	{                                                                                \
 		SETBIT(__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg, 0); \
 		(__indirect__(diopin, PMUX)) = __indirect__(diopin, PMUXVAL);                \
-	})
+	}
 
 #define mcu_config_input_isr(diopin) (mcu_config_altfunc(diopin))
 
-#define mcu_config_pwm(diopin) (                                                     \
+#define mcu_config_pwm(diopin)                                                       \
 	{                                                                                \
 		SETBIT(__indirect__(diopin, GPIO).DIR.reg, __indirect__(diopin, BIT));       \
 		__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg = 0;        \
 		SETBIT(__indirect__(diopin, GPIO).PINCFG[__indirect__(diopin, BIT)].reg, 0); \
 		(__indirect__(diopin, PMUX)) = __indirect__(diopin, PMUXVAL);                \
 		(__indirect__(diopin, CONFIG));                                              \
-	})
+	}
 
 #define mcu_get_input(diopin) (CHECKBIT(__indirect__(diopin, GPIO).IN.reg, __indirect__(diopin, BIT)))
 #define mcu_get_output(diopin) (CHECKBIT(__indirect__(diopin, GPIO).OUT.reg, __indirect__(diopin, BIT)))
@@ -2409,9 +2409,12 @@ extern "C"
 #define mcu_clear_output(diopin) (__indirect__(diopin, GPIO).OUTCLR.reg = (1UL << __indirect__(diopin, BIT)))
 #define mcu_toggle_output(diopin) (__indirect__(diopin, GPIO).OUTTGL.reg = (1UL << __indirect__(diopin, BIT)))
 
-#define mcu_set_pwm(diopin, pwmvalue) ({ (__indirect__(diopin, DUTYCYCLE)) = pwmvalue; })
+#define mcu_set_pwm(diopin, pwmvalue)                 \
+	{                                                 \
+		(__indirect__(diopin, DUTYCYCLE)) = pwmvalue; \
+	}
 
-#define mcu_get_analog(diopin) (                                     \
+#define mcu_get_analog(diopin)                                       \
 	{                                                                \
 		while (ADC->STATUS.bit.SYNCBUSY)                             \
 			ADC->INTFLAG.reg = ADC_INTFLAG_RESRDY;                   \
@@ -2425,7 +2428,7 @@ extern "C"
 		while (!(ADC->INTFLAG.bit.RESRDY))                           \
 			;                                                        \
 		ADC->RESULT.reg;                                             \
-	})
+	}
 	/*
 #define mcu_get_pwm(diopin) ((uint8_t)((((uint32_t)__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR)) * 255) / ((uint32_t)__indirect__(diopin, TIMREG)->ARR)))
 #ifdef PROBE
@@ -2439,17 +2442,17 @@ extern "C"
 #endif
 */
 	extern volatile bool samd21_global_isr_enabled;
-#define mcu_enable_global_isr() (         \
+#define mcu_enable_global_isr()           \
 	{                                     \
 		__enable_irq();                   \
 		samd21_global_isr_enabled = true; \
-	})
-#define mcu_disable_global_isr() (         \
+	}
+#define mcu_disable_global_isr()           \
 	{                                      \
 		samd21_global_isr_enabled = false; \
 		__disable_irq();                   \
-	})
-#define mcu_get_global_isr() ({ samd21_global_isr_enabled; })
+	}
+#define mcu_get_global_isr() samd21_global_isr_enabled
 
 #if (INTERFACE == INTERFACE_USART)
 #define mcu_rx_ready() (COM->USART.INTFLAG.bit.RXC)

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -88,14 +88,14 @@ volatile bool stm32_global_isr_enabled;
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) |= (GPIO_IN_FLOAT << (__indirect__(diopin, CROFF) << 2U)); \
 	}
 
-#define mcu_config_pullup(diopin) (                                                                                   \
+#define mcu_config_pullup(diopin)                                                                                     \
 	{                                                                                                                 \
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) &= ~(GPIO_RESET << (__indirect__(diopin, CROFF) << 2U)); \
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) |= (GPIO_IN_PUP << (__indirect__(diopin, CROFF) << 2U)); \
 		__indirect__(diopin, GPIO)->BSRR = (1U << __indirect__(diopin, BIT));                                         \
-	})
+	}
 
-#define mcu_config_pwm(diopin) (                                                                                                 \
+#define mcu_config_pwm(diopin)                                                                                                   \
 	{                                                                                                                            \
 		RCC->APB2ENR |= 0x1U;                                                                                                    \
 		__indirect__(diopin, ENREG) |= __indirect__(diopin, APBEN);                                                              \
@@ -110,9 +110,9 @@ volatile bool stm32_global_isr_enabled;
 		__indirect__(diopin, TIMREG)->BDTR |= (1 << 15);                                                                         \
 		__indirect__(diopin, TIMREG)->CR1 |= 0x01U;                                                                              \
 		__indirect__(diopin, ENOUTPUT);                                                                                          \
-	})
+	}
 
-#define mcu_config_input_isr(diopin) (                                                                          \
+#define mcu_config_input_isr(diopin)                                                                            \
 	{                                                                                                           \
 		RCC->APB2ENR |= 0x1U;                                                                                   \
 		AFIO->EXTICR[(__indirect__(diopin, EXTIREG))] &= ~(0xF << (((__indirect__(diopin, BIT)) & 0x03) << 2)); \
@@ -123,9 +123,9 @@ volatile bool stm32_global_isr_enabled;
 		NVIC_SetPriority(__indirect__(diopin, IRQ), 5);                                                         \
 		NVIC_ClearPendingIRQ(__indirect__(diopin, IRQ));                                                        \
 		NVIC_EnableIRQ(__indirect__(diopin, IRQ));                                                              \
-	})
+	}
 
-#define mcu_config_analog(diopin) (                                                                                     \
+#define mcu_config_analog(diopin)                                                                                       \
 	{                                                                                                                   \
 		RCC->CFGR &= ~(RCC_CFGR_ADCPRE);                                                                                \
 		RCC->CFGR |= RCC_CFGR_ADCPRE_DIV8;                                                                              \
@@ -143,7 +143,7 @@ volatile bool stm32_global_isr_enabled;
 		while (ADC1->CR2 & ADC_CR2_CAL)                                                                                 \
 			;                                                                                                           \
 		ADC1->CR2 |= (ADC_CR2_EXTSEL | ADC_CR2_EXTTRIG); /*external start trigger software*/                            \
-	})
+	}
 
 /**
  * The isr functions

--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -2482,9 +2482,15 @@ extern "C"
 #define PWM0_CCMREG CCMR1
 #endif
 #if (PWM0_TIMER == 1)
-#define PWM0_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM0_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM0_TIMER == 8)
-#define PWM0_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM0_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM0_ENOUTPUT \
 	{                 \
@@ -2526,9 +2532,15 @@ extern "C"
 #define PWM1_CCMREG CCMR1
 #endif
 #if (PWM1_TIMER == 1)
-#define PWM1_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM1_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM1_TIMER == 8)
-#define PWM1_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM1_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM1_ENOUTPUT \
 	{                 \
@@ -2570,9 +2582,15 @@ extern "C"
 #define PWM2_CCMREG CCMR1
 #endif
 #if (PWM2_TIMER == 1)
-#define PWM2_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM2_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM2_TIMER == 8)
-#define PWM2_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM2_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM2_ENOUTPUT \
 	{                 \
@@ -2614,9 +2632,15 @@ extern "C"
 #define PWM3_CCMREG CCMR1
 #endif
 #if (PWM3_TIMER == 1)
-#define PWM3_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM3_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM3_TIMER == 8)
-#define PWM3_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM3_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM3_ENOUTPUT \
 	{                 \
@@ -2658,9 +2682,15 @@ extern "C"
 #define PWM4_CCMREG CCMR1
 #endif
 #if (PWM4_TIMER == 1)
-#define PWM4_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM4_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM4_TIMER == 8)
-#define PWM4_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM4_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM4_ENOUTPUT \
 	{                 \
@@ -2702,9 +2732,15 @@ extern "C"
 #define PWM5_CCMREG CCMR1
 #endif
 #if (PWM5_TIMER == 1)
-#define PWM5_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM5_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM5_TIMER == 8)
-#define PWM5_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM5_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM5_ENOUTPUT \
 	{                 \
@@ -2746,9 +2782,15 @@ extern "C"
 #define PWM6_CCMREG CCMR1
 #endif
 #if (PWM6_TIMER == 1)
-#define PWM6_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM6_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM6_TIMER == 8)
-#define PWM6_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM6_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM6_ENOUTPUT \
 	{                 \
@@ -2790,9 +2832,15 @@ extern "C"
 #define PWM7_CCMREG CCMR1
 #endif
 #if (PWM7_TIMER == 1)
-#define PWM7_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM7_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM7_TIMER == 8)
-#define PWM7_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM7_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM7_ENOUTPUT \
 	{                 \
@@ -2834,9 +2882,15 @@ extern "C"
 #define PWM8_CCMREG CCMR1
 #endif
 #if (PWM8_TIMER == 1)
-#define PWM8_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM8_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM8_TIMER == 8)
-#define PWM8_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM8_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM8_ENOUTPUT \
 	{                 \
@@ -2878,9 +2932,15 @@ extern "C"
 #define PWM9_CCMREG CCMR1
 #endif
 #if (PWM9_TIMER == 1)
-#define PWM9_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM9_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM9_TIMER == 8)
-#define PWM9_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM9_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM9_ENOUTPUT \
 	{                 \
@@ -2922,9 +2982,15 @@ extern "C"
 #define PWM10_CCMREG CCMR1
 #endif
 #if (PWM10_TIMER == 1)
-#define PWM10_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM10_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM10_TIMER == 8)
-#define PWM10_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM10_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM10_ENOUTPUT \
 	{                  \
@@ -2966,9 +3032,15 @@ extern "C"
 #define PWM11_CCMREG CCMR1
 #endif
 #if (PWM11_TIMER == 1)
-#define PWM11_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM11_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM11_TIMER == 8)
-#define PWM11_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM11_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM11_ENOUTPUT \
 	{                  \
@@ -3010,9 +3082,15 @@ extern "C"
 #define PWM12_CCMREG CCMR1
 #endif
 #if (PWM12_TIMER == 1)
-#define PWM12_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM12_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM12_TIMER == 8)
-#define PWM12_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM12_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM12_ENOUTPUT \
 	{                  \
@@ -3054,9 +3132,15 @@ extern "C"
 #define PWM13_CCMREG CCMR1
 #endif
 #if (PWM13_TIMER == 1)
-#define PWM13_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM13_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM13_TIMER == 8)
-#define PWM13_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM13_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM13_ENOUTPUT \
 	{                  \
@@ -3098,9 +3182,15 @@ extern "C"
 #define PWM14_CCMREG CCMR1
 #endif
 #if (PWM14_TIMER == 1)
-#define PWM14_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM14_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM14_TIMER == 8)
-#define PWM14_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM14_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM14_ENOUTPUT \
 	{                  \
@@ -3142,9 +3232,15 @@ extern "C"
 #define PWM15_CCMREG CCMR1
 #endif
 #if (PWM15_TIMER == 1)
-#define PWM15_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM15_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM15_TIMER == 8)
-#define PWM15_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM15_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM15_ENOUTPUT \
 	{                  \
@@ -3407,7 +3503,7 @@ extern "C"
 	}
 #define mcu_get_pwm(diopin) ((uint8_t)((((uint32_t)__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR)) * 255) / ((uint32_t)__indirect__(diopin, TIMREG)->ARR)))
 
-#define mcu_get_analog(diopin) (                    \
+#define mcu_get_analog(diopin)                      \
 	{                                               \
 		ADC1->SQR3 = __indirect__(diopin, CHANNEL); \
 		ADC1->CR2 |= ADC_CR2_SWSTART;               \
@@ -3416,7 +3512,7 @@ extern "C"
 			;                                       \
 		ADC1->SR &= ~ADC_SR_EOS;                    \
 		(0xFF & (ADC1->DR >> 4));                   \
-	})
+	}
 #ifdef PROBE
 #ifdef PROBE_ISR
 #define mcu_enable_probe_isr() SETBIT(EXTI->IMR, PROBE_BIT)
@@ -3428,17 +3524,17 @@ extern "C"
 #endif
 
 	extern volatile bool stm32_global_isr_enabled;
-#define mcu_enable_global_isr() (        \
+#define mcu_enable_global_isr()          \
 	{                                    \
 		__enable_irq();                  \
 		stm32_global_isr_enabled = true; \
-	})
-#define mcu_disable_global_isr() (        \
+	}
+#define mcu_disable_global_isr()          \
 	{                                     \
 		stm32_global_isr_enabled = false; \
 		__disable_irq();                  \
-	})
-#define mcu_get_global_isr() ({ stm32_global_isr_enabled; })
+	}
+#define mcu_get_global_isr() stm32_global_isr_enabled
 
 // #ifdef COM_PORT
 // #ifndef ENABLE_SYNC_TX

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -83,13 +83,13 @@ volatile bool stm32_global_isr_enabled;
 		__indirect__(diopin, GPIO)->OSPEEDR |= (0x03 << ((__indirect__(diopin, BIT)) << 1));										/*output mode*/ \
 	}
 
-#define mcu_config_pullup(diopin) (                                                                  \
+#define mcu_config_pullup(diopin)                                                                    \
 	{                                                                                                \
 		__indirect__(diopin, GPIO)->PUPDR &= ~(GPIO_RESET << ((__indirect__(diopin, BIT)) << 1));    \
 		__indirect__(diopin, GPIO)->PUPDR |= (GPIO_IN_PULLUP << ((__indirect__(diopin, BIT)) << 1)); \
-	})
+	}
 
-#define mcu_config_pwm(diopin) (                                                                                                                                    \
+#define mcu_config_pwm(diopin)                                                                                                                                      \
 	{                                                                                                                                                               \
 		RCC->AHB1ENR |= __indirect__(diopin, AHB1EN);                                                                                                               \
 		PWM0_ENREG |= PWM0_APBEN;                                                                                                                                   \
@@ -106,9 +106,9 @@ volatile bool stm32_global_isr_enabled;
 		__indirect__(diopin, TIMREG)->BDTR |= (1 << 15);                                                                                                            \
 		__indirect__(diopin, TIMREG)->CR1 |= 0x01U;                                                                                                                 \
 		__indirect__(diopin, ENOUTPUT);                                                                                                                             \
-	})
+	}
 
-#define mcu_config_input_isr(diopin) (                                                                            \
+#define mcu_config_input_isr(diopin)                                                                              \
 	{                                                                                                             \
 		RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;                                                                     \
 		SYSCFG->EXTICR[(__indirect__(diopin, EXTIREG))] &= ~(0xF << (((__indirect__(diopin, BIT)) & 0x03) << 2)); \
@@ -119,7 +119,7 @@ volatile bool stm32_global_isr_enabled;
 		NVIC_SetPriority(__indirect__(diopin, IRQ), 5);                                                           \
 		NVIC_ClearPendingIRQ(__indirect__(diopin, IRQ));                                                          \
 		NVIC_EnableIRQ(__indirect__(diopin, IRQ));                                                                \
-	})
+	}
 
 #if defined(ADC1_COMMON)
 #define ADC_COMMON ADC1_COMMON
@@ -129,7 +129,7 @@ volatile bool stm32_global_isr_enabled;
 #define ADC_COMMON ADC123_COMMON
 #endif
 
-#define mcu_config_analog(diopin) (                                                                                                   \
+#define mcu_config_analog(diopin)                                                                                                     \
 	{                                                                                                                                 \
 		ADC_COMMON->CCR &= ~(ADC_CCR_ADCPRE);                                                                                         \
 		ADC_COMMON->CCR |= (ADC_CCR_ADCPRE_0 | ADC_CCR_ADCPRE_1);                                                                     \
@@ -143,7 +143,7 @@ volatile bool stm32_global_isr_enabled;
 		__indirect__(diopin, GPIO)->MODER |= (GPIO_ANALOG << ((__indirect__(diopin, BIT)) << 1)); /*analog mode*/                     \
 		ADC1->CR2 |= ADC_CR2_ADON;																  /*enable adc*/                      \
 		ADC1->CR2 |= (ADC_CR2_EXTEN_0 | ADC_CR2_EXTEN_1);										  /*external start trigger software*/ \
-	})
+	}
 
 /**
  * The isr functions

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -1521,9 +1521,15 @@ extern "C"
 #define PWM0_CCMREG CCMR1
 #endif
 #if (PWM0_TIMER == 1)
-#define PWM0_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM0_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM0_TIMER == 8)
-#define PWM0_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM0_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM0_ENOUTPUT \
 	{                 \
@@ -1573,9 +1579,15 @@ extern "C"
 #define PWM1_CCMREG CCMR1
 #endif
 #if (PWM1_TIMER == 1)
-#define PWM1_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM1_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM1_TIMER == 8)
-#define PWM1_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM1_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM1_ENOUTPUT \
 	{                 \
@@ -1625,9 +1637,15 @@ extern "C"
 #define PWM2_CCMREG CCMR1
 #endif
 #if (PWM2_TIMER == 1)
-#define PWM2_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM2_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM2_TIMER == 8)
-#define PWM2_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM2_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM2_ENOUTPUT \
 	{                 \
@@ -1677,9 +1695,15 @@ extern "C"
 #define PWM3_CCMREG CCMR1
 #endif
 #if (PWM3_TIMER == 1)
-#define PWM3_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM3_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM3_TIMER == 8)
-#define PWM3_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM3_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM3_ENOUTPUT \
 	{                 \
@@ -1729,9 +1753,15 @@ extern "C"
 #define PWM4_CCMREG CCMR1
 #endif
 #if (PWM4_TIMER == 1)
-#define PWM4_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM4_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM4_TIMER == 8)
-#define PWM4_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM4_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM4_ENOUTPUT \
 	{                 \
@@ -1781,9 +1811,15 @@ extern "C"
 #define PWM5_CCMREG CCMR1
 #endif
 #if (PWM5_TIMER == 1)
-#define PWM5_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM5_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM5_TIMER == 8)
-#define PWM5_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM5_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM5_ENOUTPUT \
 	{                 \
@@ -1833,9 +1869,15 @@ extern "C"
 #define PWM6_CCMREG CCMR1
 #endif
 #if (PWM6_TIMER == 1)
-#define PWM6_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM6_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM6_TIMER == 8)
-#define PWM6_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM6_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM6_ENOUTPUT \
 	{                 \
@@ -1885,9 +1927,15 @@ extern "C"
 #define PWM7_CCMREG CCMR1
 #endif
 #if (PWM7_TIMER == 1)
-#define PWM7_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM7_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM7_TIMER == 8)
-#define PWM7_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM7_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM7_ENOUTPUT \
 	{                 \
@@ -1937,9 +1985,15 @@ extern "C"
 #define PWM8_CCMREG CCMR1
 #endif
 #if (PWM8_TIMER == 1)
-#define PWM8_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM8_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM8_TIMER == 8)
-#define PWM8_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM8_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM8_ENOUTPUT \
 	{                 \
@@ -1989,9 +2043,15 @@ extern "C"
 #define PWM9_CCMREG CCMR1
 #endif
 #if (PWM9_TIMER == 1)
-#define PWM9_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM9_ENOUTPUT            \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM9_TIMER == 8)
-#define PWM9_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM9_ENOUTPUT            \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM9_ENOUTPUT \
 	{                 \
@@ -2041,9 +2101,15 @@ extern "C"
 #define PWM10_CCMREG CCMR1
 #endif
 #if (PWM10_TIMER == 1)
-#define PWM10_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM10_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM10_TIMER == 8)
-#define PWM10_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM10_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM10_ENOUTPUT \
 	{                  \
@@ -2093,9 +2159,15 @@ extern "C"
 #define PWM11_CCMREG CCMR1
 #endif
 #if (PWM11_TIMER == 1)
-#define PWM11_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM11_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM11_TIMER == 8)
-#define PWM11_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM11_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM11_ENOUTPUT \
 	{                  \
@@ -2145,9 +2217,15 @@ extern "C"
 #define PWM12_CCMREG CCMR1
 #endif
 #if (PWM12_TIMER == 1)
-#define PWM12_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM12_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM12_TIMER == 8)
-#define PWM12_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM12_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM12_ENOUTPUT \
 	{                  \
@@ -2197,9 +2275,15 @@ extern "C"
 #define PWM13_CCMREG CCMR1
 #endif
 #if (PWM13_TIMER == 1)
-#define PWM13_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM13_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM13_TIMER == 8)
-#define PWM13_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM13_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM13_ENOUTPUT \
 	{                  \
@@ -2249,9 +2333,15 @@ extern "C"
 #define PWM14_CCMREG CCMR1
 #endif
 #if (PWM14_TIMER == 1)
-#define PWM14_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM14_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM14_TIMER == 8)
-#define PWM14_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM14_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM14_ENOUTPUT \
 	{                  \
@@ -2301,9 +2391,15 @@ extern "C"
 #define PWM15_CCMREG CCMR1
 #endif
 #if (PWM15_TIMER == 1)
-#define PWM15_ENOUTPUT ({ TIM1->BDTR |= (1 << 15); })
+#define PWM15_ENOUTPUT           \
+	{                            \
+		TIM1->BDTR |= (1 << 15); \
+	}
 #elif (PWM15_TIMER == 8)
-#define PWM15_ENOUTPUT ({ TIM8->BDTR |= (1 << 15); })
+#define PWM15_ENOUTPUT           \
+	{                            \
+		TIM8->BDTR |= (1 << 15); \
+	}
 #else
 #define PWM15_ENOUTPUT \
 	{                  \
@@ -2546,11 +2642,14 @@ extern "C"
 #define mcu_set_output(diopin) (__indirect__(diopin, GPIO)->BSRR = (1UL << __indirect__(diopin, BIT)))
 #define mcu_clear_output(diopin) (__indirect__(diopin, GPIO)->BSRR = ((1UL << 16) << __indirect__(diopin, BIT)))
 #define mcu_toggle_output(diopin) (TOGGLEBIT(__indirect__(diopin, GPIO)->ODR, __indirect__(diopin, BIT)))
-#define mcu_set_pwm(diopin, pwmvalue) ({ __indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = (uint16_t)((__indirect__(diopin, TIMREG)->ARR * pwmvalue) / 255); })
+#define mcu_set_pwm(diopin, pwmvalue)                                                                                               \
+	{                                                                                                                               \
+		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = (uint16_t)((__indirect__(diopin, TIMREG)->ARR * pwmvalue) / 255); \
+	}
 
 #define mcu_get_pwm(diopin) ((uint8_t)((((uint32_t)__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR)) * 255) / ((uint32_t)__indirect__(diopin, TIMREG)->ARR)))
 
-#define mcu_get_analog(diopin) (                    \
+#define mcu_get_analog(diopin)                      \
 	{                                               \
 		ADC1->SQR3 = __indirect__(diopin, CHANNEL); \
 		ADC1->CR2 |= ADC_CR2_SWSTART;               \
@@ -2559,7 +2658,7 @@ extern "C"
 			;                                       \
 		ADC1->SR &= ~ADC_SR_EOC;                    \
 		(0xFF & (ADC1->DR >> 4));                   \
-	})
+	}
 #ifdef PROBE
 #ifdef PROBE_ISR
 #define mcu_enable_probe_isr() SETBIT(EXTI->IMR, PROBE_BIT)
@@ -2571,17 +2670,17 @@ extern "C"
 #endif
 
 	extern volatile bool stm32_global_isr_enabled;
-#define mcu_enable_global_isr() (        \
+#define mcu_enable_global_isr()          \
 	{                                    \
 		__enable_irq();                  \
 		stm32_global_isr_enabled = true; \
-	})
-#define mcu_disable_global_isr() (        \
+	}
+#define mcu_disable_global_isr()          \
 	{                                     \
 		stm32_global_isr_enabled = false; \
 		__disable_irq();                  \
-	})
-#define mcu_get_global_isr() ({ stm32_global_isr_enabled; })
+	}
+#define mcu_get_global_isr() stm32_global_isr_enabled
 
 // #ifdef COM_PORT
 // #ifndef ENABLE_SYNC_TX

--- a/uCNC/src/hal/tools/tool.c
+++ b/uCNC/src/hal/tools/tool.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define DECL_TOOL(tool) extern const tool_t __rom__ tool;
+#define DECL_TOOL(tool) extern const tool_t __rom__ tool
 
 static tool_t tool_current;
 

--- a/uCNC/src/hal/tools/tool_helper.h
+++ b/uCNC/src/hal/tools/tool_helper.h
@@ -1,20 +1,20 @@
 /*
-	Name: tool_helper.h
-	Description: The tool_helper set of macros for µCNC.
+    Name: tool_helper.h
+    Description: The tool_helper set of macros for µCNC.
         This is responsible to define and manage tools.
 
-	Copyright: Copyright (c) João Martins
-	Author: João Martins
-	Date: 17/12/2021
+    Copyright: Copyright (c) João Martins
+    Author: João Martins
+    Date: 17/12/2021
 
-	µCNC is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+    µCNC is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version. Please see <http://www.gnu.org/licenses/>
 
-	µCNC is distributed WITHOUT ANY WARRANTY;
-	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the	GNU General Public License for more details.
+    µCNC is distributed WITHOUT ANY WARRANTY;
+    Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the	GNU General Public License for more details.
 */
 
 #ifndef TOOL_HELPER_H
@@ -29,37 +29,37 @@ extern "C"
 #define MIST_MASK 0x01
 
     /**
- * X - PWM pin
- * Y - DIR pin
- * W - pwm value
- * Z - dir value
- * */
+     * X - PWM pin
+     * Y - DIR pin
+     * W - pwm value
+     * Z - dir value
+     * */
 
-#define SET_SPINDLE(X, Y, W, Z) ( \
-    {                              \
-        io_set_output(Y, Z);       \
-        io_set_pwm(X, W);          \
-    })
+#define SET_SPINDLE(X, Y, W, Z) \
+    {                           \
+        io_set_output(Y, Z);    \
+        io_set_pwm(X, W);       \
+    }
 
 /**
  * X - PWM pin
  * Y - pwm value
  * */
-#define SET_LASER(X, Y) (      \
-    {                          \
+#define SET_LASER(X, Y)   \
+    {                     \
         io_set_pwm(X, Y); \
-    })
+    }
 
 /**
  * X - flood pin
  * Y - mist pin
  * z - mask value
  * */
-#define SET_COOLANT(X, Y, Z) (      \
-    {                                \
-    io_set_output(X, (Z && COOLANT_MASK)); \
-    io_set_output(Y, (Z && MIST_MASK)); \
-    })
+#define SET_COOLANT(X, Y, Z)                   \
+    {                                          \
+        io_set_output(X, (Z && COOLANT_MASK)); \
+        io_set_output(Y, (Z && MIST_MASK));    \
+    }
 
 #ifdef __cplusplus
 }

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -64,7 +64,7 @@ void protocol_send_alarm(int8_t alarm)
 #endif
 }
 
-void protocol_send_string(const unsigned char *__s)
+void protocol_send_string(const char *__s)
 {
 #ifdef ECHO_CMD
     protocol_busy = true;
@@ -75,7 +75,7 @@ void protocol_send_string(const unsigned char *__s)
 #endif
 }
 
-void protocol_send_feedback(const unsigned char *__s)
+void protocol_send_feedback(const char *__s)
 {
 #ifdef ECHO_CMD
     protocol_busy = true;
@@ -165,7 +165,7 @@ void protocol_send_status(void)
 #endif
     float axis[MAX(AXIS_COUNT, 3)];
 
-    uint32_t steppos[STEPPER_COUNT];
+    int32_t steppos[STEPPER_COUNT];
     itp_get_rt_position(steppos);
     kinematics_apply_forward(steppos, axis);
     kinematics_apply_reverse_transform(axis);

--- a/uCNC/src/interface/protocol.h
+++ b/uCNC/src/interface/protocol.h
@@ -31,8 +31,8 @@ extern "C"
 	void protocol_send_error(uint8_t error);
 	void protocol_send_alarm(int8_t alarm);
 	void protocol_send_status(void);
-	void protocol_send_string(const unsigned char *__s);
-	void protocol_send_feedback(const unsigned char *__s);
+	void protocol_send_string(const char *__s);
+	void protocol_send_feedback(const char *__s);
 	void protocol_send_probe_result(uint8_t val);
 	void protocol_send_gcode_coordsys(void);
 	void protocol_send_gcode_modes(void);

--- a/uCNC/src/interface/serial.c
+++ b/uCNC/src/interface/serial.c
@@ -1,19 +1,19 @@
 /*
-	Name: serial.c
-	Description: Serial communication basic read/write functions µCNC.
+    Name: serial.c
+    Description: Serial communication basic read/write functions µCNC.
 
-	Copyright: Copyright (c) João Martins
-	Author: João Martins
-	Date: 30/12/2019
+    Copyright: Copyright (c) João Martins
+    Author: João Martins
+    Date: 30/12/2019
 
-	µCNC is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+    µCNC is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version. Please see <http://www.gnu.org/licenses/>
 
-	µCNC is distributed WITHOUT ANY WARRANTY;
-	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the	GNU General Public License for more details.
+    µCNC is distributed WITHOUT ANY WARRANTY;
+    Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the	GNU General Public License for more details.
 */
 
 #include <math.h>
@@ -32,7 +32,7 @@ static uint8_t serial_tx_write;
 static uint8_t serial_read_select;
 static uint16_t serial_read_index;
 
-//static void serial_rx_clear();
+// static void serial_rx_clear();
 
 void serial_init(void)
 {
@@ -166,13 +166,13 @@ unsigned char serial_peek(void)
     return EOL;
 }
 
-void serial_inject_cmd(const unsigned char *__s)
+void serial_inject_cmd(const char *__s)
 {
-    unsigned char c = rom_strptr(__s++);
+    unsigned char c = (unsigned char)rom_strptr(__s++);
     do
     {
         mcu_com_rx_cb(c);
-        c = rom_strptr(__s++);
+        c = (unsigned char)rom_strptr(__s++);
     } while (c != 0);
 }
 
@@ -187,7 +187,7 @@ void serial_putc(unsigned char c)
     while (write == serial_tx_read)
     {
         cnc_dotasks();
-    } //while buffer is full
+    } // while buffer is full
 
     serial_tx_buffer[serial_tx_write] = c;
     serial_tx_write = write;
@@ -204,13 +204,13 @@ void serial_putc(unsigned char c)
 #endif
 }
 
-void serial_print_str(const unsigned char *__s)
+void serial_print_str(const char *__s)
 {
-    unsigned char c = rom_strptr(__s++);
+    unsigned char c = (unsigned char)rom_strptr(__s++);
     do
     {
         serial_putc(c);
-        c = rom_strptr(__s++);
+        c = (unsigned char)rom_strptr(__s++);
     } while (c != 0);
 }
 
@@ -337,13 +337,13 @@ void serial_flush(void)
 #endif
 }
 
-//ISR
-//New char handle strategy
-//All ascii will be sent to buffer and processed later (including comments)
+// ISR
+// New char handle strategy
+// All ascii will be sent to buffer and processed later (including comments)
 void mcu_com_rx_cb(unsigned char c)
 {
     uint8_t write;
-    if (c < ((unsigned char)'~')) //ascii (except CMD_CODE_CYCLE_START and DEL)
+    if (c < ((unsigned char)'~')) // ascii (except CMD_CODE_CYCLE_START and DEL)
     {
         switch (c)
         {
@@ -372,7 +372,7 @@ void mcu_com_rx_cb(unsigned char c)
             break;
         }
     }
-    else //extended ascii (plus CMD_CODE_CYCLE_START and DEL)
+    else // extended ascii (plus CMD_CODE_CYCLE_START and DEL)
     {
         cnc_call_rt_command((uint8_t)c);
     }

--- a/uCNC/src/interface/serial.h
+++ b/uCNC/src/interface/serial.h
@@ -48,13 +48,13 @@ extern "C"
 	unsigned char serial_getc(void);
 	void serial_ungetc(void);
 	unsigned char serial_peek(void);
-	void serial_inject_cmd(const unsigned char *__s);
+	void serial_inject_cmd(const char *__s);
 	void serial_restore_line(void);
 	void serial_rx_clear(void);
 	void serial_select(uint8_t source);
 
 	void serial_putc(unsigned char c);
-	void serial_print_str(const unsigned char *__s);
+	void serial_print_str(const char *__s);
 	void serial_print_int(int32_t num);
 	void serial_print_flt(float num);
 	void serial_print_fltunits(float num);

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -66,6 +66,7 @@ const uint8_t __rom__ crc7_table[256] =
 static uint8_t crc7(uint8_t c, uint8_t crc)
 {
     uint8_t i = 8;
+    crc ^= c;
     for (;;)
     {
         if (crc & 0x80)
@@ -74,7 +75,7 @@ static uint8_t crc7(uint8_t c, uint8_t crc)
         }
         if (!--i)
         {
-            return (crc);
+            return crc;
         }
         crc <<= 1;
     }
@@ -481,7 +482,7 @@ uint8_t settings_change(uint8_t setting, float value)
 #endif
 #if TOOL_COUNT > 0
     case 80:
-        g_settings.default_tool = CLAMP(0, value8, TOOL_COUNT);
+        g_settings.default_tool = CLAMP(0, value8, (uint8_t)TOOL_COUNT);
         break;
 #endif
 #if (KINEMATIC == KINEMATIC_DELTA)

--- a/uCNC/src/module.h
+++ b/uCNC/src/module.h
@@ -38,16 +38,17 @@ extern "C"
     delegate##_event_t *
 #define EVENT_TYPE(delegate) delegate##_event_t
 #define CREATE_LISTENER(delegate, handler) __attribute__((used)) delegate##_event_t delegate##_##handler = {&handler, NULL}
-#define ADD_LISTENER(delegate, handler, event) ({   \
-    extern delegate##_event_t delegate##_##handler; \
-    delegate##_event_t **p = &event;                \
-    while ((*p) != NULL)                            \
-    {                                               \
-        (*p) = (*p)->next;                          \
-    }                                               \
-    (*p) = &delegate##_##handler;                   \
-    (*p)->next = NULL;                              \
-})
+#define ADD_LISTENER(delegate, handler, event)          \
+    {                                                   \
+        extern delegate##_event_t delegate##_##handler; \
+        delegate##_event_t **p = &event;                \
+        while ((*p) != NULL)                            \
+        {                                               \
+            (*p) = (*p)->next;                          \
+        }                                               \
+        (*p) = &delegate##_##handler;                   \
+        (*p)->next = NULL;                              \
+    }
 
     // definitions to create overridable default handlers for functions void-void hooks
     // the resulting handles is named mod_<hookname>_hook and can be placed inside any point in the core code
@@ -60,17 +61,18 @@ extern "C"
     hook##_event;                          \
     void mod_##hook##_hook(void)
 #define WEAK_HOOK(hook) void __attribute__((weak)) mod_##hook##_hook(void)
-#define DEFAULT_HANDLER(hook) ({                     \
-    EVENT_TYPE(hook##_delegate) *ptr = hook##_event; \
-    while (ptr != NULL)                              \
-    {                                                \
-        if (ptr->fptr != NULL)                       \
-        {                                            \
-            ptr->fptr();                             \
-        }                                            \
-        ptr = ptr->next;                             \
-    }                                                \
-})
+#define DEFAULT_HANDLER(hook)                            \
+    {                                                    \
+        EVENT_TYPE(hook##_delegate) *ptr = hook##_event; \
+        while (ptr != NULL)                              \
+        {                                                \
+            if (ptr->fptr != NULL)                       \
+            {                                            \
+                ptr->fptr();                             \
+            }                                            \
+            ptr = ptr->next;                             \
+        }                                                \
+    }
 
 #ifdef ENABLE_PARSER_MODULES
     // defines a delegate function for the gcode parser handler

--- a/uCNC/src/utils.h
+++ b/uCNC/src/utils.h
@@ -28,10 +28,11 @@ extern "C"
 #include <stdbool.h>
 
 #ifndef BYTE_OPS
-#define SETBIT(x, y) ((x) |= (1 << (y)))	/* Set bit y in byte x*/
-#define CLEARBIT(x, y) ((x) &= ~(1 << (y))) /* Clear bit y in byte x*/
-#define CHECKBIT(x, y) ((x) & (1 << (y)))	/* Check bit y in byte x*/
-#define TOGGLEBIT(x, y) ((x) ^= (1 << (y))) /* Toggle bit y in byte x*/
+#define BYTE_OPS
+#define SETBIT(x, y) ((x) |= (1U << (y)))	 /* Set bit y in byte x*/
+#define CLEARBIT(x, y) ((x) &= ~(1U << (y))) /* Clear bit y in byte x*/
+#define CHECKBIT(x, y) ((x) & (1U << (y)))	 /* Check bit y in byte x*/
+#define TOGGLEBIT(x, y) ((x) ^= (1U << (y))) /* Toggle bit y in byte x*/
 
 #define SETFLAG(x, y) ((x) |= (y))	  /* Set byte y in byte x*/
 #define CLEARFLAG(x, y) ((x) &= ~(y)) /* Clear byte y in byte x*/


### PR DESCRIPTION
  - fixed set PWM macro for AVR (cause issues on Mega boards)
  - fixed several C99/GNU99 compliance warnings
  - fixed dir mask implementation ($2)
  - fixed settings crc calculation (without lookup table)
  - fixed output pin toggle macro for AVR
  - fixed AVR RX pin setup
  - fixed BYTE_OPS redefinition