### PR TITLE
STM32 peripheral clocks now calculated from APB settings

### DIFF
--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -5,13 +5,14 @@
 [common_stm32]
 platform = ststm32
 ; debug with st-link
+upload_protocol = cmsis-dap
 platform_packages = platformio/tool-openocd
 debug_build_flags = -Og -g3 -ggdb3 -gdwarf-2
 debug_init_cmds =
   target extended-remote $DEBUG_PORT
   load
   monitor reset init
-build_flags = ${common.build_flags} -D HAL_TIM_MODULE_DISABLED -D HAL_EXTI_MODULE_DISABLED -D HAL_UART_MODULE_ONLY -D FRAMEWORK_CLOCKS_INIT
+build_flags = ${common.build_flags} -D HAL_TIM_MODULE_DISABLED -D HAL_EXTI_MODULE_DISABLED -D HAL_UART_MODULE_ONLY -D FRAMEWORK_CLOCKS_INIT -D DISABLE_ALL_CONTROLS
 
 [env:bluepill_f103c8]
 extends = common_stm32
@@ -40,7 +41,7 @@ upload_flags = -c set CPUTAPID 0x2ba01477
 [env:blackpill_f401cc]
 extends = common_stm32
 board = blackpill_f401cc
-build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_BLACKPILL -D INTERFACE=1
+build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_BLACKPILL -D INTERFACE=0
 
 [env:mks_robin_nano_v1_2]
 extends = common_stm32

--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -5,14 +5,14 @@
 [common_stm32]
 platform = ststm32
 ; debug with st-link
-upload_protocol = cmsis-dap
+; upload_protocol = cmsis-dap
 platform_packages = platformio/tool-openocd
 debug_build_flags = -Og -g3 -ggdb3 -gdwarf-2
 debug_init_cmds =
   target extended-remote $DEBUG_PORT
   load
   monitor reset init
-build_flags = ${common.build_flags} -D HAL_TIM_MODULE_DISABLED -D HAL_EXTI_MODULE_DISABLED -D HAL_UART_MODULE_ONLY -D FRAMEWORK_CLOCKS_INIT -D DISABLE_ALL_CONTROLS
+build_flags = ${common.build_flags} -D HAL_TIM_MODULE_DISABLED -D HAL_EXTI_MODULE_DISABLED -D HAL_UART_MODULE_ONLY -D FRAMEWORK_CLOCKS_INIT
 
 [env:bluepill_f103c8]
 extends = common_stm32
@@ -41,7 +41,7 @@ upload_flags = -c set CPUTAPID 0x2ba01477
 [env:blackpill_f401cc]
 extends = common_stm32
 board = blackpill_f401cc
-build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_BLACKPILL -D INTERFACE=0
+build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_BLACKPILL -D INTERFACE=1
 
 [env:mks_robin_nano_v1_2]
 extends = common_stm32

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -350,9 +350,9 @@ void osSystickHandler(void)
 static void mcu_rtc_init(void);
 static void mcu_usart_init(void);
 
-#ifndef FRAMEWORK_CLOCKS_INIT
 void mcu_clocks_init()
 {
+#ifndef FRAMEWORK_CLOCKS_INIT
 	/* Reset the RCC clock configuration to the default reset state */
 	/* Set HSION bit */
 	RCC->CR |= (uint32_t)0x00000001;
@@ -376,8 +376,7 @@ void mcu_clocks_init()
 	 * If crystal is 16MHz, add in PLLXTPRE flag to prescale by 2
 	 */
 	RCC->CFGR = (uint32_t)(RCC_CFGR_HPRE_DIV1 |
-						   RCC_CFGR_PPRE2_DIV1 |
-						   APB1_PRESC |
+						   APB1_PRESC | APB2_PRESC |
 						   RCC_CFGR_PLLSRC |
 						   RCC_CFGR_PLLMULL9);
 	/* Enable PLL */
@@ -390,8 +389,11 @@ void mcu_clocks_init()
 	/* Wait till PLL is used as system clock source */
 	while (!(RCC->CFGR & (uint32_t)RCC_CFGR_SWS))
 		;
-}
+#else
+	RCC->CFGR &= ~(RCC_CFGR_PPRE1_Msk | RCC_CFGR_PPRE2_Msk);
+	RCC->CFGR |= (APB1_PRESC | APB2_PRESC);
 #endif
