### PR TITLE
XOR limits while HOMING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - AVR DIN0-7 pins ISR was not enabled (#201)
 - fixed error were coordinates would be forgotten/override if applying multiple G10 commands for different axis (ex. G10L20X0 and G10L20Y0) (#204)
 - fixed logic error when both limits switches are active for an axis (not dual-drive) and are inverted, trigger would only happen if both were pressed (#205)
+- fixed logic ORING of signals when homing leading to incorrect trigger when self-squaring cause by #205 (#207)
 
 ## [1.4.3] - 2022-05-02
 

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -199,22 +199,22 @@ uint8_t io_get_limits(void)
     uint8_t value2 = 0;
 
 #if !(LIMIT_X2 < 0)
-    // #if !(LIMITS_DUAL_MASK & LIMIT_X_MASK)
+#if !(LIMITS_DUAL_MASK & LIMIT_X_MASK)
     value2 |= ((mcu_get_input(LIMIT_X2)) ? LIMIT_X_MASK : 0);
-// #endif
+#endif
 #endif
 #if !(LIMIT_Y2 < 0)
-    // #if !(LIMITS_DUAL_MASK & LIMIT_Y_MASK)
+#if !(LIMITS_DUAL_MASK & LIMIT_Y_MASK)
     value2 |= ((mcu_get_input(LIMIT_Y2)) ? LIMIT_Y_MASK : 0);
-// #endif
+#endif
 #endif
 #if !(LIMIT_Z2 < 0)
-    // #if !(LIMITS_DUAL_MASK & LIMIT_Z_MASK)
+#if !(LIMITS_DUAL_MASK & LIMIT_Z_MASK)
     value2 |= ((mcu_get_input(LIMIT_Z2)) ? LIMIT_Z_MASK : 0);
-// #endif
+#endif
 #endif
 
-    result |= (value2 ^ (inv & LIMITS_DUAL_INV_MASK));
+    result |= (value2 ^ (inv & LIMITS_DUAL_INV_MASK & ~LIMITS_DUAL_MASK));
 
 #endif
 
@@ -253,7 +253,8 @@ uint8_t io_get_limits_dual(void)
     value |= ((mcu_get_input(LIMIT_Z2)) ? LIMIT_Z_MASK : 0);
 #endif
 #endif
-    return (value ^ (g_settings.limits_invert_mask & LIMITS_DUAL_MASK & LIMITS_DUAL_INV_MASK));
+    uint8_t inv = io_invert_limits_mask & LIMITS_DUAL_MASK;
+    return (value ^ (g_settings.limits_invert_mask & LIMITS_DUAL_MASK & LIMITS_DUAL_INV_MASK) ^ inv);
 #endif
 }
 


### PR DESCRIPTION
- filter limit switch triggering when homing (dual axis) that was being incorrectly mixed after #205