### PR TITLE
352 bug some alarms are not being printed

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -128,7 +128,7 @@ void cnc_run(void)
 
 		cnc_state.loop_state = LOOP_FAULT;
 		serial_flush();
-		uint8_t alarm = cnc_state.alarm;
+		int8_t alarm = cnc_state.alarm;
 		if (alarm > EXEC_ALARM_NOALARM)
 		{
 			protocol_send_alarm(cnc_state.alarm);
@@ -400,6 +400,8 @@ void cnc_clear_exec_state(uint8_t statemask)
 	if (CHECKFLAG(controls, ESTOP_MASK)) // can't clear the alarm flag if ESTOP is active
 	{
 		CLEARFLAG(statemask, EXEC_KILL);
+		// no point in continuing
+		return;
 	}
 #endif
 #if ASSERT_PIN(SAFETY_DOOR)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -534,9 +534,11 @@ void cnc_call_rt_command(uint8_t command)
 			SETFLAG(cnc_state.rt_cmd, RT_CMD_CYCLE_START); // tries to clear hold if possible
 		}
 		break;
+#if ASSERT_PIN(SAFETY_DOOR)
 	case CMD_CODE_SAFETY_DOOR:
 		SETFLAG(cnc_state.exec_state, (EXEC_HOLD | EXEC_DOOR));
 		break;
+#endif
 	case CMD_CODE_JOG_CANCEL:
 		if (cnc_get_exec_state(EXEC_JOG | EXEC_RUN) == (EXEC_JOG | EXEC_RUN))
 		{
@@ -812,6 +814,7 @@ bool cnc_check_interlocking(void)
 		return false;
 	}
 
+#if ASSERT_PIN(SAFETY_DOOR)
 	// the safety door condition is active
 	if (cnc_get_exec_state(EXEC_DOOR))
 	{
@@ -832,6 +835,7 @@ bool cnc_check_interlocking(void)
 
 		return false;
 	}
+#endif
 
 	// an hold condition is active and motion as stopped
 	if (cnc_get_exec_state(EXEC_HOLD) && !cnc_get_exec_state(EXEC_RUN))

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -420,7 +420,7 @@ void cnc_clear_exec_state(uint8_t statemask)
 #endif
 
 	// has a pending (not cleared by user) alarm
-	if (cnc_state.alarm <= EXEC_ALARM_ABORT_CYCLE || g_settings.homing_enabled)
+	if (cnc_state.alarm || g_settings.homing_enabled)
 	{
 		CLEARFLAG(statemask, EXEC_UNHOMED);
 	}

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -157,8 +157,9 @@ void cnc_run(void)
 		if (cnc_state.alarm < 0)
 		{
 			cnc_state.loop_state = LOOP_STARTUP_RESET;
+			cnc_clear_exec_state(EXEC_KILL);
 		}
-	} while (cnc_state.loop_state == LOOP_REQUIRE_RESET);
+	} while (cnc_state.loop_state == LOOP_REQUIRE_RESET || cnc_get_exec_state(EXEC_KILL));
 }
 
 bool cnc_exec_cmd(void)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -420,7 +420,7 @@ void cnc_clear_exec_state(uint8_t statemask)
 #endif
 
 	// has a pending (not cleared by user) alarm
-	if (cnc_state.alarm)
+	if (cnc_state.alarm <= EXEC_ALARM_ABORT_CYCLE || g_settings.homing_enabled)
 	{
 		CLEARFLAG(statemask, EXEC_UNHOMED);
 	}
@@ -429,12 +429,9 @@ void cnc_clear_exec_state(uint8_t statemask)
 #if (LIMITS_MASK != 0)
 	limits = io_get_limits(); // can't clear the EXEC_UNHOMED is any limit is triggered
 #endif
-	if (g_settings.hard_limits_enabled) // if hardlimits are enabled and limits are triggered
+	if (g_settings.hard_limits_enabled && limits) // if hardlimits are enabled and limits are triggered
 	{
-		if (limits || g_settings.homing_enabled)
-		{
-			CLEARFLAG(statemask, EXEC_UNHOMED);
-		}
+		CLEARFLAG(statemask, EXEC_UNHOMED);
 	}
 
 	// if releasing from a HOLD state with and active delay in exec

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -80,7 +80,6 @@ extern "C"
 #define EXEC_UNHOMED 32														// Machine is not homed or lost position due to abrupt stop
 #define EXEC_LIMITS 64														// Limits hit
 #define EXEC_KILL 128														// Emergency stop
