### PR TITLE
Better µs delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - modified grbl system command parser to enable command extensions via modules (#236)
 - modified tools to convert between core speed and tool speed to avoid range/precision compression losses
 - modified parser/planner to correctly calculate tool power output when minimal power is not 0 (example: laser minimal power output when S0) (#240)
+- better µs delay for all paltforms (now accepts 16bit value as argument) and better precision for AVR (#241)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - modified grbl system command parser to enable command extensions via modules (#236)
 - modified tools to convert between core speed and tool speed to avoid range/precision compression losses
 - modified parser/planner to correctly calculate tool power output when minimal power is not 0 (example: laser minimal power output when S0) (#240)
-- better µs delay for all paltforms (now accepts 16bit value as argument) and better precision for AVR (#241)
+- better µs delay for all platforms (now accepts 16bit value as argument) and better precision for AVR (#241)
 
 ### Fixed
 
@@ -30,7 +30,7 @@
 
 ### Added
 
-- added core support for ESP8266 with limitied functionalities (lacks analog and input ISR) (#222)
+- added core support for ESP8266 with limited functionalities (lacks analog and input ISR) (#222)
 - added support for NXP LPC176x core (lacks EEPROM and analog) (#227)
 
 ### Changed
@@ -67,13 +67,13 @@
 - added software I2C (bit-banging) (#215)
 - removed encoders dependency of modules. Stepper encoders and regular encoders reset is now independent (#216)
 - encoders counting pulse and direction can be inverted via setting $8 and $9 (#216)
-- modified settings initialization code. Added option to hase settings on RAM only (volatile) (#217)
+- modified settings initialization code. Added option to store settings on RAM only (volatile) (#217)
 - added option to store G92 offset in non volatile memory to prevent undesired wear (#221)
 
 ### Changed
 
 - module system complete restructure. Core complementary modules kept in the core code. Remaining modules pulled to a different repository (#215)
-- encoders initial state aquired at startup to prevent initial noise counts (#216)
+- encoders initial state acquired at startup to prevent initial noise counts (#216)
 - fixed dir mask detection for ENC0 and ENC1 (#216)
 - moved the mod_cnc_dotasks_hook callback to allow it to work even if hold is active (#218)
 
@@ -118,7 +118,7 @@ Next release will will have some extensive changes in µCNC modules to make it m
 ### Changed
 
 - overridable F_STEP_MAX and F_STEP_MIN (#190)
-- removed kinematic transformations filter from JOG motions to prevent inpredictable motions after forced motion systems sync (#195)
+- removed kinematic transformations filter from JOG motions to prevent unpredictable motions after forced motion systems sync (#195)
 - modified Grbl compatible startup message (#196)
 - updated M42 to reflect current HAL IO convention (#197)
 - added servo pins configurations to RAMPS boardmap (pins D4, D5, D6 and D11) (#197)
@@ -132,14 +132,14 @@ Next release will will have some extensive changes in µCNC modules to make it m
 ### Fixed
 
 - fixed typo in error constant name (#184)
-- fixed G49 was not reseting TLO (#188)
+- fixed G49 was not resetting TLO (#188)
 - fixed motion systems unsync after recovering from emergency stop (#193)
 - emergency stop press was not stopping tool as expected (#192)
 - position read from motion control was not reversing user geometry transformations (#195)
 - AVR DIN0-7 pins ISR was not enabled (#201)
 - fixed error were coordinates would be forgotten/override if applying multiple G10 commands for different axis (ex. G10L20X0 and G10L20Y0) (#204)
 - fixed logic error when both limits switches are active for an axis (not dual-drive) and are inverted, trigger would only happen if both were pressed (#205)
-- fixed logic ORING of signals when homing leading to incorrect trigger when self-squaring cause by #205 (#207)
+- fixed logic ORIGIN of signals when homing leading to incorrect trigger when self-squaring cause by #205 (#207)
 - fixed G28-G30 not updating parser position leading to intermediate travel on next command (#211)
 
 ## [1.4.3] - 2022-05-02
@@ -167,7 +167,7 @@ Next release will will have some extensive changes in µCNC modules to make it m
 - fixed missing stepper 6 and 7 DIR and EN pins from HAL (#175)
 - redesigned axis dual endstop trigger with limits inverted (#175)
 - wrong limit switch trigger during home with dual axis enabled was not being detected (#175)
-- redesigned axis dual limit switch detection. Non dual drive axis limits are combined to detect colisions in min and max (#180)
+- redesigned axis dual limit switch detection. Non dual drive axis limits are combined to detect collisions in min and max (#180)
 
 ## [1.4.2] - 2022-04-19
 
@@ -226,7 +226,7 @@ A special thank you note to Alexandros Angelidis (bastardazzo) for all the time 
 
 - fixed tmc soft uart input pins (#163)
 - fixed missing feedback message after settings reset command $RST ($164)
-- invalid eeprom reset and $RST=\* now also clears N0 and N1 blocks as expected ($164)
+- invalid EEPROM reset and $RST=\* now also clears N0 and N1 blocks as expected ($164)
 - forced control pin checking to prevent undesired motion unlock while control pin state still active ($164)
 - fixed tool length offset setting index
 - fixed rounding error when printing float numbers close to the next integer value (#166)
@@ -264,7 +264,7 @@ It also adds Trinamic driver support as well as RAMBO board hardware improvement
 - added softuart (bit-banging) module (#152)
 - added TMC drivers integration. UART drivers are supported. SPI drivers are not tested. Optional M350, M906 and M920 commands available. (#155)
 - added digital MSTEP pin support (RAMBO board and similar). Optional M351 command available. (#156)
-- added digital potentiometer for stepper current regulationvia SPI driver support (RAMBO board and similar). Optional M907 command available. (#156)
+- added digital potentiometer for stepper current regulation via SPI driver support (RAMBO board and similar). Optional M907 command available. (#156)
 - added softspi (bit-banging) module (#156)
 
 ### Changed
@@ -286,7 +286,7 @@ It also adds Trinamic driver support as well as RAMBO board hardware improvement
 ## [1.4.0-beta] - 2022-03-15
 
 µCNC version 1.4.0 packs lots of new features as well as the initial support for SMT32F4 core MCU's.
-Beta release fixes several issues detected in the alpha version. It also expans the generic pins capabilities for future expansions.
+Beta release fixes several issues detected in the alpha version. It also expands the generic pins capabilities for future expansions.
 
 ### Added
 
@@ -438,7 +438,7 @@ It also adds a couple of important fixes that affected step generation with Dyna
 
 ## [1.3.3] - 2022-01-07
 
-µCNC version 1.3.3 aims to addresse several critical bug fixes in the gcode parsing (some of them introduced in the current major release):
+µCNC version 1.3.3 aims to addressed several critical bug fixes in the gcode parsing (some of them introduced in the current major release):
 It also removes `G43.1` (non compliant RS274NGC command) and replaces it with the `G43` compliant version. It still accepts the `Z` word. For tool lengths the `H` word should be used.
 Tool lengths can be set and stored in settings `$41=<Tool1 offset>..$42=<Tool2 offset>...etc`. Also the default tool loaded at start/reset is stored via setting `$40`.
 Encoders are also working in uni and bidirectional mode. Each encoder position is also reported by command `$P` available via `config.h`
@@ -483,7 +483,7 @@ Encoders are also working in uni and bidirectional mode. Each encoder position i
 
 ## [1.3.2] - 2022-01-05
 
-µCNC version 1.3.2 aims to addresse several critical bug fixes in the gcode parsing (some of them introduced in the current major release):
+µCNC version 1.3.2 aims to addressed several critical bug fixes in the gcode parsing (some of them introduced in the current major release):
 
 ### Changed
 
@@ -528,7 +528,7 @@ Encoders are also working in uni and bidirectional mode. Each encoder position i
 
 - added tool PID to cnc scheduled tasks (#95)
 - fixed encoder module missing dir function and pulse previous state not being stored (#94)
-- fixed input/limits/control ISR reentrancy in SAMD21 and STM32 (#94)
+- fixed input/limits/control ISR reentrance in SAMD21 and STM32 (#94)
 - call missing encoder update on input isr callback (#94)
 - return argument on get_encoder_pos (#94)
 
@@ -566,9 +566,9 @@ RC adds/fixes the following issue:
 ### Changed
 
 - modified some NVIC IRQ and global interrupt enable and disable inside ISR code in STM32 and SAMD21 (#75)
-- modified RTC to prevent reentrancy inside ISR code in STM32 and SAMD21 (#75)
+- modified RTC to prevent reentrance inside ISR code in STM32 and SAMD21 (#75)
 - modified planner buffer size in AVR size to prevent memory errors (#77)
-- planner and interpolator block and segment buffer slots are cleaned before writting data to prevent errors from previous data. (#77)
+- planner and interpolator block and segment buffer slots are cleaned before writing data to prevent errors from previous data. (#77)
 - step ISR optimizations (for main stepper and idle steppers) are now optional. (#77)
 - new AVR make file (#82)
 - modified/simplified parser G90/G91 (absolute/relative coordinates) (#83)
@@ -578,11 +578,11 @@ RC adds/fixes the following issue:
 ### Fixed
 
 - fixed issue with active CS_RES input that caused resume condition (delay) without active hold present (#75)
-- fixed SAMD21 PWM frequency configuration (now is aprox 976Hz like AVR) (#78)
+- fixed SAMD21 PWM frequency configuration (now is aprox. 976Hz like AVR) (#78)
 - real line number (N word) processing was not being read (#81)
 - fixed welcome message not being sent after soft reset (#79)
 - fixed step generation ISR random problems (stop working). This was caused by problems in the segment buffer read write. Solved by adding atomic lock blocks to the code (#85)
-- G28 and G30 now perform in whatever coordinate mode before travelling home (RS274NGC compliant) (#83)
+- G28 and G30 now perform in whatever coordinate mode before traveling home (RS274NGC compliant) (#83)
 
 ## [1.3.b2] - 2021-12-14
 
@@ -669,7 +669,7 @@ The following things were changed:
 
 ### Fixed
 
-- fixed flash eeprom reading that caused SMT32F1 to hang with USB virtual COM port. SMT32F1 default value for errased flash is 0xFF and not 0x00. This caused the startup blocks to read a sequence of 0xFF chars. This was fixed by filtering the accepted values to standard asccii only. Both serial versions of SMT32F1 and AVR were not affected. (#65)
+- fixed flash eeprom reading that caused SMT32F1 to hang with USB virtual COM port. SMT32F1 default value for erased flash is 0xFF and not 0x00. This caused the startup blocks to read a sequence of 0xFF chars. This was fixed by filtering the accepted values to standard ASCII only. Both serial versions of SMT32F1 and AVR were not affected. (#65)
 
 ## [1.2.1] - 2021-08-06
 
@@ -687,7 +687,7 @@ The following things were changed:
 - all hard/soft limit alarms cause the firmware to lock until software reset is issued as described by Grbl (#63)
 - readapted homing and probing to the new interlocking logic (#63)
 - startup code improvements (#62)
-- modified µCNC to execute synchronous motions at motion control level. This reduces the pipeline travelling of the code at the expense of additional restart delay that is neglectable (#59)
+- modified µCNC to execute synchronous motions at motion control level. This reduces the pipeline traveling of the code at the expense of additional restart delay that is neglectable (#59)
 - dropped the Abort status in favor of the Alarm status to be more Grbl compliant (#59)
 - blocked status reports during startup blocks to prevent startup block ill-formated strings that were causing the interface software to correctly recognize the responses (#59)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ List of Supported G-Codes since µCNC 1.3.0:
     - General Pin Control: M42*
     - Trinamic settings: M350* (set/get microsteps), M906* (set/get current), 913* (stealthchop threshold), 914* (stall sensitivity-stallGuard capable chips only), 920* (set/get register)
     - Digital pins/trimpot settings: M351* (set/get microsteps), M907* (set/get current via digipot)
-    - Valid Non-Command Words: E (used by 3D printing firmwares like [Marlin](https://github.com/MarlinFirmware/Marlin)) (currently not used)
+    - Valid Non-Command Words: E (used by 3D printing firmware like [Marlin](https://github.com/MarlinFirmware/Marlin)) (currently not used)
 
 * see notes
 

--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -4396,13 +4396,18 @@ extern "C"
 #define mcu_disable_global_isr cli
 #define mcu_get_global_isr() (SREG & 0x80)
 
-#define mcu_delay_us(x)                       \
-	{                                         \
-		uint8_t delay_loop = x;               \
-		while (delay_loop--)                  \
-		{                                     \
-			_delay_loop_1(F_CPU / 4000000UL); \
-		}                                     \
+#define US_DELAY_TICK (F_CPU / 3000000UL)
+#define US_DELAY_TICK2 (F_CPU / 4000000UL)
+#define mcu_delay_us(x)                            \
+	{                                              \
+		if (x <= 85)                               \
+		{                                          \
+			_delay_loop_1((uint8_t)(x * US_DELAY_TICK - 1));   \
+		}                                          \
+		else                                       \
+		{                                          \
+			_delay_loop_2((uint16_t)(x * US_DELAY_TICK2 - 6)); \
+		}                                          \
 	}
 
 #define mcu_tx_ready() (CHECKBIT(UCSRA, UDRE))

--- a/uCNC/src/hal/mcus/esp32/mcu_esp32.c
+++ b/uCNC/src/hal/mcus/esp32/mcu_esp32.c
@@ -1245,7 +1245,7 @@ uint32_t mcu_millis()
 }
 
 #ifndef mcu_delay_us
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	int64_t time = esp_timer_get_time() + delay;
 	while (time > esp_timer_get_time())

--- a/uCNC/src/hal/mcus/esp8266/mcu_esp8266.c
+++ b/uCNC/src/hal/mcus/esp8266/mcu_esp8266.c
@@ -1259,7 +1259,7 @@ uint32_t mcu_millis()
 }
 
 #ifndef mcu_delay_us
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	uint32_t time = system_get_time() + delay;
 	while (time > system_get_time())

--- a/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
+++ b/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
@@ -1305,7 +1305,7 @@ uint32_t mcu_millis()
  * */
 #define mcu_micros ((mcu_runtime_ms * 1000) + ((SysTick->LOAD - SysTick->VAL) / (SystemCoreClock / 1000000)))
 #ifndef mcu_delay_us
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	// lpc176x_delay_us(delay);
 	uint32_t target = mcu_micros;

--- a/uCNC/src/hal/mcus/mcu.h
+++ b/uCNC/src/hal/mcus/mcu.h
@@ -271,7 +271,7 @@ extern "C"
 	 * the maximum allowed delay is 255 us
 	 * */
 #ifndef mcu_delay_us
-	void mcu_delay_us(uint8_t delay);
+	void mcu_delay_us(uint16_t delay);
 #endif
 
 	/**

--- a/uCNC/src/hal/mcus/samd21/mcu_samd21.c
+++ b/uCNC/src/hal/mcus/samd21/mcu_samd21.c
@@ -1542,7 +1542,7 @@ uint32_t mcu_millis()
 	return c;
 }
 
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	uint32_t loops;
 	if (!delay)

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1370,7 +1370,7 @@ void mcu_rtc_init()
 	SysTick->CTRL = 3; // Start SysTick (ABH clock/8)
 }
 
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	uint32_t startTick = DWT->CYCCNT,
 			 delayTicks = startTick + delay * (F_CPU / 1000000);

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -1453,7 +1453,7 @@ void mcu_printfp(const char *__fmt, ...)
 	va_end(__ap);
 }
 
-void mcu_delay_us(uint8_t delay)
+void mcu_delay_us(uint16_t delay)
 {
 	unsigned long start = getTickCounter();
 	double elapsed = 0;


### PR DESCRIPTION
- better µs delay for all platforms (now accepts 16bit value as argument) and better precision for AVR