### PR TITLE
Tool correct minimal speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - refactored event/delegate macros now with a single function declaration/signature. Adding new events for extensions is easier (#234)
 - modified grbl system command parser to enable command extensions via modules (#236)
 - modified tools to convert between core speed and tool speed to avoid range/precision compression losses
+- modified parser/planner to correctly calculate tool power output when minimal power is not 0 (example: laser minimal power output when S0) (#240)
 
 ### Fixed
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -695,7 +695,7 @@ void cnc_exec_rt_commands(void)
 			{
 				motion_data_t block = {0};
 #if TOOL_COUNT > 0
-				block.coolant = planner_get_previous_coolant();
+				block.motion_flags.bit.coolant = planner_get_previous_coolant();
 				block.spindle = planner_get_previous_spindle_speed();
 #endif
 				mc_update_tools(&block);

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -1061,7 +1061,7 @@ uint8_t itp_sync(void)
 void itp_sync_spindle(void)
 {
 #if TOOL_COUNT > 0
-	tool_set_speed(planner_get_spindle_speed(0));
+	tool_set_speed(planner_get_spindle_speed(1));
 #endif
 }
 

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -263,7 +263,6 @@ uint8_t mc_line(float *target, motion_data_t *block_data)
 	block_data->feed = (float)max_steps * inv_delta;
 
 	// this contains a motion. Any tool update will be done here
-	block_data->update_tools = false;
 	uint32_t line_segments = 1;
 #if (KINEMATIC != KINEMATIC_DELTA)
 	if (max_steps > MAX_STEPS_PER_LINE)
@@ -319,13 +318,13 @@ uint8_t mc_line(float *target, motion_data_t *block_data)
 				break;
 			}
 		}
-		block_data->is_subsegment = true;
+		block_data->motion_flags.bit.is_subsegment = 1;
 	}
 
 	// stores the new position for the next motion
 	memcpy(mc_last_target, target, sizeof(mc_last_target));
 	block_data->feed = feed;
-	block_data->is_subsegment = false;
+	block_data->motion_flags.bit.is_subsegment = 0;
 	return error;
 }
 

--- a/uCNC/src/core/motion_control.h
+++ b/uCNC/src/core/motion_control.h
@@ -36,6 +36,25 @@ extern "C"
 #define MOTIONCONTROL_PROBE_INVERT 1
 #define MOTIONCONTROL_PROBE_NOALARM_ONFAIL 2
 
+	typedef union
+	{
+		/* data */
+		uint8_t reg;
+		struct
+		{
+			uint8_t feed_override : 1;
+#if TOOL_COUNT > 0
+			uint8_t spindle_running : 1;
+			uint8_t coolant : 2;
+			uint8_t coolant_override : 2;
+#else
+		uint8_t : 5; // unused
+#endif
+			uint8_t is_subsegment : 1;
+			
+		} bit;
+	} motion_flags_t;
+
 	typedef struct
 	{
 #ifdef GCODE_PROCESS_LINE_NUMBERS
@@ -51,12 +70,7 @@ extern "C"
 		int16_t spindle;
 		uint16_t dwell;
 		uint8_t motion_mode;
-#if TOOL_COUNT > 0
-		uint8_t coolant;
-#endif
-		bool update_tools;
-		bool feed_override;
-		bool is_subsegment;
+		motion_flags_t motion_flags;
 	} motion_data_t;
 
 	void mc_init(void);

--- a/uCNC/src/core/motion_control.h
+++ b/uCNC/src/core/motion_control.h
@@ -44,11 +44,11 @@ extern "C"
 		{
 			uint8_t feed_override : 1;
 #if TOOL_COUNT > 0
-			uint8_t spindle_running : 1;
+			uint8_t spindle_running : 2;
 			uint8_t coolant : 2;
 			uint8_t coolant_override : 2;
 #else
-		uint8_t : 5; // unused
+		uint8_t : 6; // unused
 #endif
 			uint8_t is_subsegment : 1;
 			
@@ -67,7 +67,7 @@ extern "C"
 		step_t total_steps;	 // the number of pulses needed to generate all steps (maximum of all linear actuators)
 		float feed;
 		uint8_t main_stepper;
-		int16_t spindle;
+		uint16_t spindle;
 		uint16_t dwell;
 		uint8_t motion_mode;
 		motion_flags_t motion_flags;

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1087,18 +1087,16 @@ uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, pa
 	}
 
 	// 7. spindle on/off