-#define EXEC_RESUMING (EXEC_HOLD | EXEC_RUN)								// Motions are being being hold or resumed
 #define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)							// Limit switch is active during a homing motion
 #define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)					// Interlocking check failed
 #define EXEC_ALARM (EXEC_UNHOMED | EXEC_INTERLOCKING_FAIL)					// System alarms

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -51,20 +51,21 @@ extern "C"
 #define RT_CMD_COOL_MST_TOGGLE 128
 
 // current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0												// All flags cleared
-#define EXEC_RUN 1												// Motions are being executed
-#define EXEC_HOLD 2												// Feed hold is active
-#define EXEC_RESUMING (EXEC_HOLD | EXEC_RUN)					// Motions are being being hold or resumed
-#define EXEC_JOG 4												// Jogging in execution
-#define EXEC_HOMING 8											// Homing in execution
-#define EXEC_LIMTS 16											// Limits hit
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMTS)				// Limit switch is active during a homing motion
-#define EXEC_DOOR 32											// Safety door open
-#define EXEC_HALT 64											// All motions are halted and machine is locked
-#define EXEC_KILL 128											// Emergency stop
-#define EXEC_ALARM (EXEC_HALT | EXEC_DOOR | EXEC_KILL)		// System alarms
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 255										// All states
+#define EXEC_IDLE 0															// All flags cleared
+#define EXEC_RUN 1															// Motions are being executed
+#define EXEC_HOLD 2															// Feed hold is active
+#define EXEC_JOG 4															// Jogging in execution
+#define EXEC_HOMING 8														// Homing in execution
+#define EXEC_DOOR 16														// Safety door open
+#define EXEC_UNHOMED 32														// Machine is not homed or lost position due to abrupt stop
+#define EXEC_LIMITS 64														// Limits hit
+#define EXEC_KILL 128														// Emergency stop
+#define EXEC_RESUMING (EXEC_HOLD | EXEC_RUN)								// Motions are being being hold or resumed
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)							// Limit switch is active during a homing motion
+#define EXEC_ALARM (EXEC_UNHOMED | EXEC_LIMITS | EXEC_KILL)					// System alarms
+#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD)				// System reset locked
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 255													// All states
 
 // creates a set of helper masks used to configure the controller
 #define ESTOP_MASK 1

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -53,15 +53,16 @@ extern "C"
 // current cnc states (multiple can be active/overlapped at the same time)
 #define EXEC_IDLE 0												// All flags cleared
 #define EXEC_RUN 1												// Motions are being executed
-#define EXEC_RESUMING 2											// Motions are being resumed from a hold
-#define EXEC_HOLD 4												// Feed hold is active
-#define EXEC_JOG 8												// Jogging in execution
-#define EXEC_HOMING 16											// Homing in execution
-#define EXEC_HALT 32											// Limit switch is active or position lost due to abrupt stop
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_HALT)				// Limit switch is active during a homing motion
-#define EXEC_DOOR 64											// Safety door open
+#define EXEC_HOLD 2												// Feed hold is active
+#define EXEC_RESUMING (EXEC_HOLD | EXEC_RUN)					// Motions are being being hold or resumed
+#define EXEC_JOG 4												// Jogging in execution
+#define EXEC_HOMING 8											// Homing in execution
+#define EXEC_LIMTS 16											// Limits hit
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMTS)				// Limit switch is active during a homing motion
+#define EXEC_DOOR 32											// Safety door open
+#define EXEC_HALT 64											// All motions are halted and machine is locked
 #define EXEC_KILL 128											// Emergency stop
-#define EXEC_ALARM (EXEC_HALT | EXEC_DOOR | EXEC_KILL)			// System alarms
+#define EXEC_ALARM (EXEC_HALT | EXEC_DOOR | EXEC_KILL)		// System alarms
 #define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255										// All states
 

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -82,7 +82,8 @@ extern "C"
 #define EXEC_KILL 128														// Emergency stop
 #define EXEC_RESUMING (EXEC_HOLD | EXEC_RUN)								// Motions are being being hold or resumed
 #define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)							// Limit switch is active during a homing motion
-#define EXEC_ALARM (EXEC_UNHOMED | EXEC_LIMITS | EXEC_KILL)					// System alarms
+#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)					// Interlocking check failed
+#define EXEC_ALARM (EXEC_UNHOMED | EXEC_INTERLOCKING_FAIL)					// System alarms
 #define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD)				// System reset locked
 #define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255													// All states

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -50,6 +50,26 @@ extern "C"
 #define RT_CMD_COOL_FLD_TOGGLE 64
 #define RT_CMD_COOL_MST_TOGGLE 128
 
