### PR TITLE
Force parser re-sync on gcode error

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -195,6 +195,7 @@ bool cnc_exec_cmd(void)
 		}
 		else
 		{
+			parser_sync_position();
 			protocol_send_error(error);
 #ifdef ENABLE_MAIN_LOOP_MODULES
 			EVENT_INVOKE(cnc_exec_cmd_error, &error);


### PR DESCRIPTION
- Force parser re-sync on gcode error to prevent sync error between motion control and parser