### PR TITLE
Improved error recovery for STM32 microcontrollers

### DIFF
--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -856,10 +856,35 @@ static uint8_t mcu_i2c_write(uint8_t data, bool send_start, bool send_stop)
 	I2C_REG->SR1 &= ~I2C_SR1_AF;
 	if (send_start)
 	{
+		if((I2C_REG->SR1 & I2C_SR1_ARLO) || ((I2C_REG->CR1 & I2C_CR1_START) && (I2C_REG->CR1 & I2C_CR1_STOP)))
+		{
+			// Save values
+			uint32_t cr2 = I2C_REG->CR2;
+			uint32_t ccr = I2C_REG->CCR;
+			uint32_t trise = I2C_REG->TRISE;
+
+			// Software reset
+			I2C_REG->CR1 |= I2C_CR1_SWRST;
+			I2C_REG->CR1 &= ~I2C_CR1_SWRST;
+
+			// Restore values
+			I2C_REG->CR2 = cr2;
+			I2C_REG->CCR = ccr;
+			I2C_REG->TRISE = trise;
+
+			// Enable
+			I2C_REG->CR1 |= I2C_CR1_PE;
+		}
+
 		// init
 		I2C_REG->CR1 |= I2C_CR1_START;
 		while (!((I2C_REG->SR1 & I2C_SR1_SB) && (I2C_REG->SR2 & I2C_SR2_MSL) && (I2C_REG->SR2 & I2C_SR2_BUSY)))
 		{
+			if(I2C_REG->SR1 & I2C_SR1_ARLO)
+			{
+				stop = false;
+				return I2C_NOTOK;
+			}
 			if (ms_timeout < mcu_millis())
 			{
 				stop = true;
@@ -876,6 +901,15 @@ static uint8_t mcu_i2c_write(uint8_t data, bool send_start, bool send_stop)
 	I2C_REG->DR = data;
 	while (!(I2C_REG->SR1 & status))
 	{
+		if(I2C_REG->SR1 & I2C_SR1_AF)
+		{
+			break;
+		}
+		if(I2C_REG->SR1 & I2C_SR1_ARLO)
+		{
+			stop = false;
+			return I2C_NOTOK;
+		}
 		if (ms_timeout < mcu_millis())
 		{
 			stop = true;

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -966,10 +966,6 @@ static uint8_t mcu_i2c_write(uint8_t data, bool send_start, bool send_stop)
 		I2C_REG->CR1 |= I2C_CR1_START;
 		while (!((I2C_REG->SR1 & I2C_SR1_SB) && (I2C_REG->SR2 & I2C_SR2_MSL) && (I2C_REG->SR2 & I2C_SR2_BUSY)))
 		{
-			if(I2C_REG->SR1 & I2C_SR1_AF)
-			{
-				break;
-			}
 			if(I2C_REG->SR1 & I2C_SR1_ARLO)
 			{
 				stop = false;
@@ -1038,14 +1034,6 @@ static uint8_t mcu_i2c_read(uint8_t *data, bool with_ack, bool send_stop, uint32
 
 	while (!(I2C_REG->SR1 & I2C_SR1_RXNE))
 	{
-		if(I2C_REG->SR1 & I2C_SR1_AF)
-		{
-			break;
-		}
-		if(I2C_REG->SR1 & I2C_SR1_ARLO)
-		{
-			return I2C_NOTOK;
-		}
 		if (ms_timeout < mcu_millis())
 		{
 			return I2C_NOTOK;

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -942,10 +942,39 @@ static uint8_t mcu_i2c_write(uint8_t data, bool send_start, bool send_stop)
 	I2C_REG->SR1 &= ~I2C_SR1_AF;
 	if (send_start)
 	{
+		if((I2C_REG->SR1 & I2C_SR1_ARLO) || ((I2C_REG->CR1 & I2C_CR1_START) && (I2C_REG->CR1 & I2C_CR1_STOP)))
+		{
+			// Save values
+			uint32_t cr2 = I2C_REG->CR2;
+			uint32_t ccr = I2C_REG->CCR;
+			uint32_t trise = I2C_REG->TRISE;
+
+			// Software reset
+			I2C_REG->CR1 |= I2C_CR1_SWRST;
+			I2C_REG->CR1 &= ~I2C_CR1_SWRST;
+
+			// Restore values
+			I2C_REG->CR2 = cr2;
+			I2C_REG->CCR = ccr;
+			I2C_REG->TRISE = trise;
+
+			// Enable
+			I2C_REG->CR1 |= I2C_CR1_PE;
+		}
+
 		// init
 		I2C_REG->CR1 |= I2C_CR1_START;
 		while (!((I2C_REG->SR1 & I2C_SR1_SB) && (I2C_REG->SR2 & I2C_SR2_MSL) && (I2C_REG->SR2 & I2C_SR2_BUSY)))
 		{
+			if(I2C_REG->SR1 & I2C_SR1_AF)
+			{
+				break;
+			}
+			if(I2C_REG->SR1 & I2C_SR1_ARLO)
+			{
+				stop = false;
+				return I2C_NOTOK;
+			}
 			if (ms_timeout < mcu_millis())
 			{
 				stop = true;
@@ -962,6 +991,15 @@ static uint8_t mcu_i2c_write(uint8_t data, bool send_start, bool send_stop)
 	I2C_REG->DR = data;
 	while (!(I2C_REG->SR1 & status))
 	{
+		if(I2C_REG->SR1 & I2C_SR1_AF)
+		{
+			break;
+		}
+		if(I2C_REG->SR1 & I2C_SR1_ARLO)
+		{
+			stop = false;
+			return I2C_NOTOK;
+		}
 		if (ms_timeout < mcu_millis())
 		{
 			stop = true;
@@ -1000,6 +1038,14 @@ static uint8_t mcu_i2c_read(uint8_t *data, bool with_ack, bool send_stop, uint32
 
 	while (!(I2C_REG->SR1 & I2C_SR1_RXNE))
 	{
+		if(I2C_REG->SR1 & I2C_SR1_AF)
+		{
+			break;
+		}
+		if(I2C_REG->SR1 & I2C_SR1_ARLO)
+		{
+			return I2C_NOTOK;
+		}
 		if (ms_timeout < mcu_millis())
 		{
 			return I2C_NOTOK;


### PR DESCRIPTION
Implemented error recovery for I2C on STM32 microcontrollers
- [x] STM32F4x
- [x] STM32F1x

These couple of if statements improve the time it takes to respond to errors like negative acknowledge and bus lines getting stuck low. After a bit of testing it seems to prevent the I2C peripheral from getting stuck in an invalid state.