### PR TITLE
removed atomic from soft uart and spi functions

### DIFF
--- a/uCNC/src/modules/softspi.c
+++ b/uCNC/src/modules/softspi.c
@@ -51,37 +51,34 @@ uint8_t softspi_xmit(softspi_port_t *port, uint8_t c)
 #endif
 	}
 
-	__ATOMIC_FORCEON__
+	bool clk = (bool)(port->spimode & 0x2);
+	bool on_down = (bool)(port->spimode & 0x1);
+
+	port->clk(clk);
+
+	uint8_t counter = 8;
+	do
 	{
-		bool clk = (bool)(port->spimode & 0x2);
-		bool on_down = (bool)(port->spimode & 0x1);
-
-		port->clk(clk);
-
-		uint8_t counter = 8;
-		do
+		if (on_down)
 		{
-			if (on_down)
-			{
-				clk = !clk;
-				port->clk(clk);
-			}
-			port->mosi((bool)(c & 0x80));
-			c <<= 1;
-			// sample
-			softspi_delay(port->spidelay);
 			clk = !clk;
 			port->clk(clk);
-			c |= port->miso();
+		}
+		port->mosi((bool)(c & 0x80));
+		c <<= 1;
+		// sample
+		softspi_delay(port->spidelay);
+		clk = !clk;
+		port->clk(clk);
+		c |= port->miso();
 
-			softspi_delay(port->spidelay);
-			if (!on_down)
-			{
-				clk = !clk;
-				port->clk(clk);
-			}
-		} while (--counter);
-	}
+		softspi_delay(port->spidelay);
+		if (!on_down)
+		{
+			clk = !clk;
+			port->clk(clk);
+		}
+	} while (--counter);
 
 	return c;
 }


### PR DESCRIPTION
- removed atomic from soft uart and spi functions. With slow speed communications the long atomic operation caused UART and USB ISR to miss character reception.