### PR TITLE
added new planner options

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -286,6 +286,23 @@ extern "C"
 	// #define ENABLE_BACKLASH_COMPENSATION
 
 	/**
+	 * By enabling this option the planner will only care about the exit speed.
+	 * This will make the planner not perform the forward pass to adjust entry speeds.
+	 * The adjustment of the next planner block is made on the fly when the block is loaded.
+	 * */
+	// #define ENABLE_PLANNER_SPEED_OVERSHOOT
+
+	/**
+	 * By enabling this option the planner will only perform acceleration if the exit speed is higher
+	 * then the current speed and the distance travelled is lower then a give threshold
+	 * This will prevent sucessive ramp up and down speed profiles a produce more continuous speed motions
+	 * */
+	// #define ENABLE_PLANNER_NOACCEL_ON_SLOWER_EXIT
+	#ifdef ENABLE_PLANNER_NOACCEL_ON_SLOWER_EXIT
+	#define ENABLE_PLANNER_NOACCEL_MAX_SETP_DISTANCE 5
+	#endif
+
+	/**
 	 * Uncomment these to enable step ISR calculation strategies (uses more
 	 * memory) STEP_ISR_SKIP_MAIN - carries the information about the main
 	 * stepper (performs a step in every ISR tick) and skips calculations


### PR DESCRIPTION
- new planner option ENABLE_PLANNER_SPEED_OVERSHOOT. This will do a single pass in speed ramp profile calculations. This will not take in account the current travel speed (that may not allow the calculated speed to be hit). This saves some calculation cycles -new planner option ENABLE_PLANNER_NOACCEL_ON_SLOWER_EXIT and minimal distance threshold ENABLE_PLANNER_NOACCEL_MAX_SETP_DISTANCE. This prevents short length segments to accelerate and then deaccelerate again to give a smoother motion.