### PR TITLE
laser not turning on with M3 and S word missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,12 +74,7 @@ virtualeeprom
 *.cfg
 windows/uCNCgui/obj/Debug/net6.0-windows/uCNCgui.assets.cache
 windows/uCNCgui/obj/Debug/net6.0-windows/uCNCgui.GeneratedMSBuildEditorConfig.editorconfig
+.vscode
 
 #PlatformIO
 .pio
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/ipch
-.vscode/launch.json
-.vscode/extensions.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 # Changelog
 
+## [1.4.1] - Unreleased
+
+µCNC version 1.4.1 has some bug fixes from the previous version
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+
+- fixed laser not turning on with laser mode enabled and after new feed motion command is issued without S word update and M3 active (#168)
+
+
 ## [1.4.0] - 2022-04-15
 
 µCNC version 1.4.0 packs lots of new features as well as the initial support for SMT32F4 core MCU's, Trinamic drivers, canned cycles, Linear delta robot kinematics and more.

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -349,7 +349,7 @@ extern "C"
    *
    * */
 
-  // #define ENABLE_SYSTEM_INFO
+#define ENABLE_SYSTEM_INFO
 
   /**
    * Enables aditional grbl-type commands

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -553,7 +553,7 @@ void itp_run(void)
         float top_speed_inv = 1 / top_speed;
         int16_t newspindle = planner_get_spindle_speed(MIN(1, avg_speed * top_speed_inv));
 
-        if (prev_spindle != newspindle)
+        if ((prev_spindle != newspindle) || (g_settings.laser_mode && ITP_UPDATE_ISR))
         {
             prev_spindle = newspindle;
             sgm->update_itp |= ITP_UPDATE_TOOL;
@@ -862,7 +862,7 @@ void itp_run(void)
         float top_speed_inv = fast_flt_invsqrt(junction_speed_sqr);
         int16_t newspindle = planner_get_spindle_speed(MIN(1, current_speed * top_speed_inv));
 
-        if (prev_spindle != newspindle)
+        if ((prev_spindle != newspindle) || (g_settings.laser_mode && ITP_UPDATE_ISR))
         {
             prev_spindle = newspindle;
             sgm->update_itp |= ITP_UPDATE_TOOL;

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -540,6 +540,7 @@ DWORD WINAPI virtualserialserver(LPVOID lpParam)
 							recvbuflen = (dwRead > recvbuflen) ? recvbuflen : dwRead;
 							for (int i = 0; i < recvbuflen; i++)
 							{
+								putchar(recvbuf[i]);
 								mcu_com_rx_cb(recvbuf[i]);
 							}
 							memset(recvbuf, 0, sizeof(recvbuf));


### PR DESCRIPTION
fixed laser not turning on with laser mode enabled and after new feed motion command is issued without S word update and M3 active