+}
 
 void mcu_usart_init(void)
 {
@@ -481,9 +483,7 @@ void mcu_putc(char c)
 
 void mcu_init(void)
 {
-#ifndef FRAMEWORK_CLOCKS_INIT
 	mcu_clocks_init();
-#endif
 	stm32_flash_current_page = -1;
 	stm32_global_isr_enabled = false;
 	mcu_io_init();

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -138,16 +138,10 @@ static FORCEINLINE void mcu_clear_servos()
 // starts a constant rate pulse at a given frequency.
 void servo_timer_init(void)
 {
-#if (SERVO_TIMER == 1 || SERVO_TIMER == 8 || SERVO_TIMER == 9 || SERVO_TIMER == 10 || SERVO_TIMER == 11)
-	uint32_t clocks = (uint32_t)PERIPH_CLOCK(2);
-#else
-	uint32_t clocks = (uint32_t)PERIPH_CLOCK(1);
-#endif
-
 	RCC->SERVO_TIMER_ENREG |= SERVO_TIMER_APB;
 	SERVO_TIMER_REG->CR1 = 0;
 	SERVO_TIMER_REG->DIER = 0;
-	SERVO_TIMER_REG->PSC = (clocks / 255000) - 1;
+	SERVO_TIMER_REG->PSC = (F_CPU / 255000) - 1;
 	SERVO_TIMER_REG->ARR = 255;
 	SERVO_TIMER_REG->EGR |= 0x01;
 #if (SERVO_TIMER != 6 && SERVO_TIMER != 7)
@@ -415,13 +409,7 @@ void mcu_usart_init(void)
 	COM_USART->CR3 = 0;
 	COM_USART->SR = 0;
 	// //115200 baudrate
-
-#if (UART_PORT == 1) // APB2
-	uint32_t clocks = PERIPH_CLOCK(2);
-#else // APB1
-	uint32_t clocks = PERIPH_CLOCK(1);
-#endif
-	float baudrate = ((float)(clocks >> 4) / ((float)BAUDRATE));
+	float baudrate = ((float)(PERIPH_CLOCK >> 4) / ((float)BAUDRATE));
 	uint16_t brr = (uint16_t)baudrate;
 	baudrate -= brr;
 	brr <<= 4;
@@ -624,12 +612,9 @@ char mcu_getc(void)
 // convert step rate to clock cycles
 void mcu_freq_to_clocks(float frequency, uint16_t *ticks, uint16_t *prescaller)
 {
-// up and down counter (generates half the step rate at each event)
-#if (ITP_TIMER == 1 || ITP_TIMER == 8 || ITP_TIMER == 9 || ITP_TIMER == 10 || ITP_TIMER == 11)
-	uint32_t totalticks = (uint32_t)((float)PERIPH_CLOCK(2) / frequency);
-#else
-	uint32_t totalticks = (uint32_t)((float)PERIPH_CLOCK(1) / frequency);
-#endif
+	// up and down counter (generates half the step rate at each event)
+	uint32_t totalticks = (uint32_t)((float)(F_CPU >> 1) / frequency);
+
 	totalticks >>= 1;
 	*prescaller = 1;
 	while (totalticks > 0xFFFF)
@@ -840,12 +825,8 @@ void mcu_eeprom_flush()
 void mcu_spi_config(uint8_t mode, uint32_t frequency)
 {
 	mode = CLAMP(0, mode, 4);
+	uint8_t div = (uint8_t)(PERIPH_CLOCK / frequency);
 
-#if (SPI_PORT == 1)
-	uint8_t div = (uint8_t)(PERIPH_CLOCK(2) / frequency);
-#else
-	uint8_t div = (uint8_t)(PERIPH_CLOCK(1) / frequency);
-#endif
 	uint8_t speed;
 	if (div < 2)
 	{
@@ -995,12 +976,7 @@ void MCU_ONESHOT_ISR(void)
 #ifndef mcu_config_timeout
 void mcu_config_timeout(mcu_timeout_delgate fp, uint32_t timeout)
 {
-// up and down counter (generates half the step rate at each event)
-#if (ONESHOT_TIMER == 1 || ONESHOT_TIMER == 8 || ONESHOT_TIMER == 9 || ONESHOT_TIMER == 10 || ONESHOT_TIMER == 11)
-	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(2) / 1000000UL) * timeout);
-#else
-	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(1) / 1000000UL) * timeout);
-#endif
+	uint32_t clocks = (uint32_t)((F_CPU / 1000000UL) * timeout);
 	uint32_t presc = 1;
 
 	mcu_timeout_cb = fp;

--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -68,9 +68,11 @@ extern "C"
 // APB1 cannot exceed 36MHz
 #if (F_CPU > 36000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV2
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV2
 #define PERIPH_CLOCK (F_CPU>>1)
 #else
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV1
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV2
 #define PERIPH_CLOCK F_CPU
 #endif
 

--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -68,11 +68,11 @@ extern "C"
 // APB1 cannot exceed 36MHz
 #if (F_CPU > 36000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV2
+#define PERIPH_CLOCK (F_CPU>>1)
 #else
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV1
+#define PERIPH_CLOCK F_CPU
 #endif
-
-#define PERIPH_CLOCK(X) (F_CPU >> ((RCC->CFGR & RCC_CFGR_PPRE##X##_Msk) >> RCC_CFGR_PPRE##X##_Pos))
 
 // Helper macros
 #define __helper_ex__(left, mid, right) left##mid##right
@@ -3272,23 +3272,6 @@ extern "C"
 /**********************************************
  *	PWM pins
  **********************************************/
-#define PWM_TIMER1_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER2_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER3_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER4_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER5_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER6_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER7_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER8_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER9_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER10_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER11_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER12_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER13_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER14_CLOCKS PERIPH_CLOCK(1)
-#define _PWM_TIMER_CLOCKS(X) PWM_TIMER##X##_CLOCKS
-#define PWM_TIMER_CLOCKS(X) _PWM_TIMER_CLOCKS(X)
-
 #if (defined(PWM0_CHANNEL) && defined(PWM0_TIMER) && defined(PWM0))
 #if (PWM0_TIMER == 1 || (PWM0_TIMER >= 8 & PWM0_TIMER <= 11))
 #define PWM0_ENREG RCC->APB2ENR
@@ -4311,7 +4294,7 @@ extern "C"
 
 #define I2C_APBEN __helper__(RCC_APB1ENR_I2C, I2C_PORT, EN)
 #define I2C_REG __helper__(I2C, I2C_PORT, )
-#define I2C_SPEEDRANGE (PERIPH_CLOCK(1) / 1000000UL)
+#define I2C_SPEEDRANGE (PERIPH_CLOCK / 1000000UL)
 
 #if ((I2C_PORT == 1) && (I2C_SCL_PORT == B6) && (I2C_SDA_PORT == B7))
 #elif ((I2C_PORT == 1) && (I2C_SCL_PORT == B8) && (I2C_SDA_PORT == B9))
@@ -4526,7 +4509,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) &= ~(GPIO_RESET << ((__indirect__(diopin, CROFF)) << 2U));          \
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) |= (GPIO_OUTALT_PP_50MHZ << ((__indirect__(diopin, CROFF)) << 2U)); \
 		__indirect__(diopin, TIMREG)->CR1 = 0;                                                                                   \
-		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(PWM_TIMER_CLOCKS(__indirect__(diopin, TIMER)) / 1000000UL) - 1;                                                   \
+		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(F_CPU / 1000000UL) - 1;                                                   \
 		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                        \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = 0;                                                             \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCMREG) = __indirect__(diopin, MODE);                                 \

