### PR TITLE
modified ISR to prevent I2C response fail

### DIFF
--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1027,22 +1027,25 @@ void mcu_i2c_config(uint32_t frequency)
 	// reset I2C
 	I2C_REG->CR1 |= I2C_CR1_SWRST;
 	I2C_REG->CR1 &= ~I2C_CR1_SWRST;
+#if I2C_ADDRESS == 0
 	// set max freq
 	I2C_REG->CR2 |= I2C_SPEEDRANGE;
 	I2C_REG->TRISE = (I2C_SPEEDRANGE + 1);
 	I2C_REG->CCR |= (frequency <= 100000UL) ? ((I2C_SPEEDRANGE * 5) & 0x0FFF) : (((I2C_SPEEDRANGE * 5 / 6) & 0x0FFF) | I2C_CCR_FS);
-#if I2C_ADDRESS != 0
+#else
 	// set address
-	I2C_REG->OAR1 = (I2C_ADDRESS << 1);
+	I2C_REG->OAR1 &= ~(I2C_OAR1_ADDMODE | 0x0F);
+	I2C_REG->OAR1 |= (I2C_ADDRESS << 1);
 	I2C_REG->OAR2 = 0;
+	I2C_REG->CR1 &= ~I2C_CR1_NOSTRETCH;
 	// enable events
-	I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN);
+	I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN | I2C_CR2_ITBUFEN);
 	NVIC_SetPriority(I2C_IRQ, 10);
 	NVIC_ClearPendingIRQ(I2C_IRQ);
 	NVIC_EnableIRQ(I2C_IRQ);
 #endif
 	// initialize the SPI configuration register
-	I2C_REG->CR1 |= I2C_CR1_PE;
+	I2C_REG->CR1 |= (I2C_CR1_PE | I2C_CR1_ENGC);
 #if I2C_ADDRESS != 0
 	// prepare ACK in slave mode
 	I2C_REG->CR1 |= I2C_CR1_ACK;
@@ -1062,29 +1065,50 @@ void I2C_ISR(void)
 
 	// address match or generic call
 	// Clear ISR flag by reading SR1 and SR2 registers
-	if ((I2C_REG->SR1 & I2C_SR1_ADDR) == I2C_SR1_ADDR)
+	if ((I2C_REG->SR1 & I2C_SR1_ADDR))
 	{
-		index = 1;
-		i = 1;
+		// clear the ISR flag
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		status = I2C_REG->SR2;
+		(void)status;
 
-		// Address matched, do necessary processing
-		if ((I2C_REG->SR2 & I2C_SR2_TRA))
+		// // Address matched, do necessary processing
+		if ((status & I2C_SR2_TRA) && !datalen)
 		{
-			I2C_REG->DR = mcu_i2c_buffer[0];
-			if (i >= datalen)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
+			mcu_i2c_buffer[i] = 0;
+			// unlock ISR and process the info request
+			// mcu_enable_global_isr();
+			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
+			datalen = i;
+		}
+		i = 0;
+	}
+
+	if ((I2C_REG->SR1 & I2C_SR1_RXNE))
+	{
+		mcu_i2c_buffer[i++] = I2C_REG->DR;
+	}
+
+	if ((I2C_REG->SR1 & I2C_SR1_TXE))
+	{
+		I2C_REG->DR = mcu_i2c_buffer[i++];
+		if (i >= datalen)
+		{
+			// send NACK
+			I2C_REG->CR1 |= I2C_CR1_STOP;
+			datalen = 0;
 		}
 	}
 
 	// Clear ISR flag by reading SR1 and writing CR1 registers
-	if ((I2C_REG->SR1 & I2C_SR1_STOPF) == I2C_SR1_STOPF)
+	if ((I2C_REG->SR1 & I2C_SR1_STOPF))
 	{
+		// clear the ISR flag
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		I2C_REG->CR1 |= I2C_CR1_PE;
 		// stop transmission
-		index = 0;
 		datalen = 0;
 		if (!(I2C_REG->SR2 & I2C_SR2_TRA))
 		{
@@ -1093,38 +1117,8 @@ void I2C_ISR(void)
 			mcu_enable_global_isr();
 			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
 			datalen = i;
+			i = 0;
 		}
-
-		// prepare ACk for next transmition
-		I2C_REG->CR1 |= I2C_CR1_ACK;
-	}
-
-	// Clear ISR flag by reading SR1 and read/write DR registers
-	if ((I2C_REG->SR1 & I2C_SR1_BTF) == I2C_SR1_BTF)
-	{
-		if ((I2C_REG->SR2 & I2C_SR2_TRA))
-		{
-			I2C_REG->DR = mcu_i2c_buffer[i++];
-			if (i >= datalen)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
-		}
-		else
-		{
-			mcu_i2c_buffer[i++] = I2C_REG->DR;
-			if (i >= I2C_SLAVE_BUFFER_SIZE)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
-		}
-
-		index = i;
-		I2C_REG->CR1 |= I2C_CR1_ACK;
 	}
 
 	// An error ocurred
