### PR TITLE
new serial tx busy function

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -133,7 +133,6 @@ void cnc_run(void)
 		} while (cnc_exec_cmd());
 
 		cnc_state.loop_state = LOOP_FAULT;
-		// serial_flush();
 		int8_t alarm = cnc_state.alarm;
 		if (alarm > EXEC_ALARM_NOALARM)
 		{

--- a/uCNC/src/interface/serial.c
+++ b/uCNC/src/interface/serial.c
@@ -165,16 +165,24 @@ void serial_inject_cmd(const char *__s)
 	} while (c);
 }
 
+static uint8_t serial_tx_count;
 void serial_putc(unsigned char c)
 {
+	serial_tx_count++;
 	mcu_putc(c);
 	if (c == '\n')
 	{
-		serial_flush();
+		serial_tx_count = 0;
+		mcu_flush();
 	}
 #if ASSERT_PIN(ACTIVITY_LED)
 	mcu_toggle_output(ACTIVITY_LED);
 #endif
+}
+
+uint8_t serial_tx_busy(void)
+{
+	return serial_tx_count;
 }
 
 void print_str(print_cb cb, const char *__s)
@@ -316,11 +324,6 @@ void print_fltarr(print_cb cb, float *arr, uint8_t count)
 			print_flt(cb, 0);
 		} while (--i);
 	}
-}
-
-void serial_flush(void)
-{
-	mcu_flush();
 }
 
 // ISR

--- a/uCNC/src/interface/serial.h
+++ b/uCNC/src/interface/serial.h
@@ -47,11 +47,11 @@ extern "C"
 	void serial_ungetc(void);
 	unsigned char serial_peek(void);
 	void serial_inject_cmd(const char *__s);
-	void serial_restore_line(void);
 	void serial_rx_clear(void);
 	void serial_select(uint8_t source);
 
 	void serial_putc(unsigned char c);
+	uint8_t serial_tx_busy(void);
 	// printing utils
 	typedef void (*print_cb)(unsigned char);
 	void print_str(print_cb cb, const char *__s);
@@ -70,7 +70,6 @@ extern "C"
 #define serial_print_intarr(arr, count) print_intarr(serial_putc, arr, count)
 #define serial_print_fltarr(arr, count) print_fltarr(serial_putc, arr, count)
 
-	void serial_flush(void);
 	uint8_t serial_get_rx_freebytes(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
- new serial tx busy function use to evaluate status report print skip and prevent protocol message contamination (interleaved messages)
- code cleaning