--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -65,6 +65,15 @@ extern "C"
 #define ENABLE_SYNC_RX
 #endif
 
+// APB1 cannot exceed 36MHz
+#if (F_CPU > 36000000UL)
+#define APB1_PRESC RCC_CFGR_PPRE1_DIV2
+#else
+#define APB1_PRESC RCC_CFGR_PPRE1_DIV1
+#endif
+
+#define PERIPH_CLOCK(X) (F_CPU >> ((RCC->CFGR & RCC_CFGR_PPRE##X##_Msk) >> RCC_CFGR_PPRE##X##_Pos))
+
 // Helper macros
 #define __helper_ex__(left, mid, right) left##mid##right
 #define __helper__(left, mid, right) __helper_ex__(left, mid, right)
@@ -3263,6 +3272,23 @@ extern "C"
 /**********************************************
  *	PWM pins
  **********************************************/
+#define PWM_TIMER1_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER2_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER3_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER4_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER5_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER6_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER7_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER8_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER9_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER10_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER11_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER12_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER13_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER14_CLOCKS PERIPH_CLOCK(1)
+#define _PWM_TIMER_CLOCKS(X) PWM_TIMER##X##_CLOCKS
+#define PWM_TIMER_CLOCKS(X) _PWM_TIMER_CLOCKS(X)
+
 #if (defined(PWM0_CHANNEL) && defined(PWM0_TIMER) && defined(PWM0))
 #if (PWM0_TIMER == 1 || (PWM0_TIMER >= 8 & PWM0_TIMER <= 11))
 #define PWM0_ENREG RCC->APB2ENR