+/**
+ * Flags and state changes
+ * 
+ * EXEC_KILL
+ * Set by cnc_alarm.
+ * Cleared by reset or unlock depending on the the alarm priority. Cannot be cleared if ESTOP is pressed. 
+ * 
+ * EXEC_LIMITS
+ * Set when at a transition of a limit switch from inactive to the active state. 
+ * Cleared by reset or unlock. Not affected by the limit switch state.
+ * 
+ * EXEC_UNHOMED
+ * Set when the interpolator is abruptly stopped causing the position to be lost.
+ * Cleared by homing or unlock.
+ * 
+ * EXEC_DOOR
+ * Set with when the safety door pin is active or the safety door command is called.
+ * Cleared by cycle resume, unlock or reset. If the door is opened it will remain active
+ * 
+ */
 // current cnc states (multiple can be active/overlapped at the same time)
 #define EXEC_IDLE 0															// All flags cleared
 #define EXEC_RUN 1															// Motions are being executed

--- a/uCNC/src/cnc_hal_config_helper.h
+++ b/uCNC/src/cnc_hal_config_helper.h
@@ -655,8 +655,14 @@ extern "C"
 #ifndef DUAL_DRIVE1_STEPPER
 #define DUAL_DRIVE1_STEPPER 7
 #endif
+#ifndef DUAL_DRIVE2_STEPPER
+#define DUAL_DRIVE2_STEPPER 6
+#endif
+#ifndef DUAL_DRIVE3_STEPPER
+#define DUAL_DRIVE3_STEPPER 7
+#endif
 
-#if (!defined(DUAL_DRIVE0_AXIS) && !defined(DUAL_DRIVE1_AXIS))
+#if (!defined(DUAL_DRIVE0_AXIS) && !defined(DUAL_DRIVE1_AXIS) && !defined(DUAL_DRIVE2_AXIS) && !defined(DUAL_DRIVE3_AXIS))
 #error "Enabling dual axis drive requires to configure at least one axis with dual drive"
 #endif
 

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -115,8 +115,6 @@ static itp_segment_t *itp_rt_sgm;
 #if (defined(ENABLE_DUAL_DRIVE_AXIS) || defined(IS_DELTA_KINEMATICS))
 static volatile uint8_t itp_step_lock;
 #endif
-// keeps track if the itp timer is running or not (prevent restarting)
-static volatile bool itp_is_running;
 
 #ifdef ENABLE_RT_SYNC_MOTIONS
 volatile int32_t itp_sync_step_counter;
@@ -1059,8 +1057,6 @@ void itp_stop(void)
 		cnc_set_exec_state(EXEC_UNHOMED);
 	}
 
-	cnc_clear_exec_state(EXEC_RUN);
-
 	io_set_steps(g_settings.step_invert_mask);
 #if TOOL_COUNT > 0
 	if (g_settings.laser_mode)
@@ -1070,7 +1066,7 @@ void itp_stop(void)
 #endif
 
 	mcu_stop_itp_isr();
-	itp_is_running = false;
+	cnc_clear_exec_state(EXEC_RUN);
 }
 
 void itp_stop_tools(void)
