### PR TITLE
fixed jog cancelation position synch

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -825,6 +825,7 @@ bool cnc_check_interlocking(void)
 		{
 			itp_clear();
 			planner_clear();
+			mc_sync_position();
 			CLEARFLAG(cnc_state.exec_state, EXEC_HOMING | EXEC_JOG | EXEC_HOLD);
 		}
 


### PR DESCRIPTION
- fixed jog motion cancelation that causes machine to loose position synchronization between systems