@@ -4285,7 +4311,7 @@ extern "C"
 
 #define I2C_APBEN __helper__(RCC_APB1ENR_I2C, I2C_PORT, EN)
 #define I2C_REG __helper__(I2C, I2C_PORT, )
-#define I2C_SPEEDRANGE ((F_CPU >> 1) / 1000000UL)
+#define I2C_SPEEDRANGE (PERIPH_CLOCK(1) / 1000000UL)
 
 #if ((I2C_PORT == 1) && (I2C_SCL_PORT == B6) && (I2C_SDA_PORT == B7))
 #elif ((I2C_PORT == 1) && (I2C_SCL_PORT == B8) && (I2C_SDA_PORT == B9))
@@ -4500,7 +4526,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) &= ~(GPIO_RESET << ((__indirect__(diopin, CROFF)) << 2U));          \
 		__indirect__(diopin, GPIO)->__indirect__(diopin, CR) |= (GPIO_OUTALT_PP_50MHZ << ((__indirect__(diopin, CROFF)) << 2U)); \
 		__indirect__(diopin, TIMREG)->CR1 = 0;                                                                                   \
-		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(F_CPU / 1000000UL) - 1;                                                   \
+		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(PWM_TIMER_CLOCKS(__indirect__(diopin, TIMER)) / 1000000UL) - 1;                                                   \
 		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                        \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = 0;                                                             \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCMREG) = __indirect__(diopin, MODE);                                 \
@@ -4555,7 +4581,7 @@ extern "C"
 #define mcu_get_pwm(diopin) ((uint8_t)((((uint32_t)__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR)) * 255) / ((uint32_t)__indirect__(diopin, TIMREG)->ARR)))
 
 #define mcu_get_analog(diopin)                      \
