### PR TITLE
added option to debug IO alarm fault

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -366,6 +366,14 @@ extern "C"
 // #define DISABLE_PROBE
 #endif
 
+/**
+ * 
+ * Uncomment to store the state of the limits, controls and probe states that tiggered and alarm
+ * This is useful to debug momentary faults
+ * 
+*/
+// #define ENABLE_IO_ALARM_DEBUG
+
 	/**
 	 * Modifies the startup message to emulate Grbl (required by some programs so
 	 * that uCNC is recognized a Grbl protocol controller device)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -214,7 +214,7 @@ bool cnc_dotasks(void)
 		return !cnc_get_exec_state(EXEC_KILL | EXEC_HOMING);
 	}
 
-	//µCNC already in error loop. No point in sending the alarms
+	// µCNC already in error loop. No point in sending the alarms
 	if (cnc_state.loop_state == LOOP_ERROR_RESET)
 	{
 		return !cnc_get_exec_state(EXEC_KILL);
@@ -303,6 +303,14 @@ void cnc_alarm(int8_t code)
 	cnc_set_exec_state(EXEC_KILL);
 	cnc_stop();
 	cnc_state.alarm = code;
+#ifdef ENABLE_IO_ALARM_DEBUG
+	protocol_send_string(MSG_START);
+	protocol_send_string(__romstr__("LIMITS:"));
+	serial_print_int(io_alarm_limits);
+	protocol_send_string(__romstr__("CONTROLS:"));
+	serial_print_int(io_alarm_controls);
+	protocol_send_string(MSG_END);
+#endif
 }
 
 bool cnc_has_alarm()

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -305,9 +305,9 @@ void cnc_alarm(int8_t code)
 	cnc_state.alarm = code;
 #ifdef ENABLE_IO_ALARM_DEBUG
 	protocol_send_string(MSG_START);
-	protocol_send_string(__romstr__("LIMITS:"));
+	protocol_send_string(__romstr__("LIMITS>"));
 	serial_print_int(io_alarm_limits);
-	protocol_send_string(__romstr__("CONTROLS:"));
+	protocol_send_string(__romstr__(" CONTROLS>"));
 	serial_print_int(io_alarm_controls);
 	protocol_send_string(MSG_END);
 #endif

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -27,6 +27,11 @@ static volatile uint8_t io_spindle_speed;
 static uint8_t io_lock_limits_mask;
 static uint8_t io_invert_limits_mask;
 
+#ifdef ENABLE_IO_ALARM_DEBUG
+uint8_t io_alarm_limits;
+uint8_t io_alarm_controls;
+#endif
+
 #ifdef ENABLE_IO_MODULES
 // event_input_change_handler
 WEAK_EVENT_HANDLER(input_change)
@@ -159,6 +164,9 @@ MCU_IO_CALLBACK void mcu_limits_changed_cb(void)
 #endif
 			itp_stop();
 			cnc_set_exec_state(EXEC_HALT);
+#ifdef ENABLE_IO_ALARM_DEBUG
+			io_alarm_limits = limits;
+#endif
 		}
 	}
 
@@ -185,6 +193,9 @@ MCU_IO_CALLBACK void mcu_controls_changed_cb(void)
 	{
 		cnc_set_exec_state(EXEC_KILL);
 		cnc_stop();
+#ifdef ENABLE_IO_ALARM_DEBUG
+		io_alarm_controls = controls;
+#endif
 		return; // forces exit
 	}
 #endif
@@ -193,6 +204,9 @@ MCU_IO_CALLBACK void mcu_controls_changed_cb(void)
 	{
 		// safety door activates hold simultaneously to start the controlled stop
 		cnc_set_exec_state(EXEC_DOOR | EXEC_HOLD);
+#ifdef ENABLE_IO_ALARM_DEBUG
+		io_alarm_controls = controls;
+#endif
 	}
 #endif
 #if !(FHOLD < 0)

--- a/uCNC/src/core/io_control.h
+++ b/uCNC/src/core/io_control.h
@@ -82,6 +82,11 @@ extern "C"
 	// DECL_EVENT_HANDLER(set_output);
 #endif
 
+#ifdef ENABLE_IO_ALARM_DEBUG
+extern uint8_t io_alarm_limits;
+extern uint8_t io_alarm_controls;
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- added option to debug IO alarm fault verbose. This will print the limits and controls states that triggered the alarm/fault condition to allow debug of faulty wiring and noise