### PR TITLE
moved cnc_dotasks hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - module system complete restructure. Core complementary modules kept in the core code. Remaining modules pulled to a different repository (#215)
 - encoders initial state aquired at startup to prevent initial noise counts (#216)
 - fixed dir mask detection for ENC0 and ENC1 (#216)
+- moved the mod_cnc_dotasks_hook callback to allow it to work even if hold is active (#218)
 
 ### Fixed
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -185,6 +185,10 @@ bool cnc_dotasks(void)
         return !cnc_get_exec_state(EXEC_KILL);
     }
 
+#ifdef ENABLE_MAIN_LOOP_MODULES
+    mod_cnc_dotasks_hook();
+#endif
+
     // check security interlocking for any problem
     if (!cnc_check_interlocking())
     {
@@ -197,10 +201,6 @@ bool cnc_dotasks(void)
         itp_run();
         lock_itp = false;
     }
-
-#ifdef ENABLE_MAIN_LOOP_MODULES
-    mod_cnc_dotasks_hook();
-#endif
 
     return !cnc_get_exec_state(EXEC_KILL);
 }


### PR DESCRIPTION
- moved cnc_dotasks hook to allow this hook to be called even with an active hold state