### PR TITLE
logic error with dual limit switch inverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - position read from motion control was not reversing user geometry transformations (#195)
 - AVR DIN0-7 pins ISR was not enabled (#201)
 - fixed error were coordinates would be forgotten/override if applying multiple G10 commands for different axis (ex. G10L20X0 and G10L20Y0) (#204)
+- fixed logic error when both limits switches are active for an axis (not dual-drive) and are inverted, trigger would only happen if both were pressed (#205)
 
 ## [1.4.3] - 2022-05-02
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -279,8 +279,6 @@ void mcu_rtc_cb(uint32_t millis)
 
 void cnc_home(void)
 {
-    io_invert_limits(0);
-    io_lock_limits(0);
     cnc_set_exec_state(EXEC_HOMING);
     uint8_t error = kinematics_home();
     // unlock expected limits

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -279,10 +279,13 @@ void mcu_rtc_cb(uint32_t millis)
 
 void cnc_home(void)
 {
+    io_invert_limits(0);
+    io_lock_limits(0);
     cnc_set_exec_state(EXEC_HOMING);
     uint8_t error = kinematics_home();
     // unlock expected limits
     io_lock_limits(0);
+    io_invert_limits(0);
     if (error)
     {
         // disables homing and reenables alarm messages

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -192,6 +192,10 @@ uint8_t io_get_limits(void)
     value |= ((mcu_get_input(LIMIT_C)) ? LIMIT_C_MASK : 0);
 #endif
 
+    uint8_t inv = g_settings.limits_invert_mask;
+    uint8_t result = (value ^ (inv & LIMITS_INV_MASK));
+
+#if LIMITS_DUAL_INV_MASK != 0
     uint8_t value2 = 0;
 
 #if !(LIMIT_X2 < 0)
@@ -210,18 +214,20 @@ uint8_t io_get_limits(void)
 // #endif
 #endif
 
-    uint8_t inv = g_settings.limits_invert_mask;
+    result |= (value2 ^ (inv & LIMITS_DUAL_INV_MASK));
 
-    uint8_t result = ((value ^ (inv & LIMITS_INV_MASK)) | (value2 ^ (inv & LIMITS_DUAL_INV_MASK)));
+#endif
 
     if (cnc_get_exec_state(EXEC_HOMING))
     {
         result ^= io_invert_limits_mask;
     }
+#if LIMITS_DUAL_INV_MASK
     else
     {
         result |= io_get_limits_dual();
     }
+#endif
 
     return result;
 }

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -25,6 +25,7 @@ static volatile uint8_t io_spindle_speed;
 #endif
 
 static uint8_t io_lock_limits_mask;
+static uint8_t io_invert_limits_mask;
 
 void mcu_limits_changed_cb(void)
 {
@@ -160,6 +161,11 @@ void io_lock_limits(uint8_t limitmask)
     io_lock_limits_mask = limitmask;
 }
 
+void io_invert_limits(uint8_t limitmask)
+{
+    io_invert_limits_mask = limitmask;
+}
+
 uint8_t io_get_limits(void)
 {
 #ifdef DISABLE_ALL_LIMITS
@@ -186,23 +192,38 @@ uint8_t io_get_limits(void)
     value |= ((mcu_get_input(LIMIT_C)) ? LIMIT_C_MASK : 0);
 #endif
 
+    uint8_t value2 = 0;
+
 #if !(LIMIT_X2 < 0)
-#if !(LIMITS_DUAL_MASK & LIMIT_X_MASK)
-    value |= ((mcu_get_input(LIMIT_X2)) ? LIMIT_X_MASK : 0);
-#endif
+    // #if !(LIMITS_DUAL_MASK & LIMIT_X_MASK)
+    value2 |= ((mcu_get_input(LIMIT_X2)) ? LIMIT_X_MASK : 0);
+// #endif
 #endif
 #if !(LIMIT_Y2 < 0)
-#if !(LIMITS_DUAL_MASK & LIMIT_Y_MASK)
-    value |= ((mcu_get_input(LIMIT_Y2)) ? LIMIT_Y_MASK : 0);
-#endif
+    // #if !(LIMITS_DUAL_MASK & LIMIT_Y_MASK)
+    value2 |= ((mcu_get_input(LIMIT_Y2)) ? LIMIT_Y_MASK : 0);
+// #endif
 #endif
 #if !(LIMIT_Z2 < 0)
-#if !(LIMITS_DUAL_MASK & LIMIT_Z_MASK)
-    value |= ((mcu_get_input(LIMIT_Z2)) ? LIMIT_Z_MASK : 0);
-#endif
+    // #if !(LIMITS_DUAL_MASK & LIMIT_Z_MASK)
+    value2 |= ((mcu_get_input(LIMIT_Z2)) ? LIMIT_Z_MASK : 0);
+// #endif
 #endif
 
-    return (value ^ (g_settings.limits_invert_mask & LIMITS_INV_MASK));
+    uint8_t inv = g_settings.limits_invert_mask;
+
+    uint8_t result = ((value ^ (inv & LIMITS_INV_MASK)) | (value2 ^ (inv & LIMITS_DUAL_INV_MASK)));
+
+    if (cnc_get_exec_state(EXEC_HOMING))
+    {
+        result ^= io_invert_limits_mask;
+    }
+    else
+    {
+        result |= io_get_limits_dual();
+    }
+
+    return result;
 }
 
 uint8_t io_get_limits_dual(void)
@@ -226,7 +247,7 @@ uint8_t io_get_limits_dual(void)
     value |= ((mcu_get_input(LIMIT_Z2)) ? LIMIT_Z_MASK : 0);
 #endif
 #endif
-    return (value ^ (g_settings.limits_invert_mask & LIMITS_DUAL_MASK));
+    return (value ^ (g_settings.limits_invert_mask & LIMITS_DUAL_MASK & LIMITS_DUAL_INV_MASK));
 #endif
 }
 

--- a/uCNC/src/core/io_control.h
+++ b/uCNC/src/core/io_control.h
@@ -35,6 +35,7 @@ extern "C"
 
 	// inputs
 	void io_lock_limits(uint8_t limitmask);
+	void io_invert_limits(uint8_t limitmask);
 	uint8_t io_get_limits(void);
 	uint8_t io_get_limits_dual(void);
 	uint8_t io_get_controls(void);

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -588,7 +588,7 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
     block_data.steps[axis] = max_home_dist;
     // unlocks the machine for next motion (this will clear the EXEC_HALT flag
     // temporary inverts the limit mask to trigger ISR on switch release
-    g_settings.limits_invert_mask ^= axis_limit;
+    io_invert_limits(axis_limit);
 
     cnc_unlock(true);
     // flags homing clear by the unlock
@@ -598,13 +598,13 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
     if (itp_sync() != STATUS_OK)
     {
         // restores limits mask
-        g_settings.limits_invert_mask ^= axis_limit;
+        io_invert_limits(0);
         return STATUS_CRITICAL_FAIL;
     }
 
     cnc_delay_ms(g_settings.debounce_ms); // adds a delay before reading io pin (debounce)
     // resets limit mask
-    g_settings.limits_invert_mask ^= axis_limit;
+    io_invert_limits(0);
     // stops, flushes buffers and clears the hold if active
     cnc_stop();
     // clearing the interpolator unlockes any locked stepper

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -598,7 +598,6 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
     if (itp_sync() != STATUS_OK)
     {
         // restores limits mask
-        io_invert_limits(0);
         return STATUS_CRITICAL_FAIL;
     }
 

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -515,6 +515,7 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
 
     // locks limits to accept axis limit mask only or else throw error
     io_lock_limits(axis_limit);
+    io_invert_limits(0);
     // if HOLD or ALARM are still active or any limit switch is not cleared fails to home
     mcu_limits_changed_cb();
     if (cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM) /*|| CHECKFLAG(io_get_limits(), LIMITS_MASK)*/)


### PR DESCRIPTION
- fixed logic error when both limits switches are active for an axis (not dual-drive) and are inverted, trigger would only happen if both were pressed