### PR TITLE
Dotasks code redesign

### DIFF
--- a/uCNC/cnc_hal_config.h
+++ b/uCNC/cnc_hal_config.h
@@ -166,7 +166,7 @@ extern "C"
  * To achieve that each each LIMITx_IO_MASK should be set to the corresponding STEP IO MASK that it controls
  * 
  * For example to use STEP0 and STEP6 to drive the AXIS_X/LINACT0 you need to configure the correct LINACT0_IO_MASK and then to make LIMIT_X stop STEP0 and LIMIT_X2 stop STEP6 you need
- * to reassing LIMIT_X2 to STEP6 IO MASK like this
+ * to reassign LIMIT_X2 to STEP6 IO MASK do it like this
  * 
  * #define LIMIT_X2_IO_MASK STEP6_IO_MASK
  * 
@@ -217,20 +217,20 @@ extern "C"
  * Limits for AXIS X does not require any special configuration. Uses the default settings for a single linear actuator with one motor and a limit switch (uses LIMIT_X)
  * Limits for AXIS Y only require Limit Y2 to be reasigned to match STEP2 so in this case
  * 
- * #define ENABLE_Y_AUTOLEVEL
  * #define LIMIT_Y2_IO_MASK STEP2_IO_MASK
  * 
- * And finally limits for AXIS Z will new to be reassined to the matching STEPx. We will also need a 3rd limit. We will use LIMIT_A since AXIS_A is not used.
+ * And finally limits for AXIS Z will new to be reassigned to the matching STEPx. We will also need a 3rd limit. We will use LIMIT_A since AXIS_A is not used.
  *  
  * // enable Z selfsquare/selfplane
- * #define ENABLE_Z_AUTOLEVEL
  * #define LIMIT_Y_IO_MASK STEP3_IO_MASK
  * #define LIMIT_Y2_IO_MASK STEP4_IO_MASK
  * #define LIMIT_A_IO_MASK STEP5_IO_MASK
  * 
- * There is still a final step that involve reassing LINACT2 limits to include the extra limit (LIMIT A) like this
+ * There is still a final step that involve reassign LINACT2 limits to include the extra limit (LIMIT A) like this
  * 
  * #define LINACT2_LIMIT_MASK (LIMIT_Y_IO_MASK | LIMIT_Y2_IO_MASK | LIMIT_A_IO_MASK)
+ * 
+ * Also remember that ENABLE_AXIS_AUTOLEVEL should be enabled for this to work
  * 
  * That is it. 
  * 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -74,26 +74,13 @@ WEAK_EVENT_HANDLER(rtc_tick)
 // event_cnc_dotasks_handler
 WEAK_EVENT_HANDLER(cnc_dotasks)
 {
-	// prevent re-entrancy
-	static bool running = false;
-	if (!running)
-	{
-		running = true;
-		DEFAULT_EVENT_HANDLER(cnc_dotasks);
-		running = false;
-	}
+	DEFAULT_EVENT_HANDLER(cnc_dotasks);
 }
 
 // event_cnc_dotasks_handler
 WEAK_EVENT_HANDLER(cnc_io_dotasks)
 {
-	// prevent re-entrancy
-	static bool running = false;
-	if (!running)
-	{
-		running = true;
-		DEFAULT_EVENT_HANDLER(cnc_io_dotasks);
-	}
+	DEFAULT_EVENT_HANDLER(cnc_io_dotasks);
 }
 
 // event_cnc_stop_handler
@@ -271,7 +258,14 @@ bool cnc_dotasks(void)
 #endif
 
 #ifdef ENABLE_MAIN_LOOP_MODULES
-	EVENT_INVOKE(cnc_dotasks, NULL);
+	// prevent re-entrancy
+	static bool running = false;
+	if (!running)
+	{
+		running = true;
+		EVENT_INVOKE(cnc_dotasks, NULL);
+		running = false;
+	}
 #endif
 
 	if (!lock_itp)
@@ -429,6 +423,8 @@ bool cnc_has_alarm()
 
 uint8_t cnc_get_alarm(void)
 {
+	// force interlocking check to set alarm code in case this as not yet been set
+	cnc_check_interlocking();
 	return cnc_state.alarm;
 }
 
@@ -1019,7 +1015,14 @@ static void cnc_io_dotasks(void)
 	}
 
 #ifdef ENABLE_MAIN_LOOP_MODULES
-	EVENT_INVOKE(cnc_io_dotasks, NULL);
+	// prevent re-entrancy
+	static bool running = false;
+	if (!running)
+	{
+		running = true;
+		EVENT_INVOKE(cnc_io_dotasks, NULL);
+		running = false;
+	}
 #endif
 }
 

--- a/uCNC/src/hal/boards/avr/avr.ini
+++ b/uCNC/src/hal/boards/avr/avr.ini
@@ -13,26 +13,28 @@ debug_build_flags = -Og -g3 -ggdb3 -gdwarf-2
 build_flags = ${common.build_flags} -mcall-prologues -mrelax -flto -fno-fat-lto-objects -fno-tree-scev-cprop -Wl,--relax
 lib_ignore = EEPROM, SPI, Wire
 
