### PR TITLE
Allow negative values for some settings

### DIFF
--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -320,15 +320,15 @@ uint8_t settings_change(setting_offset_t id, float value)
 
 	bool value1 = (value8 != 0);
 
-	if (value < 0 && !settings_allows_negative(id))
-	{
-		return STATUS_NEGATIVE_VALUE;
-	}
-
 #ifdef ENABLE_SETTINGS_MODULES
 	if (id < 256)
 	{
 #endif
+		if (value < 0 && !settings_allows_negative(id))
+		{
+			return STATUS_NEGATIVE_VALUE;
+		}
+
 		uint8_t setting = (uint8_t)id;
 		switch (setting)
 		{

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -301,6 +301,17 @@ void settings_save(uint16_t address, uint8_t *__ptr, uint8_t size)
 #endif
 }
 
+bool settings_allows_negative(setting_offset_t id)
+{
+#if TOOL_COUNT > 0
+	if(id > 80 && id <= (80 + TOOL_COUNT))
+	{
+		return true;
+	}
+#endif
+	return false;
+}
+
 uint8_t settings_change(setting_offset_t id, float value)
 {
 	uint8_t result = STATUS_OK;
@@ -309,7 +320,7 @@ uint8_t settings_change(setting_offset_t id, float value)
 
 	bool value1 = (value8 != 0);
 
-	if (value < 0)
+	if (value < 0 && !settings_allows_negative(id))
 	{
 		return STATUS_NEGATIVE_VALUE;
 	}


### PR DESCRIPTION
This simple change allows tool length offset setting to be set to a negative value. This is achieved by calling an additional function in which other settings allowing a negative value can be added. I have also moved this check to only validate the value for the built in system settings so that modules can easily allow negative numbers in their settings. Please tell me if any other settings should allow negative values.