+	block_data.spindle = new_state->spindle;
 	switch (new_state->groups.spindle_turning)
 	{
-	case M3:
-		block_data.spindle = new_state->spindle;
-		block_data.motion_flags.bit.spindle_running = 1;
-		break;
 	case M4:
-		block_data.spindle = -new_state->spindle;
+		block_data.spindle = -block_data.spindle;
+		// continue
+	case M3:
 		block_data.motion_flags.bit.spindle_running = 1;
 		break;
 	case M5:
-		block_data.spindle = 0;
 		block_data.motion_flags.bit.spindle_running = 0;
 		break;
 	}
@@ -1417,6 +1415,7 @@ uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, pa
 		if (CHECKFLAG(cmd->words, GCODE_ALL_AXIS))
 		{
 			error = mc_line(target, &block_data);
+			update_tools = false;
 			if (error)
 			{
 				return error;
@@ -1570,6 +1569,8 @@ uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, pa
 			return error;
 		}
 
+		// tool is updated in motion
+		update_tools = false;
 		// saves position
 		memcpy(parser_last_pos, target, sizeof(parser_last_pos));
 	}

--- a/uCNC/src/core/parser.h
+++ b/uCNC/src/core/parser.h
@@ -170,7 +170,7 @@ extern "C"
 		float feedrate;
 #if TOOL_COUNT > 0
 		uint8_t tool_index;
-		int16_t spindle;
+		uint16_t spindle;
 #endif
 #ifdef GCODE_PROCESS_LINE_NUMBERS
 		uint32_t line;