@@ -1136,10 +1130,16 @@ void I2C_ISR(void)
 		I2C_REG->CR1 |= I2C_CR1_ACK;
 		I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN);
 		// clear ISR flag
-		I2C_REG->SR1 &= 0X00FF;
-		I2C_REG->SR2;
+		I2C_REG->SR1 = I2C_REG->SR1 & 0X00FF;
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		status = I2C_REG->SR2;
+		(void)status;
 	}
 
+	// prepare ACK for next transmition
+	index = i;
+	I2C_REG->CR1 |= I2C_CR1_ACK;
 	NVIC_ClearPendingIRQ(I2C_IRQ);
 }
 #endif

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1078,7 +1078,7 @@ void I2C_ISR(void)
 		{
 			mcu_i2c_buffer[i] = 0;
 			// unlock ISR and process the info request
-			// mcu_enable_global_isr();
+			mcu_enable_global_isr();
 			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
 			datalen = i;
 		}
@@ -1093,7 +1093,7 @@ void I2C_ISR(void)
 	if ((I2C_REG->SR1 & I2C_SR1_TXE))
 	{
 		I2C_REG->DR = mcu_i2c_buffer[i++];
-		if (i >= datalen)
+		if (i > datalen)
 		{
 			// send NACK
 			I2C_REG->CR1 |= I2C_CR1_STOP;
@@ -1110,15 +1110,6 @@ void I2C_ISR(void)
 		I2C_REG->CR1 |= I2C_CR1_PE;
 		// stop transmission
 		datalen = 0;
-		if (!(I2C_REG->SR2 & I2C_SR2_TRA))
-		{
-			mcu_i2c_buffer[i] = 0;
-			// unlock ISR and process the info request
-			mcu_enable_global_isr();
-			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
-			datalen = i;
-			i = 0;
-		}
 	}
 
 	// An error ocurred

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -1178,7 +1178,7 @@ void I2C_ISR(void)
 	if ((I2C_REG->SR1 & I2C_SR1_TXE))
 	{
 		I2C_REG->DR = mcu_i2c_buffer[i++];
-		if (i >= datalen)
+		if (i > datalen)
 		{
 			// send NACK
 			I2C_REG->CR1 |= I2C_CR1_STOP;
@@ -1195,15 +1195,6 @@ void I2C_ISR(void)
 		I2C_REG->CR1 |= I2C_CR1_PE;
 		// stop transmission
 		datalen = 0;
-		if (!(I2C_REG->SR2 & I2C_SR2_TRA))
-		{
-			mcu_i2c_buffer[i] = 0;
-			// unlock ISR and process the info request
-			mcu_enable_global_isr();
-			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
-			datalen = i;
-			i = 0;
-		}
 	}
 
 	// An error ocurred

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -1104,32 +1104,33 @@ uint8_t mcu_i2c_receive(uint8_t address, uint8_t *data, uint8_t datalen, uint32_
 void mcu_i2c_config(uint32_t frequency)
 {
 	RCC->APB1ENR |= I2C_APBEN;
-	mcu_config_af(I2C_CLK, I2C_AFIO);
-	mcu_config_af(I2C_DATA, I2C_AFIO);
-	mcu_config_pullup(I2C_CLK);
-	mcu_config_pullup(I2C_DATA);
-	// set opendrain
-	mcu_config_opendrain(I2C_CLK);
-	mcu_config_opendrain(I2C_DATA);
+	mcu_config_output_af(I2C_CLK, GPIO_OUTALT_OD_50MHZ);
+	mcu_config_output_af(I2C_DATA, GPIO_OUTALT_OD_50MHZ);
+#ifdef SPI_REMAP
+	AFIO->MAPR |= I2C_REMAP;
+#endif
 	// reset I2C
 	I2C_REG->CR1 |= I2C_CR1_SWRST;
 	I2C_REG->CR1 &= ~I2C_CR1_SWRST;
+#if I2C_ADDRESS == 0
 	// set max freq
 	I2C_REG->CR2 |= I2C_SPEEDRANGE;
 	I2C_REG->TRISE = (I2C_SPEEDRANGE + 1);
 	I2C_REG->CCR |= (frequency <= 100000UL) ? ((I2C_SPEEDRANGE * 5) & 0x0FFF) : (((I2C_SPEEDRANGE * 5 / 6) & 0x0FFF) | I2C_CCR_FS);
-#if I2C_ADDRESS != 0
+#else
 	// set address
-	I2C_REG->OAR1 = (I2C_ADDRESS << 1);
+	I2C_REG->OAR1 &= ~(I2C_OAR1_ADDMODE | 0x0F);
+	I2C_REG->OAR1 |= (I2C_ADDRESS << 1);
 	I2C_REG->OAR2 = 0;
+	I2C_REG->CR1 &= ~I2C_CR1_NOSTRETCH;
 	// enable events
-	I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN);
+	I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN | I2C_CR2_ITBUFEN);
 	NVIC_SetPriority(I2C_IRQ, 10);
 	NVIC_ClearPendingIRQ(I2C_IRQ);
 	NVIC_EnableIRQ(I2C_IRQ);
 #endif
 	// initialize the SPI configuration register
-	I2C_REG->CR1 |= I2C_CR1_PE;
+	I2C_REG->CR1 |= (I2C_CR1_PE | I2C_CR1_ENGC);
 #if I2C_ADDRESS != 0
 	// prepare ACK in slave mode
 	I2C_REG->CR1 |= I2C_CR1_ACK;
@@ -1149,29 +1150,50 @@ void I2C_ISR(void)
 
 	// address match or generic call
 	// Clear ISR flag by reading SR1 and SR2 registers
-	if ((I2C_REG->SR1 & I2C_SR1_ADDR) == I2C_SR1_ADDR)
+	if ((I2C_REG->SR1 & I2C_SR1_ADDR))
 	{
-		index = 1;
-		i = 1;
+		// clear the ISR flag
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		status = I2C_REG->SR2;
+		(void)status;
 
-		// Address matched, do necessary processing
-		if ((I2C_REG->SR2 & I2C_SR2_TRA))
+		// // Address matched, do necessary processing
+		if ((status & I2C_SR2_TRA) && !datalen)
 		{
-			I2C_REG->DR = mcu_i2c_buffer[0];
-			if (i >= datalen)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
+			mcu_i2c_buffer[i] = 0;
+			// unlock ISR and process the info request
+			// mcu_enable_global_isr();
+			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
+			datalen = i;
+		}
+		i = 0;
+	}
+
+	if ((I2C_REG->SR1 & I2C_SR1_RXNE))
+	{
+		mcu_i2c_buffer[i++] = I2C_REG->DR;
+	}
+
+	if ((I2C_REG->SR1 & I2C_SR1_TXE))
+	{
+		I2C_REG->DR = mcu_i2c_buffer[i++];
+		if (i >= datalen)
+		{
+			// send NACK
+			I2C_REG->CR1 |= I2C_CR1_STOP;
+			datalen = 0;
 		}
 	}
 
 	// Clear ISR flag by reading SR1 and writing CR1 registers
-	if ((I2C_REG->SR1 & I2C_SR1_STOPF) == I2C_SR1_STOPF)
+	if ((I2C_REG->SR1 & I2C_SR1_STOPF))
 	{
+		// clear the ISR flag
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		I2C_REG->CR1 |= I2C_CR1_PE;
 		// stop transmission
-		index = 0;
 		datalen = 0;
 		if (!(I2C_REG->SR2 & I2C_SR2_TRA))
 		{
@@ -1180,38 +1202,8 @@ void I2C_ISR(void)
 			mcu_enable_global_isr();
 			mcu_i2c_slave_cb(mcu_i2c_buffer, &i);
 			datalen = i;
+			i = 0;
 		}
-
-		// prepare ACk for next transmition
-		I2C_REG->CR1 |= I2C_CR1_ACK;
-	}
-
-	// Clear ISR flag by reading SR1 and read/write DR registers
-	if ((I2C_REG->SR1 & I2C_SR1_BTF) == I2C_SR1_BTF)
-	{
-		if ((I2C_REG->SR2 & I2C_SR2_TRA))
-		{
-			I2C_REG->DR = mcu_i2c_buffer[i++];
-			if (i >= datalen)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
-		}
-		else
-		{
-			mcu_i2c_buffer[i++] = I2C_REG->DR;
-			if (i >= I2C_SLAVE_BUFFER_SIZE)
-			{
-				// send NACK
-				I2C_REG->CR1 &= ~I2C_CR1_ACK;
-				return;
-			}
-		}
-
-		index = i;
-		I2C_REG->CR1 |= I2C_CR1_ACK;
 	}
 
 	// An error ocurred
@@ -1223,10 +1215,16 @@ void I2C_ISR(void)
 		I2C_REG->CR1 |= I2C_CR1_ACK;
 		I2C_REG->CR2 |= (I2C_CR2_ITEVTEN | I2C_CR2_ITERREN);
 		// clear ISR flag
-		I2C_REG->SR1 &= 0X00FF;
-		I2C_REG->SR2;
+		I2C_REG->SR1 = I2C_REG->SR1 & 0X00FF;
+		volatile uint32_t status = I2C_REG->SR1;
+		(void)status;
+		status = I2C_REG->SR2;
+		(void)status;
 	}
 
+	// prepare ACK for next transmition
+	index = i;
+	I2C_REG->CR1 |= I2C_CR1_ACK;
 	NVIC_ClearPendingIRQ(I2C_IRQ);
 }
 #endif


### PR DESCRIPTION
- modified ISR to prevent I2C response fail. NACK is sent by the slave sending a stop condition
- stop ISR flag is not signal on repeated start causing the response callback to never get called. added additional callback condition on ISR