@@ -1715,7 +1711,7 @@ MCU_CALLBACK void mcu_step_cb(void)
 void itp_start(bool is_synched)
 {
 	// starts the step isr if is stopped and there are segments to execute
-	if (!cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM | EXEC_RESUMING) && !itp_sgm_is_empty() && !itp_is_running) // exec state is not hold or alarm and not already running
+	if (!cnc_get_exec_state(EXEC_RUN | EXEC_HOLD | EXEC_ALARM) && !itp_sgm_is_empty()) // exec state is not hold or alarm and not already running
 	{
 		// check if the start is controlled by synched motion before start
 		if (!is_synched)
@@ -1723,7 +1719,6 @@ void itp_start(bool is_synched)
 			__ATOMIC__
 			{
 				cnc_set_exec_state(EXEC_RUN); // flags that it started running
-				itp_is_running = true;
 				mcu_start_itp_isr(itp_sgm_data[itp_sgm_data_read].timer_counter, itp_sgm_data[itp_sgm_data_read].timer_prescaller);
 			}
 		}

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -1056,7 +1056,7 @@ void itp_stop(void)
 	// any stop command while running triggers an HALT alarm
 	if (cnc_get_exec_state(EXEC_RUN))
 	{
-		cnc_set_exec_state(EXEC_HALT);
+		cnc_set_exec_state(EXEC_UNHOMED);
 	}
 
 	cnc_clear_exec_state(EXEC_RUN);

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -94,7 +94,7 @@ MCU_IO_CALLBACK void mcu_limits_changed_cb(void)
 {
 #ifndef DISABLE_ALL_LIMITS
 
-	if (g_settings.hard_limits_enabled)
+	if (g_settings.hard_limits_enabled || cnc_get_exec_state(EXEC_HOMING))
 	{
 		static uint8_t prev_limits = 0;
 		uint8_t limits = io_get_limits();

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -168,7 +168,7 @@ MCU_IO_CALLBACK void mcu_limits_changed_cb(void)
 			itp_lock_stepper(0); // unlocks axis
 #endif
 			itp_stop();
-			cnc_set_exec_state(EXEC_HALT);
+			cnc_set_exec_state(EXEC_LIMTS);
 #ifdef ENABLE_IO_ALARM_DEBUG
 			io_alarm_limits = limits;
 #endif
@@ -196,11 +196,10 @@ MCU_IO_CALLBACK void mcu_controls_changed_cb(void)
 #if ASSERT_PIN(ESTOP)
 	if (CHECKFLAG(controls, ESTOP_MASK))
 	{
-		cnc_set_exec_state(EXEC_KILL);
-		cnc_stop();
 #ifdef ENABLE_IO_ALARM_DEBUG
 		io_alarm_controls = controls;
 #endif
+		cnc_alarm(EXEC_ALARM_EMERGENCY_STOP);
 		return; // forces exit
 	}
 #endif

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -168,7 +168,7 @@ MCU_IO_CALLBACK void mcu_limits_changed_cb(void)
 			itp_lock_stepper(0); // unlocks axis
 #endif
 			itp_stop();
-			cnc_set_exec_state(EXEC_LIMTS);
+			cnc_set_exec_state(EXEC_LIMITS);
 #ifdef ENABLE_IO_ALARM_DEBUG
 			io_alarm_limits = limits;
 #endif
@@ -337,6 +337,7 @@ void io_lock_limits(uint8_t limitmask)
 void io_invert_limits(uint8_t limitmask)
 {
 	io_invert_limits_mask = limitmask;
+	mcu_limits_changed_cb();
 }
 
 uint8_t io_get_limits(void)

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -689,8 +689,6 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
 	motion_data_t block_data = {0};
 	uint8_t limits_flags;
 
-	cnc_unlock(true);
-
 #ifdef ENABLE_G39_H_MAPPING
 	// resets height map
 	memset(hmap_offsets, 0, sizeof(hmap_offsets));
@@ -699,8 +697,8 @@ uint8_t mc_home_axis(uint8_t axis, uint8_t axis_limit)
 	// locks limits to accept axis limit mask only or else throw error
 	io_lock_limits(axis_limit);
 	io_invert_limits(0);
-	// if HOLD or ALARM are still active or any limit switch is not cleared fails to home
-	mcu_limits_changed_cb();
+	cnc_unlock(true);
+
 	if (cnc_get_exec_state(EXEC_HOLD | EXEC_ALARM) || CHECKFLAG(io_get_limits(), LIMITS_MASK))
 	{
 		cnc_alarm(EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE);
@@ -845,7 +843,7 @@ uint8_t mc_probe(float *target, uint8_t flags, motion_data_t *block_data)
 	io_disable_probe();
 
 	// clears HALT state if possible
-	cnc_clear_exec_state(EXEC_UNHOMED);
+	cnc_unlock(true);
 
 	itp_clear();
 	planner_clear();

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -155,7 +155,7 @@ void parser_init(void)
 #endif
 	memset(parser_last_pos, 0, sizeof(parser_last_pos));
 	parser_parameters_load();
-	parser_reset();
+	parser_reset(false);
 }
 
 uint8_t parser_read_command(void)
@@ -2557,8 +2557,13 @@ static void parser_discard_command(void)
 	} while (c != EOL);
 }
 
-void parser_reset(void)
+void parser_reset(bool stopgroup_only)
 {
+	parser_state.groups.stopping = 0; // resets all stopping commands (M0,M1,M2,M30,M60)
+	if (stopgroup_only)
+	{
+		return;
+	}
 	parser_state.groups.coord_system = G54;				  // G54
 	parser_state.groups.plane = G17;					  // G17
 	parser_state.groups.feed_speed_override = M48;		  // M48
@@ -2566,7 +2571,6 @@ void parser_reset(void)
 	parser_state.groups.distance_mode = G90;			  // G90
 	parser_state.groups.feedrate_mode = G94;			  // G94
 	parser_state.groups.tlo_mode = G49;					  // G49
-	parser_state.groups.stopping = 0;					  // resets all stopping commands (M0,M1,M2,M30,M60)
 #if TOOL_COUNT > 0
 	parser_state.groups.coolant = M9;		  // M9
 	parser_state.groups.spindle_turning = M5; // M5

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -594,10 +594,12 @@ static uint8_t parse_grbl_exec_code(uint8_t code)
 		break;
 	case GRBL_UNLOCK:
 		cnc_unlock(true);
+#if ASSERT_PIN(SAFETY_DOOR)
 		if (cnc_get_exec_state(EXEC_DOOR))
 		{
 			return STATUS_CHECK_DOOR;
 		}
+#endif
 		protocol_send_feedback(MSG_FEEDBACK_3);
 		break;
 	case GRBL_HOME:
@@ -607,11 +609,12 @@ static uint8_t parse_grbl_exec_code(uint8_t code)
 		}
 
 		cnc_unlock(true);