--- a/uCNC/src/core/planner.c
+++ b/uCNC/src/core/planner.c
@@ -464,10 +464,8 @@ int16_t planner_get_spindle_speed(float scale)
 {
 	if (planner_state.state_flags.bit.spindle_running)
 	{
-		int16_t spindle = planner_state.spindle_speed;
-
-		bool neg = (spindle < 0);
-		float scaled_spindle = (float)ABS(spindle);
+		float scaled_spindle = (float)planner_state.spindle_speed;
+		bool neg = (planner_state.state_flags.bit.spindle_running == 2);
 
 		if (g_settings.laser_mode && neg) // scales laser power only if invert is active (M4)
 		{

--- a/uCNC/src/core/planner.c
+++ b/uCNC/src/core/planner.c
@@ -1,4 +1,4 @@
-/*
+/**
 	Name: planner.c
 	Description: Chain planner for linear motions and acceleration/deacceleration profiles.
 		It uses a similar algorithm to Grbl.
@@ -23,25 +23,24 @@
 #include <math.h>
 #include <float.h>
 
+
+
 typedef struct
 {
 	uint8_t feed_override;
 	uint8_t rapid_feed_override;
 #if TOOL_COUNT > 0
-	uint8_t spindle_override;
-	uint8_t coolant_override;
+	int16_t spindle_speed;
+	uint8_t spindle_speed_override;
+	planner_flags_t state_flags;
 #endif
-} planner_overrides_t;
+} planner_state_t;
 
-#if TOOL_COUNT > 0
-static int16_t planner_spindle;
-static uint8_t planner_coolant;
-#endif
 static planner_block_t planner_data[PLANNER_BUFFER_SIZE];
 static uint8_t planner_data_write;
 static uint8_t planner_data_read;
 static uint8_t planner_data_blocks;
-static planner_overrides_t planner_overrides;
+static planner_state_t planner_state;
 static uint8_t planner_ovr_counter;
 
 FORCEINLINE static void planner_add_block(void);
@@ -75,14 +74,14 @@ void planner_add_line(motion_data_t *block_data)
 	memset(&planner_data[planner_data_write], 0, sizeof(planner_block_t));
 	planner_data[planner_data_write].dirbits = block_data->dirbits;
 	planner_data[planner_data_write].main_stepper = block_data->main_stepper;
-	planner_data[planner_data_write].flags_u.flags_t.feed_override = block_data->feed_override;
+	planner_data[planner_data_write].planner_flags.reg = block_data->motion_flags.reg & STATE_COPY_FLAG_MASK; //copies the motion flags relative to coolant spindle running and feed_override
 
 #if TOOL_COUNT > 0
-	planner_spindle = planner_data[planner_data_write].spindle = block_data->spindle;
-	planner_coolant = planner_data[planner_data_write].flags_u.flags_t.coolant = block_data->coolant;
+	planner_data[planner_data_write].spindle = block_data->spindle;
 #endif
 #ifdef GCODE_PROCESS_LINE_NUMBERS
 	planner_data[planner_data_write].line = block_data->line;
+
 #endif
 
 #ifdef ENABLE_BACKLASH_COMPENSATION
@@ -112,7 +111,7 @@ void planner_add_line(motion_data_t *block_data)
 	memset(dir_vect, 0, sizeof(dir_vect));
 #else
 
-	if (!block_data->is_subsegment)
+	if (!block_data->motion_flags.bit.is_subsegment)
 	{
 		for (uint8_t i = AXIS_COUNT; i != 0;)
 		{
@@ -201,7 +200,7 @@ void planner_add_line(motion_data_t *block_data)
 	// if more than one move stored cals juntion speeds and recalculates speed profiles
 	if (cos_theta != 0 && !CHECKFLAG(block_data->motion_mode, PLANNER_MOTION_EXACT_STOP | MOTIONCONTROL_MODE_BACKLASH_COMPENSATION))
 	{
-		if (!block_data->is_subsegment)
+		if (!block_data->motion_flags.bit.is_subsegment)
 		{
 			// calculates the junction angle with previous
 			if (cos_theta > 0)
@@ -250,27 +249,52 @@ void planner_add_line(motion_data_t *block_data)
 
 static void planner_add_block(void)
 {
-	if (++planner_data_write == PLANNER_BUFFER_SIZE)
+	uint8_t index = planner_data_write;
+#if TOOL_COUNT > 0
+	// planner is empty update tools with current planner values
+	if (!planner_data_blocks)
 	{
-		planner_data_write = 0;
+		planner_state.spindle_speed = planner_data[index].spindle;
+		planner_state.state_flags.reg = planner_data[index].planner_flags.reg;
+	}
+#endif
+
+	if (++index == PLANNER_BUFFER_SIZE)
+	{
+		index = 0;
 	}
 
+	planner_data_write = index;
 	planner_data_blocks++;
 }
 
 void planner_discard_block(void)
 {
-	if (!planner_data_blocks)
+	uint8_t blocks = planner_data_blocks;
+	if (!blocks)
 	{
 		return;
 	}
 
-	if (++planner_data_read == PLANNER_BUFFER_SIZE)
+	uint8_t index = planner_data_read;
+
+	if (++index == PLANNER_BUFFER_SIZE)
 	{
-		planner_data_read = 0;
+		index = 0;
 	}
 
-	planner_data_blocks--;
+	blocks--;
+
+#if TOOL_COUNT > 0
+	// planner is empty update tools with current planner values
+	if (!blocks)
+	{
+		planner_state.spindle_speed = planner_data[index].spindle;
+		planner_state.state_flags.reg = planner_data[index].planner_flags.reg;
+	}
+#endif
+	planner_data_blocks = blocks;
+	planner_data_read = index;
 }
 
 static uint8_t planner_buffer_next(uint8_t index)
@@ -317,8 +341,8 @@ void planner_init(void)
 {
 #ifdef FORCE_GLOBALS_TO_0
 #if TOOL_COUNT > 0
-	planner_spindle = 0;
-	planner_coolant = 0;
+	planner_state.planner_spindle = 0;
+	planner_state.coolant = 0;
 #endif
 #endif
 	planner_buffer_clear();
@@ -335,8 +359,8 @@ void planner_clear(void)
 	// clears all motions stored in the buffer
 	planner_buffer_clear();
 #if TOOL_COUNT > 0
-	planner_spindle = 0;
-	planner_coolant = 0;
+	planner_state.spindle_speed = 0;
+	planner_state.state_flags.reg = 0;
 #endif
 }
 
@@ -356,18 +380,18 @@ float planner_get_block_exit_speed_sqr(void)
 	float exit_speed_sqr = planner_data[next].entry_feed_sqr;
 	float rapid_feed_sqr = planner_data[next].rapid_feed_sqr;
 
-	if (planner_data[next].flags_u.flags_t.feed_override)
+	if (planner_data[next].planner_flags.bit.feed_override)
 	{
-		if (planner_overrides.feed_override != 100)
+		if (planner_state.feed_override != 100)
 		{
-			exit_speed_sqr *= fast_flt_pow2((float)planner_overrides.feed_override);
+			exit_speed_sqr *= fast_flt_pow2((float)planner_state.feed_override);
 			exit_speed_sqr *= 0.0001f;
 		}
 
 		// if rapid overrides are active the feed must not exceed the rapid motion feed
-		if (planner_overrides.rapid_feed_override != 100)
+		if (planner_state.rapid_feed_override != 100)
 		{
-			rapid_feed_sqr *= fast_flt_pow2((float)planner_overrides.rapid_feed_override);
+			rapid_feed_sqr *= fast_flt_pow2((float)planner_state.rapid_feed_override);
 			rapid_feed_sqr *= 0.0001f;
 		}
 	}
@@ -416,18 +440,18 @@ float planner_get_block_top_speed(float exit_speed_sqr)
 
 	float rapid_feed_sqr = planner_data[planner_data_read].rapid_feed_sqr;
 	float target_speed_sqr = planner_data[planner_data_read].feed_sqr;
-	if (planner_data[planner_data_read].flags_u.flags_t.feed_override)
+	if (planner_data[planner_data_read].planner_flags.bit.feed_override)
 	{
-		if (planner_overrides.feed_override != 100)
+		if (planner_state.feed_override != 100)
 		{
-			target_speed_sqr *= fast_flt_pow2((float)planner_overrides.feed_override);
+			target_speed_sqr *= fast_flt_pow2((float)planner_state.feed_override);
 			target_speed_sqr *= 0.0001f;
 		}
 
 		// if rapid overrides are active the feed must not exceed the rapid motion feed
-		if (planner_overrides.rapid_feed_override != 100)
+		if (planner_state.rapid_feed_override != 100)
 		{
-			rapid_feed_sqr *= fast_flt_pow2((float)planner_overrides.rapid_feed_override);
+			rapid_feed_sqr *= fast_flt_pow2((float)planner_state.rapid_feed_override);
 			rapid_feed_sqr *= 0.0001f;
 		}
 	}
@@ -440,48 +464,39 @@ float planner_get_block_top_speed(float exit_speed_sqr)
 #if TOOL_COUNT > 0
 int16_t planner_get_spindle_speed(float scale)
 {
-	int16_t spindle = (!planner_data_blocks) ? planner_spindle : planner_data[planner_data_read].spindle;
+	int16_t spindle = (!planner_data_blocks) ? planner_state.spindle_speed : planner_data[planner_data_read].spindle;
 
-	if (spindle != 0)
+	bool neg = (spindle < 0);
+	float scaled_spindle = (float)ABS(spindle);
+
+	if (g_settings.laser_mode && neg) // scales laser power only if invert is active (M4)
 	{
-		bool neg = (spindle < 0);
-		float scaled_spindle = (float)ABS(spindle);
-
-		if (g_settings.laser_mode && neg) // scales laser power only if invert is active (M4)
-		{
-			scaled_spindle *= scale; // scale calculated in laser mode (otherwise scale is always 1)
-		}
-
-		if (planner_data[planner_data_read].flags_u.flags_t.feed_override && planner_overrides.spindle_override != 100)
-		{
-			scaled_spindle = 0.01f * (float)planner_overrides.spindle_override * scaled_spindle;
-		}
-		scaled_spindle = CLAMP(g_settings.spindle_min_rpm, scaled_spindle, g_settings.spindle_max_rpm);
-		int16_t output = tool_range_speed(scaled_spindle);
-
-		return (!neg) ? output : -output;
+		scaled_spindle *= scale; // scale calculated in laser mode (otherwise scale is always 1)
 	}
 
-	return 0;
+	if (planner_data[planner_data_read].planner_flags.bit.feed_override && planner_state.spindle_speed_override != 100)
+	{
+		scaled_spindle = 0.01f * (float)planner_state.spindle_speed_override * scaled_spindle;
+	}
+	scaled_spindle = CLAMP(g_settings.spindle_min_rpm, scaled_spindle, g_settings.spindle_max_rpm);
+	int16_t output = tool_range_speed(scaled_spindle);
+
+	return (!neg) ? output : -output;
 }
 
 float planner_get_previous_spindle_speed(void)
 {
-	return (float)planner_spindle;
+	return (float)planner_state.spindle_speed;
 }
 
 uint8_t planner_get_coolant(void)
 {
-	uint8_t coolant = (!planner_data_blocks) ? planner_coolant : planner_data[planner_data_read].flags_u.flags_t.coolant;
-
-	coolant ^= planner_overrides.coolant_override;
-
-	return coolant;
+	return (planner_state.state_flags.bit.coolant ^ planner_state.state_flags.bit.coolant_override);
 }
 
 uint8_t planner_get_previous_coolant(void)
 {
-	return planner_coolant;
+	return planner_state.state_flags.bit.coolant;
 }
 #endif
 
@@ -501,7 +516,7 @@ static void planner_recalculate(void)
 	// optimizes entry speeds given the current exit speed (backward pass)
 	uint8_t next = planner_buffer_next(block);
 
-	while (!planner_data[block].flags_u.flags_t.optimal && block != first)
+	while (!planner_data[block].planner_flags.bit.optimal && block != first)
 	{
 		float speedchange = ((float)(planner_data[block].total_steps << 1)) * planner_data[block].acceleration;
 		if (planner_data[block].entry_feed_sqr != planner_data[block].entry_max_feed_sqr)
@@ -535,7 +550,7 @@ static void planner_recalculate(void)
 				// lowers next entry speed (aka exit speed) to the maximum reachable speed from current block
 				// optimization achieved for this movement
 				planner_data[next].entry_feed_sqr = MIN(planner_data[next].entry_max_feed_sqr, speedchange);
-				planner_data[next].flags_u.flags_t.optimal = true;
+				planner_data[next].planner_flags.bit.optimal = true;
 			}
 		}
 
@@ -553,22 +568,22 @@ static void planner_recalculate(void)
 void planner_sync_tools(motion_data_t *block_data)
 {
 #if TOOL_COUNT > 0
-	planner_spindle = block_data->spindle;
-	planner_coolant = block_data->coolant;
+	planner_state.spindle_speed = block_data->spindle;
+	planner_state.state_flags.bit.coolant = block_data->motion_flags.bit.coolant;
 #endif
 }
 
 // overrides
 void planner_feed_ovr_inc(uint8_t value)
 {
-	uint8_t ovr_val = planner_overrides.feed_override;
+	uint8_t ovr_val = planner_state.feed_override;
 	ovr_val += value;
 	ovr_val = MAX(ovr_val, FEED_OVR_MIN);
 	ovr_val = MIN(ovr_val, FEED_OVR_MAX);
 
-	if (ovr_val != planner_overrides.feed_override)
+	if (ovr_val != planner_state.feed_override)
 	{
-		planner_overrides.feed_override = ovr_val;
+		planner_state.feed_override = ovr_val;
 		planner_ovr_counter = 0;
 		itp_update();
 	}
@@ -576,9 +591,9 @@ void planner_feed_ovr_inc(uint8_t value)
 
 void planner_rapid_feed_ovr(uint8_t value)
 {
-	if (planner_overrides.rapid_feed_override != value)
+	if (planner_state.rapid_feed_override != value)
 	{
-		planner_overrides.rapid_feed_override = value;
+		planner_state.rapid_feed_override = value;
 		planner_ovr_counter = 0;
 		itp_update();
 	}
@@ -586,9 +601,9 @@ void planner_rapid_feed_ovr(uint8_t value)
 
 void planner_feed_ovr_reset(void)
 {
-	if (planner_overrides.feed_override != 100)
+	if (planner_state.feed_override != 100)
 	{
-		planner_overrides.feed_override = 100;
+		planner_state.feed_override = 100;
 		planner_ovr_counter = 0;
 		itp_update();
 	}
@@ -596,9 +611,9 @@ void planner_feed_ovr_reset(void)
 
 void planner_rapid_feed_ovr_reset(void)
 {
-	if (planner_overrides.rapid_feed_override != 100)
+	if (planner_state.rapid_feed_override != 100)
 	{
-		planner_overrides.rapid_feed_override = 100;
+		planner_state.rapid_feed_override = 100;
 		planner_ovr_counter = 0;
 		itp_update();
 	}
@@ -607,34 +622,34 @@ void planner_rapid_feed_ovr_reset(void)
 #if TOOL_COUNT > 0
 void planner_spindle_ovr_inc(uint8_t value)
 {
-	uint8_t ovr_val = planner_overrides.spindle_override;
+	uint8_t ovr_val = planner_state.spindle_speed_override;
 	ovr_val += value;
 	ovr_val = MAX(ovr_val, SPINDLE_OVR_MIN);
 	ovr_val = MIN(ovr_val, SPINDLE_OVR_MAX);
 
-	if (ovr_val != planner_overrides.spindle_override)
+	if (ovr_val != planner_state.spindle_speed_override)
 	{
-		planner_overrides.spindle_override = ovr_val;
+		planner_state.spindle_speed_override = ovr_val;
 		planner_ovr_counter = 0;
 	}
 }
 
 void planner_spindle_ovr_reset(void)
 {
-	planner_overrides.spindle_override = 100;
+	planner_state.spindle_speed_override = 100;
 	planner_ovr_counter = 0;
 }
 
 uint8_t planner_coolant_ovr_toggle(uint8_t value)
 {
-	planner_overrides.coolant_override ^= value;
-	return planner_overrides.coolant_override;
+	planner_state.state_flags.bit.coolant_override ^= value;
+	return planner_state.state_flags.bit.coolant_override;
 }
 
 void planner_coolant_ovr_reset(void)
 {
-	planner_coolant = 0;
-	planner_overrides.coolant_override = 0;
+	planner_state.state_flags.bit.coolant = 0;
+	planner_state.state_flags.bit.coolant_override = 0;
 }
 #endif
 
@@ -642,10 +657,10 @@ bool planner_get_overflows(uint8_t *overflows)
 {
 	if (!planner_ovr_counter)
 	{
-		overflows[0] = planner_overrides.feed_override;
-		overflows[1] = planner_overrides.rapid_feed_override;
+		overflows[0] = planner_state.feed_override;
+		overflows[1] = planner_state.rapid_feed_override;
 #if TOOL_COUNT > 0
-		overflows[2] = planner_overrides.spindle_override;
+		overflows[2] = planner_state.spindle_speed_override;
 #else
 		overflows[2] = 0;
 #endif

--- a/uCNC/src/core/planner.h
+++ b/uCNC/src/core/planner.h
@@ -36,7 +36,7 @@ extern "C"
 #define PLANNER_MOTION_EXACT_STOP 64
 #define PLANNER_MOTION_CONTINUOUS 128
 
-#define STATE_COPY_FLAG_MASK 0x3F
+#define STATE_COPY_FLAG_MASK 0x0F
 typedef union
 	{
 		uint8_t reg;

--- a/uCNC/src/core/planner.h
+++ b/uCNC/src/core/planner.h
@@ -36,7 +36,7 @@ extern "C"
 #define PLANNER_MOTION_EXACT_STOP 64
 #define PLANNER_MOTION_CONTINUOUS 128
 
-#define STATE_COPY_FLAG_MASK 0x0F
+#define STATE_COPY_FLAG_MASK 0x1F
 typedef union
 	{
 		uint8_t reg;
@@ -44,11 +44,11 @@ typedef union
 		{
 			uint8_t feed_override : 1;
 #if TOOL_COUNT > 0
-			uint8_t spindle_running : 1;
+			uint8_t spindle_running : 2;
 			uint8_t coolant : 2;
 			uint8_t coolant_override : 2;
 #else
-		uint8_t : 5; // unused
+		uint8_t : 6; // unused
 #endif
 			uint8_t optimal : 1;
 			uint8_t backlash_comp : 1;

--- a/uCNC/src/core/planner.h
+++ b/uCNC/src/core/planner.h
@@ -36,6 +36,25 @@ extern "C"
 #define PLANNER_MOTION_EXACT_STOP 64
 #define PLANNER_MOTION_CONTINUOUS 128
 
+#define STATE_COPY_FLAG_MASK 0x3F
+typedef union
+	{
+		uint8_t reg;
+		struct
+		{
+			uint8_t feed_override : 1;
+#if TOOL_COUNT > 0
+			uint8_t spindle_running : 1;
+			uint8_t coolant : 2;
+			uint8_t coolant_override : 2;
+#else
+		uint8_t : 5; // unused
+#endif
+			uint8_t optimal : 1;
+			uint8_t backlash_comp : 1;
+		} bit;
+	} planner_flags_t;
+
 	typedef struct planner_block_
 	{
 #ifdef GCODE_PROCESS_LINE_NUMBERS
@@ -55,20 +74,8 @@ extern "C"
 #if TOOL_COUNT > 0
 		int16_t spindle;
 #endif
-
 		uint8_t action;
-		union flags_u_
-		{
-			struct flags_t_
-			{
-				uint8_t coolant : 2;
-				uint8_t optimal : 1;
-				uint8_t feed_override : 1;
-				uint8_t backlash_comp : 1;
-			} flags_t;
-			uint8_t flags;
-		} flags_u;
-
+		planner_flags_t planner_flags;
 	} planner_block_t;
 
 	void planner_init(void);

--- a/uCNC/src/hal/tools/tools/laser.c
+++ b/uCNC/src/hal/tools/tools/laser.c
@@ -63,8 +63,8 @@ void laser_set_speed(int16_t value)
 int16_t laser_range_speed(float value)
 {
 	// converts core tool speed to laser power (PWM)
-	value = (255.0f - PWM_MIN_VALUE) * (value / g_settings.spindle_max_rpm);
-	return ((int16_t)value + PWM_MIN_VALUE);
+	value = PWM_MIN_VALUE + ((255.0f - PWM_MIN_VALUE) * (value / g_settings.spindle_max_rpm));
+	return (int16_t)value;
 }
 
 void laser_set_coolant(uint8_t value)

--- a/uCNC/src/hal/tools/tools/laser.c
+++ b/uCNC/src/hal/tools/tools/laser.c
@@ -32,7 +32,7 @@
 #define LASER_PWM PWM0
 #define COOLANT_FLOOD DOUT1
 // this sets the minimum power (laser will never fully turn off during engraving and prevents power up delays)
-#define PWM_MIN_VALUE 5
+#define PWM_MIN_VALUE 2
 
 static bool previous_laser_mode;
 


### PR DESCRIPTION
- modified tool speed/direction calculation to correctly set the minimal output speed or do a full stop. An example of this is the minimal ouput of a PWM controlled laser tool that sets a minimal PWM ouput to make laser response faster from 0 to desired value.