### PR TITLE
fixed RAM_ONLY_SETTINGS by default

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -522,7 +522,7 @@ extern "C"
 	 * Storing is disabled and the defaults will be loaded at each power up
 	 * This is useful if you don't have EEPROM/FLASH storage or the divide read/write maximum cycle count is low to prevent damage
 	 * */
-	#define RAM_ONLY_SETTINGS
+	// #define RAM_ONLY_SETTINGS
 
 	/**
 	 * EXPERIMENTAL! Uncomment to enable fast math macros to reduce the number of

--- a/uCNC/src/hal/boards/rp2040/rp2040.ini
+++ b/uCNC/src/hal/boards/rp2040/rp2040.ini
@@ -18,9 +18,7 @@ board_build.f_cpu = 133000000L
 [env:rpi_pico]
 extends = common_rp2040
 board = rpipico
-platform_packages =
-   framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#11ac5ed33efa6daeae5dea63d6c330986401a8cc
-; build_src_filter = +<*>-<libraries/SerialBT>-<libraries/BTstack>
+lib_ignore = HTTPUpdateServer, LittleFS, WiFi, WebServer, WiFi, SerialBT, DNSServer, Hash
 build_flags = -DBOARD=BOARD_RPI_PICO
 
 [env:rpi_pico_w]

--- a/uCNC/src/hal/mcus/rp2040/mcu_rp2040.c
+++ b/uCNC/src/hal/mcus/rp2040/mcu_rp2040.c
@@ -32,6 +32,11 @@ extern bool rp2040_uart_rx_ready(void);
 extern bool rp2040_uart_tx_ready(void);
 extern void rp2040_uart_process(void);
 
+extern void rp2040_eeprom_init(int size);
+extern uint8_t rp2040_eeprom_read(uint16_t address);
+extern void rp2040_eeprom_write(uint16_t address, uint8_t value);
+extern void rp2040_eeprom_flush(void);
+
 uint8_t rp2040_pwm[16];
 
 void mcu_din_isr(void)

--- a/uCNC/src/hal/mcus/rp2040/rp2040_arduino.cpp
+++ b/uCNC/src/hal/mcus/rp2040/rp2040_arduino.cpp
@@ -575,22 +575,22 @@ extern "C"
 #include <EEPROM.h>
 extern "C"
 {
-	static void rp2040_eeprom_init(int size)
+	void rp2040_eeprom_init(int size)
 	{
 		EEPROM.begin(size);
 	}
 
-	static uint8_t rp2040_eeprom_read(uint16_t address)
+	uint8_t rp2040_eeprom_read(uint16_t address)
 	{
 		return EEPROM.read(address);
 	}
 
-	static void rp2040_eeprom_write(uint16_t address, uint8_t value)
+	void rp2040_eeprom_write(uint16_t address, uint8_t value)
 	{
 		EEPROM.write(address, value);
 	}
 
-	static void rp2040_eeprom_flush(void)
+	void rp2040_eeprom_flush(void)
 	{
 		if (!EEPROM.commit())
 		{


### PR DESCRIPTION
- fixed compilation error on EEPROM emulation for RP2040
- update PIO ini for RP2040 to use the latest framework version
- removed global RAM_ONLY_SETTINGS