+#if ASSERT_PIN(SAFETY_DOOR)
 		if (cnc_get_exec_state(EXEC_DOOR))
 		{
 			return STATUS_CHECK_DOOR;
 		}
-
+#endif
 		cnc_home();
 		break;
 	case GRBL_HELP:
@@ -2583,7 +2586,7 @@ void parser_reset(void)
 #endif
 
 #ifdef ENABLE_PARSER_MODULES
-		EVENT_INVOKE(parser_reset, NULL);
+	EVENT_INVOKE(parser_reset, NULL);
 #endif
 }
 

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -191,7 +191,7 @@ uint8_t parser_read_command(void)
 		cnc_clear_exec_state(EXEC_JOG);
 		return error;
 	}
-	else if (cnc_get_exec_state(~(EXEC_RUN | EXEC_HOLD | EXEC_RESUMING)))
+	else if (cnc_get_exec_state(~(EXEC_RUN | EXEC_HOLD)) || cnc_has_alarm()) // if any other than idle, run or hold discards the command
 	{
 		parser_discard_command();
 		return STATUS_SYSTEM_GC_LOCK;

--- a/uCNC/src/core/parser.h
+++ b/uCNC/src/core/parser.h
@@ -278,7 +278,7 @@ extern "C"
 	void parser_parameters_reset(void);
 	void parser_parameters_save(void);
 	void parser_sync_position(void);
-	void parser_reset(void);
+	void parser_reset(bool stopgroup_only);
 	void parser_machine_to_work(float *axis);
 	uint8_t parser_get_float(float *value);
 	uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *words, parser_cmd_explicit_t *cmd);

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -726,18 +726,18 @@ DWORD WINAPI virtualconsoleserver(LPVOID lpParam)
 		unsigned char c = getch();
 		switch (c)
 		{
-		// case '"':
-		// 	virtualmap.special_inputs ^= (1 << (ESTOP - LIMIT_X));
-		// 	mcu_controls_changed_cb();
-		// 	break;
-		// case '%':
-		// 	virtualmap.special_inputs ^= (1 << (LIMIT_X - LIMIT_X));
-		// 	mcu_limits_changed_cb();
-		// 	break;
-		// case '&':
-		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Y - LIMIT_X));
-		// 	mcu_limits_changed_cb();
-		// 	break;
+		 case '"':
+		 	virtualmap.special_inputs ^= (1 << (ESTOP - LIMIT_X));
+		 	mcu_controls_changed_cb();
+		 	break;
+		 case '%':
+		 	virtualmap.special_inputs ^= (1 << (PROBE - LIMIT_X));
+		 	mcu_limits_changed_cb();
+		 	break;
+		 case '&':
+		 	virtualmap.special_inputs ^= (1 << (LIMIT_Y - LIMIT_X));
+		 	mcu_limits_changed_cb();
+		 	break;
 		// case '/':
 		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Z - LIMIT_X));
 		// 	mcu_limits_changed_cb();

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -723,25 +723,25 @@ DWORD WINAPI virtualconsoleserver(LPVOID lpParam)
 	// Receive until the peer shuts down the connection
 	do
 	{
-		unsigned char c = getch();
+		unsigned char c = getchar();
 		switch (c)
 		{
-		 case '"':
-		 	virtualmap.special_inputs ^= (1 << (ESTOP - LIMIT_X));
-		 	mcu_controls_changed_cb();
-		 	break;
-		 case '%':
-		 	virtualmap.special_inputs ^= (1 << (PROBE - LIMIT_X));
-		 	mcu_limits_changed_cb();
-		 	break;
-		 case '&':
-		 	virtualmap.special_inputs ^= (1 << (LIMIT_Y - LIMIT_X));
-		 	mcu_limits_changed_cb();
-		 	break;
-		// case '/':
-		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Z - LIMIT_X));
-		// 	mcu_limits_changed_cb();
-		// 	break;
+//		 case '"':
+//		 	virtualmap.special_inputs ^= (1 << (ESTOP - LIMIT_X));
+//		 	mcu_controls_changed_cb();
+//		 	break;
+//		 case '%':
+//		 	virtualmap.special_inputs ^= (1 << (LIMIT_X - LIMIT_X));
+//		 	mcu_limits_changed_cb();
+//		 	break;
+//		 case '&':
+//		 	virtualmap.special_inputs ^= (1 << (LIMIT_Y - LIMIT_X));
+//		 	mcu_limits_changed_cb();
+//		 	break;
+//		 case '/':
+//		 	virtualmap.special_inputs ^= (1 << (LIMIT_Z - LIMIT_X));
+//		 	mcu_limits_changed_cb();
+//		 	break;
 		// case '[':
 		// 	virtualmap.special_inputs ^= (1 << (LIMIT_X2 - LIMIT_X));
 		// 	mcu_limits_changed_cb();

