### PR TITLE
optional G0-G1 without axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 # Changelog
 
+## [1.4.2] - Unreleased
+
+µCNC version 1.4.2 has the following changes
+
+### Added
+
+
+### Changed
+
+- added option to accept G0 and G1 without explicit axis words to target
+
+### Fixed
+
+
 ## [1.4.1] - 2022-04-17
 
 µCNC version 1.4.1 has an important bug fix regarding laser mode and M3 tool mode

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -165,6 +165,11 @@ extern "C"
 #define IGNORE_UNDEFINED_AXIS
 
 /**
+ * accept G0 and G1 without explicit target
+ * */
+#define IGNORE_G0_G1_MISSING_AXIS_WORDS
+
+/**
  * processes and displays the currently executing gcode numbered line
  * */
 

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -759,8 +759,10 @@ static uint8_t parser_validate_command(parser_state_t *new_state, parser_words_t
     {
         switch (new_state->groups.motion)
         {
-        case G0:    // G0
-        case G1:    // G1
+#ifndef IGNORE_G0_G1_MISSING_AXIS_WORDS
+        case G0: // G0
+        case G1: // G1
+#endif
         case G38_2: // G38.2
         case G38_3: // G38.3
         case G38_4: // G38.4


### PR DESCRIPTION
added option to accept G0 and G1 without explicit axis words to target