### PR TITLE
prevent M2/M30 hold with check mode enabled

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -193,7 +193,7 @@ extern "C"
 /**
  * accept G0 and G1 without explicit target
  * */
-// #define IGNORE_G0_G1_MISSING_AXIS_WORDS
+#define IGNORE_G0_G1_MISSING_AXIS_WORDS
 
 /**
  * processes and displays the currently executing gcode numbered line

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1602,7 +1602,7 @@ uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, pa
 		break;
 	}
 
-	if (hold)
+	if (hold && !mc_get_checkmode())
 	{
 		mc_pause();
 		if (resetparser)


### PR DESCRIPTION
- prevent M2/M30 hold with check mode enabled
- any commands after M2 will still emit error