--- a/uCNC/src/hal/mcus/virtual/mcu_virtual.c
+++ b/uCNC/src/hal/mcus/virtual/mcu_virtual.c
@@ -83,12 +83,12 @@
 #define COM_BUFFER_SIZE 50
 #endif
 
-//MCU_IO_CALLBACK void mcu_inputs_changed_cb(void)
+// MCU_IO_CALLBACK void mcu_inputs_changed_cb(void)
 //{
-//#ifdef ENABLE_IO_MODULES
+// #ifdef ENABLE_IO_MODULES
 //	EVENT_INVOKE(input_change, NULL);
-//#endif
-//}
+// #endif
+// }
 
 /*timers*/
 int start_timer(int, void (*)(void));
@@ -154,9 +154,9 @@ unsigned long getCPUFreq(void)
 		printf("QueryPerformanceFrequency failed!\n");
 		return 0;
 	}
-	
-	cyclesPerMicrosecond = (double)perf_counter.QuadPart/1000000.0;
-	cyclesPerMillisecond = (double)perf_counter.QuadPart/1000.0;
+
+	cyclesPerMicrosecond = (double)perf_counter.QuadPart / 1000000.0;
+	cyclesPerMillisecond = (double)perf_counter.QuadPart / 1000.0;
 
 	return perf_counter.QuadPart;
 }
@@ -723,8 +723,41 @@ DWORD WINAPI virtualconsoleserver(LPVOID lpParam)
 	// Receive until the peer shuts down the connection
 	do
 	{
-		unsigned char c = getchar();
-		mcu_com_rx_cb(c);
+		unsigned char c = getch();
+		switch (c)
+		{
+		// case '"':
+		// 	virtualmap.special_inputs ^= (1 << (ESTOP - LIMIT_X));
+		// 	mcu_controls_changed_cb();
+		// 	break;
+		// case '%':
+		// 	virtualmap.special_inputs ^= (1 << (LIMIT_X - LIMIT_X));
+		// 	mcu_limits_changed_cb();
+		// 	break;
+		// case '&':
+		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Y - LIMIT_X));
+		// 	mcu_limits_changed_cb();
+		// 	break;
+		// case '/':
+		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Z - LIMIT_X));
+		// 	mcu_limits_changed_cb();
+		// 	break;
+		// case '[':
+		// 	virtualmap.special_inputs ^= (1 << (LIMIT_X2 - LIMIT_X));
+		// 	mcu_limits_changed_cb();
+		// 	break;
+		// case ']':
+		// 	virtualmap.special_inputs ^= (1 << (LIMIT_Y2 - LIMIT_X));
+		// 	mcu_limits_changed_cb();
+		// 	break;
+		// case '}':
+		// 	virtualmap.special_inputs ^= (1 << (SAFETY_DOOR - LIMIT_X));
+		// 	mcu_controls_changed_cb();
+		// 	break;
+		default:
+			mcu_com_rx_cb(c);
+			break;
+		}
 
 	} while (1);
 
@@ -1080,7 +1113,7 @@ void *stepsimul(void *args)
 
 void rpmsimul(void)
 {
-	virtualmap.inputs ^= (1<<7);
+	virtualmap.inputs ^= (1 << 7);
 	mcu_inputs_changed_cb();
 }
 
@@ -1116,11 +1149,10 @@ void ticksimul(void)
 	}
 }
 
-//uint32_t mcu_millis()
+// uint32_t mcu_millis()
 //{
 //	return mcu_runtime;