-[env:uno]
+[atmega328p]
 extends = common_avr
 board = uno
-build_flags = ${common_avr.build_flags} -D BOARD=BOARD_UNO
+;saves a bit of flash
+build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES
+
+[env:uno]
+extends = atmega328p
+build_flags = ${atmega328p.build_flags} -D BOARD=BOARD_UNO
 
 [env:uno_shield_v3]
-extends = common_avr
-board = uno
-build_flags = ${common_avr.build_flags} -D BOARD=BOARD_UNO_SHIELD_V3
+extends = atmega328p
+build_flags = ${atmega328p.build_flags} -D BOARD=BOARD_UNO_SHIELD_V3
 
 [env:x_controller]
-extends = common_avr
-board = uno
-build_flags = ${common_avr.build_flags} -D BOARD=BOARD_X_CONTROLLER
+extends = atmega328p
+build_flags = ${atmega328p.build_flags} -D BOARD=BOARD_X_CONTROLLER
 
 [env:mks_dlc]
 extends = common_avr
-board = uno
 board_build.f_cpu = 20000000UL
-build_flags = ${common_avr.build_flags} -D BOARD=BOARD_MKS_DLC
+build_flags = ${atmega328p.build_flags} -D BOARD=BOARD_MKS_DLC
 
 [env:ramps14]
 extends = common_avr

--- a/uCNC/src/hal/kinematics/kinematic_scara.c
+++ b/uCNC/src/hal/kinematics/kinematic_scara.c
@@ -93,58 +93,46 @@ uint8_t kinematics_home(void)
 	float target[AXIS_COUNT];
 
 #ifndef DISABLE_ALL_LIMITS
-#ifndef DISABLE_Z_HOMING
-#if (defined(AXIS_Z) && (ASSERT_PIN(LIMIT_Z) || ASSERT_PIN(LIMIT_Z2)))
-	if (mc_home_axis(AXIS_Z, LIMIT_Z_MASK))
+#if AXIS_Z_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_Z_HOMING_MASK, LINACT2_LIMIT_MASK))
 	{
 		return KINEMATIC_HOMING_ERROR_Z;
 	}
 #endif
-#endif
 
-#ifndef DISABLE_X_HOMING
-#if (defined(AXIS_X) && (ASSERT_PIN(LIMIT_X) || ASSERT_PIN(LIMIT_X2)))
-	if (mc_home_axis(AXIS_X, LIMIT_X_MASK))
+#if AXIS_X_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_X_HOMING_MASK, LINACT0_LIMIT_MASK))
 	{
 		return KINEMATIC_HOMING_ERROR_X;
 	}
 #endif
-#endif
 
-#ifndef DISABLE_Y_HOMING
-#if (defined(AXIS_Y) && (ASSERT_PIN(LIMIT_Y) || ASSERT_PIN(LIMIT_Y2)))
-	if (mc_home_axis(AXIS_Y, LIMIT_Y_MASK))
+#if AXIS_Y_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_Y_HOMING_MASK, LINACT1_LIMIT_MASK))
 	{
 		return KINEMATIC_HOMING_ERROR_Y;
 	}
 #endif
-#endif
 
-#ifndef DISABLE_A_HOMING
-#if (defined(AXIS_A) && ASSERT_PIN(LIMIT_A))
-	if (mc_home_axis(AXIS_A, LIMIT_A_MASK))
+#if AXIS_A_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_A_HOMING_MASK, LINACT3_LIMIT_MASK))
 	{
 		return (KINEMATIC_HOMING_ERROR_X | KINEMATIC_HOMING_ERROR_Y | KINEMATIC_HOMING_ERROR_Z);
 	}
 #endif
-#endif
 
-#ifndef DISABLE_B_HOMING
-#if (defined(AXIS_B) && ASSERT_PIN(LIMIT_B))
-	if (mc_home_axis(AXIS_B, LIMIT_B_MASK))
+#if AXIS_B_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_B_HOMING_MASK, LINACT4_LIMIT_MASK))
 	{
 		return KINEMATIC_HOMING_ERROR_B;
 	}
 #endif
-#endif
 
-#ifndef DISABLE_C_HOMING
-#if (defined(AXIS_C) && ASSERT_PIN(LIMIT_C))
-	if (mc_home_axis(AXIS_C, LIMIT_C_MASK))
+#if AXIS_C_HOMING_MASK != 0
+	if (mc_home_axis(AXIS_C_HOMING_MASK, LINACT5_LIMIT_MASK))
 	{
 		return KINEMATIC_HOMING_ERROR_C;
 	}
-#endif
 #endif
 
 	cnc_unlock(true);


### PR DESCRIPTION
- modified cnc delay to run dotasks instead of only io_dotasks
- prevent re-entrant code inside dotasks events
- redesign the main loop tasks to prevent re-entrant code on the event callbacks
- force interlocking check before getting the alarm to force alarm code refresh if alarm condition is triggered by ISR
- fixed scara kinematics code to match new multi axis