-	({                                               \
+	({                                              \
 		ADC1->SQR3 = __indirect__(diopin, CHANNEL); \
 		ADC1->CR2 |= ADC_CR2_SWSTART;               \
 		ADC1->CR2 &= ~ADC_CR2_SWSTART;              \
@@ -4586,7 +4612,7 @@ extern "C"
 #endif
 #endif
 
-	extern volatile bool stm32_global_isr_enabled;
+extern volatile bool stm32_global_isr_enabled;
 #define mcu_enable_global_isr()          \
 	{                                    \
 		__enable_irq();                  \

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -125,10 +125,16 @@ static FORCEINLINE void mcu_clear_servos()
 // starts a constant rate pulse at a given frequency.
 void servo_timer_init(void)
 {
+	#if (SERVO_TIMER == 1 || SERVO_TIMER == 8 || SERVO_TIMER == 9 || SERVO_TIMER == 10 || SERVO_TIMER == 11)
+	uint32_t clocks = (uint32_t)PERIPH_CLOCK(2);
+#else
+	uint32_t clocks = (uint32_t)PERIPH_CLOCK(1);
+#endif
+
 	RCC->SERVO_TIMER_ENREG |= SERVO_TIMER_APB;
 	SERVO_TIMER_REG->CR1 = 0;
 	SERVO_TIMER_REG->DIER = 0;
-	SERVO_TIMER_REG->PSC = (F_CPU / 255000) - 1;
+	SERVO_TIMER_REG->PSC = (clocks / 255000) - 1;
 	SERVO_TIMER_REG->ARR = 255;
 	SERVO_TIMER_REG->EGR |= 0x01;
 	SERVO_TIMER_REG->SR &= ~0x01;
@@ -330,12 +336,6 @@ void osSystickHandler(void)
 static void mcu_rtc_init(void);
 static void mcu_usart_init(void);
 
-#if (INTERFACE == INTERFACE_UART)
-#define APB2_PRESCALER RCC_CFGR_PPRE2_DIV2
-#else
-#define APB2_PRESCALER RCC_CFGR_PPRE2_DIV1
-#endif
-
 #ifndef FRAMEWORK_CLOCKS_INIT
 #if (F_CPU == 84000000)
 #define PLLN 336
@@ -389,7 +389,7 @@ void mcu_clocks_init()
 	/* HCLK = SYSCLK, PCLK2 = HCLK, PCLK1 = HCLK / 2
 	 * If crystal is 16MHz, add in PLLXTPRE flag to prescale by 2
 	 */
-	SETFLAG(RCC->CFGR, (uint32_t)(RCC_CFGR_HPRE_DIV1 | APB2_PRESCALER | RCC_CFGR_PPRE1_DIV2));
+	SETFLAG(RCC->CFGR, (uint32_t)(RCC_CFGR_HPRE_DIV1 | APB2_PRESC | APB1_PRESC));
 
 	/* Select PLL as system clock source */
 	CLEARFLAG(RCC->CFGR, RCC_CFGR_SW);
@@ -425,8 +425,13 @@ void mcu_usart_init(void)
 	COM_USART->CR2 = 0; // 1 stop bit STOP=00
 	COM_USART->CR3 = 0;
 	COM_USART->SR = 0;
-	// //115200 baudrate
-	float baudrate = ((float)(F_CPU >> 1) / ((float)(BAUDRATE * 8 * 2)));
+// //115200 baudrate
+#if (UART_PORT == 1 || UART_PORT == 6) // APB2
+	uint32_t clocks = PERIPH_CLOCK(2);
+#else // APB1
+	uint32_t clocks = PERIPH_CLOCK(1);
+#endif
+	float baudrate = ((float)(clocks >> 4) / ((float)(BAUDRATE)));
 	uint16_t brr = (uint16_t)baudrate;
 	baudrate -= brr;
 	brr <<= 4;
@@ -885,7 +890,11 @@ void mcu_eeprom_flush()
 void mcu_spi_config(uint8_t mode, uint32_t frequency)
 {
 	mode = CLAMP(0, mode, 4);
-	uint8_t div = (uint8_t)(F_CPU / frequency);
+#if (SPI_PORT == 1 || SPI_PORT == 4 || SPI_PORT == 5 || SPI_PORT == 6)
+	uint8_t div = (uint8_t)(PERIPH_CLOCK(2) / frequency);
+#else
+	uint8_t div = (uint8_t)(PERIPH_CLOCK(1) / frequency);
+#endif
 	uint8_t speed;
 	if (div < 2)
 	{
@@ -1036,7 +1045,11 @@ void MCU_ONESHOT_ISR(void)
 void mcu_config_timeout(mcu_timeout_delgate fp, uint32_t timeout)
 {
 	// up and down counter (generates half the step rate at each event)
-	uint32_t clocks = (uint32_t)((F_CPU / 1000000UL) * timeout);
+#if (ONESHOT_TIMER == 1 || ONESHOT_TIMER == 8 || ONESHOT_TIMER == 9 || ONESHOT_TIMER == 10 || ONESHOT_TIMER == 11)
+	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(2) / 1000000UL) * timeout);
+#else
+	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(1) / 1000000UL) * timeout);
+#endif
 	uint32_t presc = 1;
 
 	mcu_timeout_cb = fp;

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -23,6 +23,7 @@
 #include "core_cm4.h"
 #include "stm32f4xx.h"
 #include "mcumap_stm32f4x.h"
+#include <math.h>
 
 #if (INTERFACE == INTERFACE_USB)
 #include "../../../tinyusb/tusb_config.h"
@@ -342,9 +343,10 @@ static void mcu_usart_init(void);
 #else
 #error "Running the CPU at this frequency might lead to unexpected behaviour"
 #endif
-
+#endif
 void mcu_clocks_init()
 {
+#ifndef FRAMEWORK_CLOCKS_INIT
 	// enable power clock
 	SETFLAG(RCC->APB1ENR, RCC_APB1ENR_PWREN);
 	// set voltage regulator scale 2
@@ -403,9 +405,12 @@ void mcu_clocks_init()
 	// 	DWT->CYCCNT = 0;
 	// 	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 	// }
-}
 
+#else
+	RCC->CFGR &= ~(RCC_CFGR_PPRE1_Msk | RCC_CFGR_PPRE2_Msk);
+	RCC->CFGR |= (APB2_PRESC | APB1_PRESC);
 #endif
+}
 
 void mcu_usart_init(void)
 {
@@ -419,7 +424,7 @@ void mcu_usart_init(void)
 	COM_USART->CR2 = 0; // 1 stop bit STOP=00
 	COM_USART->CR3 = 0;
 	COM_USART->SR = 0;
-	// //115200 baudrate
+// //115200 baudrate
 	float baudrate = ((float)(PERIPH_CLOCK >> 4) / ((float)(BAUDRATE)));
 	uint16_t brr = (uint16_t)baudrate;
 	baudrate -= brr;
@@ -506,10 +511,8 @@ void mcu_putc(char c)
 
 void mcu_init(void)
 {
-// make sure both APB1 and APB2 are running at the same clock (48MHz)
-#ifndef FRAMEWORK_CLOCKS_INIT
+	// make sure both APB1 and APB2 are running at the same clock (48MHz)
 	mcu_clocks_init();
-#endif
 	stm32_flash_current_page = -1;
 	stm32_global_isr_enabled = false;
 	mcu_io_init();

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -125,16 +125,10 @@ static FORCEINLINE void mcu_clear_servos()
 // starts a constant rate pulse at a given frequency.
 void servo_timer_init(void)
 {
-	#if (SERVO_TIMER == 1 || SERVO_TIMER == 8 || SERVO_TIMER == 9 || SERVO_TIMER == 10 || SERVO_TIMER == 11)
-	uint32_t clocks = (uint32_t)PERIPH_CLOCK(2);
-#else
-	uint32_t clocks = (uint32_t)PERIPH_CLOCK(1);
-#endif
-
 	RCC->SERVO_TIMER_ENREG |= SERVO_TIMER_APB;
 	SERVO_TIMER_REG->CR1 = 0;
 	SERVO_TIMER_REG->DIER = 0;
-	SERVO_TIMER_REG->PSC = (clocks / 255000) - 1;
+	SERVO_TIMER_REG->PSC = (F_CPU / 255000) - 1;
 	SERVO_TIMER_REG->ARR = 255;
 	SERVO_TIMER_REG->EGR |= 0x01;
 	SERVO_TIMER_REG->SR &= ~0x01;
@@ -425,13 +419,8 @@ void mcu_usart_init(void)
 	COM_USART->CR2 = 0; // 1 stop bit STOP=00
 	COM_USART->CR3 = 0;
 	COM_USART->SR = 0;
-// //115200 baudrate
-#if (UART_PORT == 1 || UART_PORT == 6) // APB2
-	uint32_t clocks = PERIPH_CLOCK(2);
-#else // APB1
-	uint32_t clocks = PERIPH_CLOCK(1);
-#endif
-	float baudrate = ((float)(clocks >> 4) / ((float)(BAUDRATE)));
+	// //115200 baudrate
+	float baudrate = ((float)(PERIPH_CLOCK >> 4) / ((float)(BAUDRATE)));
 	uint16_t brr = (uint16_t)baudrate;
 	baudrate -= brr;
 	brr <<= 4;
@@ -890,11 +879,8 @@ void mcu_eeprom_flush()
 void mcu_spi_config(uint8_t mode, uint32_t frequency)
 {
 	mode = CLAMP(0, mode, 4);
-#if (SPI_PORT == 1 || SPI_PORT == 4 || SPI_PORT == 5 || SPI_PORT == 6)
-	uint8_t div = (uint8_t)(PERIPH_CLOCK(2) / frequency);
-#else
-	uint8_t div = (uint8_t)(PERIPH_CLOCK(1) / frequency);
-#endif
+	uint8_t div = (uint8_t)(PERIPH_CLOCK / frequency);
+
 	uint8_t speed;
 	if (div < 2)
 	{
@@ -1045,11 +1031,7 @@ void MCU_ONESHOT_ISR(void)
 void mcu_config_timeout(mcu_timeout_delgate fp, uint32_t timeout)
 {
 	// up and down counter (generates half the step rate at each event)
-#if (ONESHOT_TIMER == 1 || ONESHOT_TIMER == 8 || ONESHOT_TIMER == 9 || ONESHOT_TIMER == 10 || ONESHOT_TIMER == 11)
-	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(2) / 1000000UL) * timeout);
-#else
-	uint32_t clocks = (uint32_t)((PERIPH_CLOCK(1) / 1000000UL) * timeout);
-#endif
+	uint32_t clocks = (uint32_t)((F_CPU / 1000000UL) * timeout);
 	uint32_t presc = 1;
 
 	mcu_timeout_cb = fp;

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -70,12 +70,12 @@ extern "C"
 // APB1 cannot exceed 36MHz
 #if (F_CPU > 90000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV4
-#define APB2_PRESC RCC_CFGR_PPRE2_DIV2
-#define PERIPH_CLOCK (F_CPU>>2)
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV4
+#define PERIPH_CLOCK (F_CPU >> 2)
 #elif (F_CPU > 45000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV2
-#define APB2_PRESC RCC_CFGR_PPRE2_DIV1
-#define PERIPH_CLOCK (F_CPU>>1)
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV2
+#define PERIPH_CLOCK (F_CPU >> 1)
 #else
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV1
 #define APB2_PRESC RCC_CFGR_PPRE2_DIV1
@@ -3242,7 +3242,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->OTYPER |= (1 << ((__indirect__(diopin, BIT)))); \
 	}
 
-#define mcu_config_pwm(diopin, freq)                                                                                                                                      \
+#define mcu_config_pwm(diopin, freq)                                                                                                                                \
 	{                                                                                                                                                               \
 		RCC->AHB1ENR |= __indirect__(diopin, AHB1EN);                                                                                                               \
 		PWM0_ENREG |= PWM0_APBEN;                                                                                                                                   \
@@ -3252,7 +3252,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] |= ((__indirect__(diopin, AF) << ((__indirect__(diopin, BIT) & 0x07) << 2))); /*af mode*/ \
 		__indirect__(diopin, TIMREG)->CR1 = 0;                                                                                                                      \
 		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(F_CPU / 1000000UL) - 1;                                                                                      \
-		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                                 \
+		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                                                           \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = 0;                                                                                                \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCMREG) = __indirect__(diopin, MODE);                                                                    \
 		__indirect__(diopin, TIMREG)->CCER |= (1U << ((__indirect__(diopin, CHANNEL) - 1) << 2));                                                                   \
@@ -3311,7 +3311,7 @@ extern "C"
 #define mcu_get_pwm(diopin) ((uint8_t)((((uint32_t)__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR)) * 255) / ((uint32_t)__indirect__(diopin, TIMREG)->ARR)))
 
 #define mcu_get_analog(diopin)                      \
-	({                                               \
+	({                                              \
 		ADC1->SQR3 = __indirect__(diopin, CHANNEL); \
 		ADC1->CR2 |= ADC_CR2_SWSTART;               \
 		ADC1->CR2 &= ~ADC_CR2_SWSTART;              \
@@ -3322,7 +3322,7 @@ extern "C"
 	})
 
 #define mcu_spi_xmit(X)                                               \
-	({                                                                 \
+	({                                                                \
 		SPI_REG->DR = X;                                              \
 		while (!(SPI1->SR & SPI_SR_TXE) && !(SPI1->SR & SPI_SR_RXNE)) \
 			;                                                         \

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -71,15 +71,16 @@ extern "C"
 #if (F_CPU > 90000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV4
 #define APB2_PRESC RCC_CFGR_PPRE2_DIV2
+#define PERIPH_CLOCK (F_CPU>>2)
 #elif (F_CPU > 45000000UL)
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV2
 #define APB2_PRESC RCC_CFGR_PPRE2_DIV1
+#define PERIPH_CLOCK (F_CPU>>1)
 #else
 #define APB1_PRESC RCC_CFGR_PPRE1_DIV1
 #define APB2_PRESC RCC_CFGR_PPRE2_DIV1
+#define PERIPH_CLOCK F_CPU
 #endif
-
-#define PERIPH_CLOCK(X) (F_CPU >> ((RCC->CFGR & RCC_CFGR_PPRE##X##_Msk) >> RCC_CFGR_PPRE##X##_Pos))
 
 // Helper macros
 #define __helper_ex__(left, mid, right) left##mid##right
@@ -1936,23 +1937,6 @@ extern "C"
 /**********************************************
  *	PWM pins
  **********************************************/
-#define PWM_TIMER1_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER2_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER3_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER4_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER5_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER6_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER7_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER8_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER9_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER10_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER11_CLOCKS PERIPH_CLOCK(2)
-#define PWM_TIMER12_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER13_CLOCKS PERIPH_CLOCK(1)
-#define PWM_TIMER14_CLOCKS PERIPH_CLOCK(1)
-#define _PWM_TIMER_CLOCKS(X) PWM_TIMER##X##_CLOCKS
-#define PWM_TIMER_CLOCKS(X) _PWM_TIMER_CLOCKS(X)
-
 #if (defined(PWM0_CHANNEL) && defined(PWM0_TIMER) && defined(PWM0))
 #if (PWM0_TIMER == 1 || (PWM0_TIMER >= 8 & PWM0_TIMER <= 11))
 #define PWM0_ENREG RCC->APB2ENR
@@ -3074,7 +3058,7 @@ extern "C"
 
 #define I2C_APBEN __helper__(RCC_APB1ENR_I2C, I2C_PORT, EN)
 #define I2C_REG __helper__(I2C, I2C_PORT, )
-#define I2C_SPEEDRANGE (PERIPH_CLOCK(1) / 1000000UL)
+#define I2C_SPEEDRANGE (PERIPH_CLOCK / 1000000UL)
 #define I2C_AFIO 4
 
 #ifndef I2C_FREQ

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -3251,7 +3251,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] &= ~(0xf << ((__indirect__(diopin, BIT) & 0x07) << 2));                                   \
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] |= ((__indirect__(diopin, AF) << ((__indirect__(diopin, BIT) & 0x07) << 2))); /*af mode*/ \
 		__indirect__(diopin, TIMREG)->CR1 = 0;                                                                                                                      \
-		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(PWM_TIMER_CLOCKS(__indirect__(diopin, TIMER)) / 1000000UL) - 1;                                                                                      \
+		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(F_CPU / 1000000UL) - 1;                                                                                      \
 		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                                 \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = 0;                                                                                                \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCMREG) = __indirect__(diopin, MODE);                                                                    \

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -67,6 +67,20 @@ extern "C"
 #define ENABLE_SYNC_RX
 #endif
 
+// APB1 cannot exceed 36MHz
+#if (F_CPU > 90000000UL)
+#define APB1_PRESC RCC_CFGR_PPRE1_DIV4
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV2
+#elif (F_CPU > 45000000UL)
+#define APB1_PRESC RCC_CFGR_PPRE1_DIV2
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV1
+#else
+#define APB1_PRESC RCC_CFGR_PPRE1_DIV1
+#define APB2_PRESC RCC_CFGR_PPRE2_DIV1
+#endif
+
+#define PERIPH_CLOCK(X) (F_CPU >> ((RCC->CFGR & RCC_CFGR_PPRE##X##_Msk) >> RCC_CFGR_PPRE##X##_Pos))
+
 // Helper macros
 #define __helper_ex__(left, mid, right) left##mid##right
 #define __helper__(left, mid, right) __helper_ex__(left, mid, right)
@@ -1922,6 +1936,23 @@ extern "C"
 /**********************************************
  *	PWM pins
  **********************************************/
+#define PWM_TIMER1_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER2_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER3_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER4_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER5_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER6_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER7_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER8_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER9_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER10_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER11_CLOCKS PERIPH_CLOCK(2)
+#define PWM_TIMER12_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER13_CLOCKS PERIPH_CLOCK(1)
+#define PWM_TIMER14_CLOCKS PERIPH_CLOCK(1)
+#define _PWM_TIMER_CLOCKS(X) PWM_TIMER##X##_CLOCKS
+#define PWM_TIMER_CLOCKS(X) _PWM_TIMER_CLOCKS(X)
+
 #if (defined(PWM0_CHANNEL) && defined(PWM0_TIMER) && defined(PWM0))
 #if (PWM0_TIMER == 1 || (PWM0_TIMER >= 8 & PWM0_TIMER <= 11))
 #define PWM0_ENREG RCC->APB2ENR
@@ -3043,7 +3074,7 @@ extern "C"
 
 #define I2C_APBEN __helper__(RCC_APB1ENR_I2C, I2C_PORT, EN)
 #define I2C_REG __helper__(I2C, I2C_PORT, )
-#define I2C_SPEEDRANGE ((F_CPU >> 1) / 1000000UL)
+#define I2C_SPEEDRANGE (PERIPH_CLOCK(1) / 1000000UL)
 #define I2C_AFIO 4
 
 #ifndef I2C_FREQ
@@ -3236,7 +3267,7 @@ extern "C"
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] &= ~(0xf << ((__indirect__(diopin, BIT) & 0x07) << 2));                                   \
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] |= ((__indirect__(diopin, AF) << ((__indirect__(diopin, BIT) & 0x07) << 2))); /*af mode*/ \
 		__indirect__(diopin, TIMREG)->CR1 = 0;                                                                                                                      \
-		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(F_CPU / 1000000UL) - 1;                                                                                      \
+		__indirect__(diopin, TIMREG)->PSC = (uint16_t)(PWM_TIMER_CLOCKS(__indirect__(diopin, TIMER)) / 1000000UL) - 1;                                                                                      \
 		__indirect__(diopin, TIMREG)->ARR = (uint16_t)(1000000UL / freq);                                                                 \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCR) = 0;                                                                                                \
 		__indirect__(diopin, TIMREG)->__indirect__(diopin, CCMREG) = __indirect__(diopin, MODE);                                                                    \


### PR DESCRIPTION
- SMT32 Peripheral clocks now calculated from APB (slow or fast) settings and F_CPU