-//}
-
+// }
 
 void mcu_init(void)
 {
@@ -1154,9 +1186,9 @@ void mcu_init(void)
 	g_cpu_freq = getCPUFreq();
 	start_timer(1, &ticksimul);
 	start_timer(10, &rpmsimul);
-	//#ifdef USECONSOLE
+	// #ifdef USECONSOLE
 	//	pthread_create(&thread_idout, NULL, &comoutsimul, NULL);
-	//#endif
+	// #endif
 	pthread_create(&thread_step_id, NULL, &stepsimul, NULL);
 	pthread_create(&thread_io, NULL, &ioserver, NULL);
 	mcu_tx_enabled = false;
@@ -1180,7 +1212,8 @@ extern MCU_CALLBACK mcu_timeout_delgate mcu_timeout_cb;
 HANDLE oneshot_handle;
 VOID CALLBACK oneshot_handler(PVOID lpParameter, BOOLEAN TimerOrWaitFired)
 {
-	if(mcu_timeout_cb){
+	if (mcu_timeout_cb)
+	{
 		mcu_timeout_cb();
 	}
 }
@@ -1188,20 +1221,21 @@ VOID CALLBACK oneshot_handler(PVOID lpParameter, BOOLEAN TimerOrWaitFired)
  * configures a single shot timeout in us
  * */
 #ifndef mcu_config_timeout
-	void mcu_config_timeout(mcu_timeout_delgate fp, uint32_t timeout)
-	{
-		mcu_timeout_cb = fp;
-		mcu_timeout = timeout;
-	}
+void mcu_config_timeout(mcu_timeout_delgate fp, uint32_t timeout)
+{
+	mcu_timeout_cb = fp;
+	mcu_timeout = timeout;
+}
 #endif
 
 /**
  * starts the timeout. Once hit the the respective callback is called
  * */
 #ifndef mcu_start_timeout
-	void mcu_start_timeout(){
-		CreateTimerQueueTimer(&oneshot_handle, NULL, (WAITORTIMERCALLBACK)oneshot_handler, NULL, 0, mcu_timeout, WT_EXECUTEINTIMERTHREAD|WT_EXECUTEONLYONCE);
-	}
+void mcu_start_timeout()
+{
+	CreateTimerQueueTimer(&oneshot_handle, NULL, (WAITORTIMERCALLBACK)oneshot_handler, NULL, 0, mcu_timeout, WT_EXECUTEINTIMERTHREAD | WT_EXECUTEONLYONCE);
+}
 #endif
 #endif
 
@@ -1602,7 +1636,8 @@ void mcu_dotasks(void)
 {
 }
 
-void mcu_config_input_isr(int pin){
+void mcu_config_input_isr(int pin)
+{
 }
 
 #endif

--- a/uCNC/src/interface/grbl_interface.h
+++ b/uCNC/src/interface/grbl_interface.h
@@ -136,18 +136,19 @@ extern "C"
 #define EXEC_ALARM_EMERGENCY_STOP -1
 #define EXEC_ALARM_NOALARM 0
 // Grbl alarm codes. Valid values (1-255). Zero is reserved for the reset alarm.
-#define EXEC_ALARM_HARD_LIMIT 1
-#define EXEC_ALARM_SOFT_LIMIT 2
-#define EXEC_ALARM_ABORT_CYCLE 3
-#define EXEC_ALARM_PROBE_FAIL_INITIAL 4
-#define EXEC_ALARM_PROBE_FAIL_CONTACT 5
-#define EXEC_ALARM_HOMING_FAIL_RESET 6
-#define EXEC_ALARM_HOMING_FAIL_DOOR 7
-#define EXEC_ALARM_HOMING_FAIL_PULLOFF 8
-#define EXEC_ALARM_HOMING_FAIL_APPROACH 9
-#define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10
-#define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11
-#define EXEC_ALARM_SPINDLE_SYNC_FAIL 12
+#define EXEC_ALARM_HARD_LIMIT 1 // hard limits hit while in motion other then homing
+#define EXEC_ALARM_SOFT_LIMIT 2 // target is off bounds of the machine kinematics 
+#define EXEC_ALARM_ABORT_CYCLE 3 // an abort command was issued
+#define EXEC_ALARM_PROBE_FAIL_INITIAL 4 // probe was already triggered and was not able to initialize probing
+#define EXEC_ALARM_PROBE_FAIL_CONTACT 5 // probe failed to triggered before reaching the limit target
+#define EXEC_ALARM_HOMING_FAIL_RESET 6 // homing was aborted by a reset command
+#define EXEC_ALARM_HOMING_FAIL_DOOR 7 // door was opened during homing motion
+#define EXEC_ALARM_HOMING_FAIL_PULLOFF 8 // homing limits failed to normalize after retract by pull-distance
+#define EXEC_ALARM_HOMING_FAIL_APPROACH 9 // homing limits failed make initial contact
+#define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10 // homing limits failed make initial contact (self squaring)
+#define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11 // homing could not start since one of the limits was already triggered
+#define EXEC_ALARM_SPINDLE_SYNC_FAIL 12 // failed to achieve spindle sync speed
+#define EXEC_ALARM_HARD_LIMIT_NOMOTION 13 // hard limits were triggered without any motion (position was not lost)
 
 // formated messages
 #define STR_EOL "\r\n"

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -278,7 +278,6 @@ void protocol_send_status(void)
 		case EXEC_JOG:
 			protocol_send_string(MSG_STATUS_JOG);
 			break;
-		case EXEC_RESUMING:
 		case EXEC_RUN:
 			protocol_send_string(MSG_STATUS_RUN);
 			break;

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -236,7 +236,6 @@ void protocol_send_status(void)
 			protocol_send_string(MSG_STATUS_DOOR);
 			if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
 			{
-
 				if (cnc_get_exec_state(EXEC_RUN))
 				{
 					serial_putc('2');
@@ -258,8 +257,16 @@ void protocol_send_status(void)
 				}
 			}
 			break;
-		case EXEC_HALT:
-			protocol_send_string(MSG_STATUS_ALARM);
+		case EXEC_UNHOMED:
+		case EXEC_LIMITS:
+			if (!cnc_get_exec_state(EXEC_HOMING))
+			{
+				protocol_send_string(MSG_STATUS_ALARM);
+			}
+			else
+			{
+				protocol_send_string(MSG_STATUS_HOME);
+			}
 			break;
 		case EXEC_HOLD:
 			protocol_send_string(MSG_STATUS_HOLD);
@@ -869,6 +876,24 @@ void protocol_send_pins_states(void)
 #define FASTMATH_INFO ""
 #endif
 
+#ifdef RAM_ONLY_SETTINGS
+#define SETTINGS_INFO "RAM,"
+#else
+#define SETTINGS_INFO ""
+#endif
+
+#ifdef ENABLE_IO_ALARM_DEBUG
+#define IODBG_INFO "IODBG,"
+#else
+#define IODBG_INFO ""
+#endif
+
+#ifdef FORCE_SOFT_POLLING
+#define SPOLL_INFO "SP,"
+#else
+#define SPOLL_INFO ""
+#endif
+
 #ifdef ENABLE_LINACT_PLANNER
 #define LINPLAN_INFO "LP,"
 #else
@@ -908,7 +933,7 @@ void protocol_send_pins_states(void)
 #define BOARD_NAME "Generic board"
 #endif
 
-#define OPT_INFO __romstr__("[OPT:" KINEMATIC_INFO LINES_INFO BRESENHAM_INFO DSS_INFO DYNACCEL_INFO ACCELALG_INFO SKEW_INFO LINPLAN_INFO HMAP_INFO PPI_INFO INVESTOP_INFO CONTROLS_INFO LIMITS_INFO PROBE_INFO EXTRACMD_INFO FASTMATH_INFO)
+#define OPT_INFO __romstr__("[OPT:" KINEMATIC_INFO LINES_INFO BRESENHAM_INFO DSS_INFO DYNACCEL_INFO ACCELALG_INFO SKEW_INFO LINPLAN_INFO HMAP_INFO PPI_INFO INVESTOP_INFO SPOLL_INFO CONTROLS_INFO LIMITS_INFO PROBE_INFO IODBG_INFO SETTINGS_INFO EXTRACMD_INFO FASTMATH_INFO)
 #define VER_INFO __romstr__("[VER: uCNC " CNC_VERSION " - " BOARD_NAME "]" STR_EOL)
 
 WEAK_EVENT_HANDLER(protocol_send_cnc_info)

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -501,9 +501,10 @@ void protocol_send_gcode_modes(void)
 
 	protocol_send_string(__romstr__("[GC:"));
 
-	for (uint8_t i = 0; i < 7; i++)
+	protocol_send_parser_modalstate('G', modalgroups[0], modalgroups[12]);
+	for (uint8_t i = 1; i < 7; i++)
 	{
-		protocol_send_parser_modalstate('G', modalgroups[i], modalgroups[12]);
+		protocol_send_parser_modalstate('G', modalgroups[i], 0);
 	}
 
 	if (modalgroups[7] == 62)

--- a/uCNC/src/interface/protocol.c
+++ b/uCNC/src/interface/protocol.c
@@ -232,6 +232,7 @@ void protocol_send_status(void)
 	{
 		switch (state)
 		{
+#if ASSERT_PIN(SAFETY_DOOR)
 		case EXEC_DOOR:
 			protocol_send_string(MSG_STATUS_DOOR);
 			if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
@@ -257,6 +258,7 @@ void protocol_send_status(void)
 				}
 			}
 			break;
+#endif
 		case EXEC_UNHOMED:
 		case EXEC_LIMITS:
 			if (!cnc_get_exec_state(EXEC_HOMING))


### PR DESCRIPTION
Redesigned internal machine states:
- fixed multi drive axis compilation error
- added limit alarm with no motion (no reset required)
- replaced halt state by not homed
- added limits exec state
- high priority (lower values) alarms now require user reset (hard or soft reset)
- prevent reset loop while emergency stop is pressed