### PR TITLE
prevent JOG synch problem on cancel

### DIFF
--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -1059,7 +1059,7 @@ void itp_stop(void)
 	}
 
 	// end of JOG
-	if (state & EXEC_JOG)
+	if (CHECKFLAG(state, (EXEC_JOG | EXEC_HOLD)) == EXEC_JOG)
 	{
 		if (itp_is_empty())
 		{


### PR DESCRIPTION
- prevent JOG synch problem on cancel (with soft limits enabled)