### PR TITLE
TMC driver redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@
 
 ### Added
 
-- added Marlin M913 command to TMC driver module
+- added Marlin M913 command to TMC driver module (#226)
 
 ### Changed
 
-- modified TMC driver to include shadow registers of write only
+- modified TMC driver to include shadow registers of write only (#226)
 
 ### Fixed
 
-- fixed compilation error on STM32F1 if probe pin is not defined
-- fixed TMC M914 extension command initialization
+- fixed compilation error on STM32F1 if probe pin is not defined (#225)
+- fixed TMC M914 extension command initialization (#226)
 
 ## [1.4.6] - 2022-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@
 
 ### Added
 
+- added Marlin M913 command to TMC driver module
 
 ### Changed
 
+- modified TMC driver to include shadow registers of write only
 
 ### Fixed
 
 - fixed compilation error on STM32F1 if probe pin is not defined
+- fixed TMC M914 extension command initialization
 
 ## [1.4.6] - 2022-06-28
 

--- a/uCNC/src/modules/tmc.c
+++ b/uCNC/src/modules/tmc.c
@@ -63,6 +63,7 @@ uint32_t tmc_read_register(tmc_driver_t *driver, uint8_t address)
 		switch (driver->type)
 		{
 		case 2209:
+		case 2226:
 			return (address == SGTHRS) ? driver->reg.sgthrs_coolconf : TMC_READ_ERROR;
 		case 2130:
 			return (address == COOLCONF) ? driver->reg.sgthrs_coolconf : TMC_READ_ERROR;
@@ -152,6 +153,7 @@ uint32_t tmc_write_register(tmc_driver_t *driver, uint8_t address, uint32_t val)
 		switch (driver->type)
 		{
 		case 2209:
+		case 2226:
 			if (driver->reg.sgthrs_coolconf == val)
 			{
 				return val;
@@ -493,6 +495,7 @@ int32_t tmc_get_stallguard(tmc_driver_t *driver)
 	switch (driver->type)
 	{
 	case 2209:
+	case 2226:
 		return (driver->reg.sgthrs_coolconf & 0xFF);
 	case 2130:
 		return (driver->reg.sgthrs_coolconf & (1UL << 22)) ? -((driver->reg.sgthrs_coolconf >> 16) & 0x7F) : ((driver->reg.sgthrs_coolconf >> 16) & 0x7F);
@@ -508,6 +511,7 @@ void tmc_set_stallguard(tmc_driver_t *driver, int32_t value)
 	switch (driver->type)
 	{
 	case 2209:
+	case 2226:
 		tmc_write_register(driver, SGTHRS, (uint32_t)value);
 		break;
 	case 2130:

--- a/uCNC/src/modules/tmc.h
+++ b/uCNC/src/modules/tmc.h
@@ -27,17 +27,30 @@ extern "C"
 #include <stdint.h>
 
 #define TMC_READ_ERROR 0xFFFFFFFFUL
+#define TMC_WRITE_ERROR 0xFFFFFFFFUL
 #define GCONF 0x00
+#define IFCNT 0x02
 #define IHOLD_IRUN 0x10
-#define CHOPCONF 0x6C
 #define TPWMTHRS 0X13
 #define TCOOLTHRS 0x14
 #define SGTHRS 0x40
 #define SG_RESULT 0x41
+#define CHOPCONF 0x6C
+#define COOLCONF 0x6D
 #define DRV_STATUS 0x6F
+#define PWMCONF 0x70
 
 	typedef void (*tmc_rw)(uint8_t *, uint8_t, uint8_t);
 	typedef void (*tmc_startup)(void);
+
+	typedef struct
+	{
+		uint8_t ifcnt;
+		uint32_t ihold_irun;
+		uint32_t tpwmthrs;
+		uint32_t tcoolthrs;
+		uint32_t sgthrs_coolconf;
+	} tmc_driver_reg_t;
 
 	typedef struct
 	{
@@ -49,19 +62,21 @@ extern "C"
 		tmc_startup init;
 		// Callback for RW
 		tmc_rw rw;
+		// internal driver registers
+		tmc_driver_reg_t reg;
 	} tmc_driver_t;
 
 	void tmc_init(tmc_driver_t *driver);
 	float tmc_get_current(tmc_driver_t *driver, float rsense);
-	void tmc_set_current(tmc_driver_t *driver, float current, float rsense, float ihold_mul);
+	void tmc_set_current(tmc_driver_t *driver, float current, float rsense, float ihold_mul, uint8_t ihold_delay);
 	int32_t tmc_get_microstep(tmc_driver_t *driver);
 	void tmc_set_microstep(tmc_driver_t *driver, int16_t ms);
 	uint8_t tmc_get_stepinterpol(tmc_driver_t *driver);
 	void tmc_set_stepinterpol(tmc_driver_t *driver, uint8_t enable);
-	uint32_t tmc_get_stealthshop(tmc_driver_t *driver);
-	void tmc_set_stealthchop(tmc_driver_t *driver, uint32_t value);
+	int32_t tmc_get_stealthchop(tmc_driver_t *driver);
+	void tmc_set_stealthchop(tmc_driver_t *driver, int32_t value);
 	int32_t tmc_get_stallguard(tmc_driver_t *driver);
-	void tmc_set_stallguard(tmc_driver_t *driver, int16_t value);
+	void tmc_set_stallguard(tmc_driver_t *driver, int32_t value);
 	uint32_t tmc_get_status(tmc_driver_t *driver);
 	uint32_t tmc_read_register(tmc_driver_t *driver, uint8_t address);
 	uint32_t tmc_write_register(tmc_driver_t *driver, uint8_t address, uint32_t val);

--- a/uCNC/src/modules/tmcdriver.c
+++ b/uCNC/src/modules/tmcdriver.c
@@ -1140,16 +1140,8 @@ DECL_MODULE(tmcdriver)
 	ADD_LISTENER(gcode_exec_delegate, m906_exec, gcode_exec_event);
 	ADD_LISTENER(gcode_parse_delegate, m913_parse, gcode_parse_event);
 	ADD_LISTENER(gcode_exec_delegate, m913_exec, gcode_exec_event);
-	switch (STEPPER2_DRIVER_TYPE)
-	{
-	case 2209:
-	case 2226:
-	case 2130:
-		ADD_LISTENER(gcode_parse_delegate, m914_parse, gcode_parse_event);
-		ADD_LISTENER(gcode_exec_delegate, m914_exec, gcode_exec_event);
-		break;
-	}
-
+	ADD_LISTENER(gcode_parse_delegate, m914_parse, gcode_parse_event);
+	ADD_LISTENER(gcode_exec_delegate, m914_exec, gcode_exec_event);
 	ADD_LISTENER(gcode_parse_delegate, m920_parse, gcode_parse_event);
 	ADD_LISTENER(gcode_exec_delegate, m920_exec, gcode_exec_event);
 #endif

--- a/uCNC/src/modules/tmcdriver.c
+++ b/uCNC/src/modules/tmcdriver.c
@@ -1140,8 +1140,16 @@ DECL_MODULE(tmcdriver)
 	ADD_LISTENER(gcode_exec_delegate, m906_exec, gcode_exec_event);
 	ADD_LISTENER(gcode_parse_delegate, m913_parse, gcode_parse_event);
 	ADD_LISTENER(gcode_exec_delegate, m913_exec, gcode_exec_event);
-	ADD_LISTENER(gcode_parse_delegate, m914_parse, gcode_parse_event);
-	ADD_LISTENER(gcode_exec_delegate, m914_exec, gcode_exec_event);
+	switch (STEPPER2_DRIVER_TYPE)
+	{
+	case 2209:
+	case 2226:
+	case 2130:
+		ADD_LISTENER(gcode_parse_delegate, m914_parse, gcode_parse_event);
+		ADD_LISTENER(gcode_exec_delegate, m914_exec, gcode_exec_event);
+		break;
+	}
+
 	ADD_LISTENER(gcode_parse_delegate, m920_parse, gcode_parse_event);
 	ADD_LISTENER(gcode_exec_delegate, m920_exec, gcode_exec_event);
 #endif


### PR DESCRIPTION
- fixed M914 initialization
- added shadow registers of write only registers of TMC
- changed TMC settings stored in RAM to prevent softreset defaults loading
- added M913 command (stealthchop)