### PR TITLE
224 compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@
 
 # Changelog
 
-## [1.4.6] - 2022-06-28
+## [1.4.7] - Unreleased
 
+### Added
+
+
+### Changed
+
+
+### Fixed
+
+- fixed compilation error on STM32F1 if probe pin is not defined
+
+## [1.4.6] - 2022-06-28
 
 ### Added
 

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1222,6 +1222,26 @@ void mcu_init(void)
 	mcu_enable_global_isr();
 }
 
+/**
+ * enables the pin probe mcu isr on change
+ * can be defined either as a function or a macro call
+ * */
+#ifndef mcu_enable_probe_isr
+void mcu_enable_probe_isr(void)
+{
+}
+#endif
+
+/**
+ * disables the pin probe mcu isr on change
+ * can be defined either as a function or a macro call
+ * */
+#ifndef mcu_disable_probe_isr
+void mcu_disable_probe_isr(void)
+{
+}
+#endif
+
 /*IO functions*/
 // IO functions
 void mcu_set_servo(uint8_t servo, uint8_t value)


### PR DESCRIPTION
- fixed compilation error on STM32F1 if probe pin is not defined