### PR TITLE
parser tweak for modules

### DIFF
--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1026,7 +1026,7 @@ uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, pa
         }
     }
 
-    // 6. M6 change tool (not implemented yet)
+    // 6. M6 change tool
     if (CHECKFLAG(cmd->groups, GCODE_GROUP_TOOLCHANGE))
     {
         itp_sync();
@@ -2177,14 +2177,12 @@ static uint8_t parser_letter_word(unsigned char c, float value, uint8_t mantissa
         words->xyzabc[AXIS_C] = value;
         break;
 #endif
-#ifdef ENABLE_CANNED_CYCLES
     // treats Q like D since they cannot cooexist
     case 'Q':
         if (value < 0)
         {
             return STATUS_NEGATIVE_VALUE;
         }
-#endif
     case 'D':
         new_words |= GCODE_WORD_D;
         words->d = value;

--- a/uCNC/src/core/parser.h
+++ b/uCNC/src/core/parser.h
@@ -33,6 +33,9 @@ extern "C"
 #include <stdint.h>
 #include <stdbool.h>
 
+#define EXTENDED_MCODE(X) (1000 + X)
+#define EXTENDED_GCODE(X) (0 + X)
+
 // group masks
 #define GCODE_GROUP_MOTION 0x0001
 #define GCODE_GROUP_PLANE 0x0002


### PR DESCRIPTION
- Q word recognized even if canned cycles not enabled
- added macro for extended codes uniformization