### PR TITLE
Prevent usb flush infinite loop if unconnected

### DIFF
--- a/uCNC/src/cnc_build.h
+++ b/uCNC/src/cnc_build.h
@@ -25,7 +25,7 @@ extern "C"
 #endif
 
 #define CNC_MAJOR_MINOR_VERSION "1.7"
-#define CNC_PATCH_VERSION ".5"
+#define CNC_PATCH_VERSION ".5-fix"
 
 #define CNC_VERSION CNC_MAJOR_MINOR_VERSION CNC_PATCH_VERSION
 

--- a/uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp
+++ b/uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp
@@ -60,21 +60,18 @@ extern "C"
 	DECL_BUFFER(uint8_t, usb, USB_TX_BUFFER_SIZE);
 	void mcu_usb_flush(void)
 	{
-#ifdef MCU_HAS_USB
-#ifdef USE_ARDUINO_CDC
+
 		while (!BUFFER_EMPTY(usb))
 		{
 			char tmp[USB_TX_BUFFER_SIZE];
 			uint8_t r;
 
 			BUFFER_READ(usb, tmp, USB_TX_BUFFER_SIZE, r);
+#ifdef MCU_HAS_USB
 			UsbSerial.write(tmp, r);
 			UsbSerial.flushTX();
+#endif
 		}
-#else
-		tusb_cdc_flush();
-#endif
-#endif
 	}
 
 	void mcu_usb_putc(uint8_t c)

--- a/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
+++ b/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
@@ -788,6 +788,10 @@ void mcu_usb_flush(void)
 	while (!tusb_cdc_write_available())
 	{
 		mcu_dotasks(); // tinyusb device task
+		if (!tusb_cdc_connected)
+		{
+			return;
+		}
 	}
 }
 #endif

--- a/uCNC/src/hal/mcus/samd21/mcu_samd21.c
+++ b/uCNC/src/hal/mcus/samd21/mcu_samd21.c
@@ -756,6 +756,10 @@ void mcu_usb_putc(uint8_t c)
 	if (!tusb_cdc_write_available())
 	{
 		mcu_usb_flush();
+		if (!tusb_cdc_connected)
+		{
+			return;
+		}
 	}
 	tusb_cdc_write(c);
 }

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -488,6 +488,10 @@ void mcu_usb_flush(void)
 	while (!tusb_cdc_write_available())
 	{
 		mcu_dotasks(); // tinyusb device task
+		if (!tusb_cdc_connected)
+		{
+			return;
+		}
 	}
 }
 #endif

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -497,6 +497,10 @@ void mcu_usb_flush(void)
 	while (!tusb_cdc_write_available())
 	{
 		mcu_dotasks(); // tinyusb device task
+		if (!tusb_cdc_connected)
+		{
+			return;
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Prevent usb flush infinite loop if unconnected allowing other ports like UART to flush the message protocol.
These changes affect mainly STM32 and SAMD21 since other boards with USB are using Arduino CDC.