### PR TITLE
better us delays

### DIFF
--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -33,7 +33,7 @@ extern "C"
 */
 #include <avr/pgmspace.h>
 #include <avr/interrupt.h>
-#include <util/delay_basic.h>
+#include <util/delay.h>
 
 /*
 	AVR Defaults
@@ -4398,17 +4398,7 @@ extern "C"
 
 #define US_DELAY_TICK (F_CPU / 3000000UL)
 #define US_DELAY_TICK2 (F_CPU / 4000000UL)
-#define mcu_delay_us(x)                            \
-	{                                              \
-		if (x <= 85)                               \
-		{                                          \
-			_delay_loop_1((uint8_t)(x * US_DELAY_TICK - 1));   \
-		}                                          \
-		else                                       \
-		{                                          \
-			_delay_loop_2((uint16_t)(x * US_DELAY_TICK2 - 6)); \
-		}                                          \
-	}
+#define mcu_delay_us(x) _delay_us(x)
 
 #define mcu_tx_ready() (CHECKBIT(UCSRA, UDRE))
 #define mcu_rx_ready() (CHECKBIT(UCSRA, RX))

--- a/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
+++ b/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
@@ -1301,14 +1301,13 @@ uint32_t mcu_millis()
 
 /**
  * provides a delay in us (micro seconds)
- * the maximum allowed delay is 255 us
  * */
 #define mcu_micros ((mcu_runtime_ms * 1000) + ((SysTick->LOAD - SysTick->VAL) / (SystemCoreClock / 1000000)))
 #ifndef mcu_delay_us
 void mcu_delay_us(uint16_t delay)
 {
 	// lpc176x_delay_us(delay);
-	uint32_t target = mcu_micros;
+	uint32_t target = mcu_micros + delay;
 	while (target > mcu_micros)
 		;
 }

--- a/uCNC/src/hal/mcus/samd21/mcu_samd21.c
+++ b/uCNC/src/hal/mcus/samd21/mcu_samd21.c
@@ -1551,7 +1551,7 @@ void mcu_delay_us(uint16_t delay)
 	}
 	else
 	{
-		loops = (delay * (F_CPU / 1000000) / 6) - 2;
+		loops = (delay * (F_CPU / 1000000UL) / 6) - 2;
 	}
 	while (loops--)
 		asm("nop");

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1373,7 +1373,7 @@ void mcu_rtc_init()
 void mcu_delay_us(uint16_t delay)
 {
 	uint32_t startTick = DWT->CYCCNT,
-			 delayTicks = startTick + delay * (F_CPU / 1000000);
+			 delayTicks = startTick + delay * (F_CPU / 1000000UL);
 
 	while (DWT->CYCCNT < delayTicks)
 		;

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -1241,6 +1241,16 @@ void mcu_init(void)
 #if SERVOS_MASK > 0
 	servo_timer_init();
 #endif
+
+	// use debugger timer to generate µs delay
+	// initialize debugger clock (used by us delay)
+	if (!(CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk))
+	{
+		CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+		DWT->CYCCNT = 0;
+		DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+	}
+
 	mcu_disable_probe_isr();
 	mcu_enable_global_isr();
 }
@@ -1424,6 +1434,15 @@ uint32_t mcu_millis()
 {
 	uint32_t val = mcu_runtime_ms;
 	return val;
+}
+
+void mcu_delay_us(uint16_t delay)
+{
+	uint32_t startTick = DWT->CYCCNT,
+			 delayTicks = startTick + delay * (F_CPU / 1000000UL);
+
+	while (DWT->CYCCNT < delayTicks)
+		;
 }
 
 void mcu_rtc_init()


### PR DESCRIPTION
- used built in AVR µs delay
- added STM32F4 missing mcu_delay_ms function (needs testing)
- fixed LPC176x mcu_delay_us