### PR TITLE
fixed RUN state clear after alarm while running

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -343,6 +343,8 @@ void cnc_stop(void)
 #ifdef ENABLE_MAIN_LOOP_MODULES
 	EVENT_INVOKE(cnc_stop, NULL);
 #endif
+
+	cnc_clear_exec_state(EXEC_RUN);
 }
 
 uint8_t cnc_unlock(bool force)


### PR DESCRIPTION
- fixes sticky RUN state after alarm and CNC stop. This would prevent the reset to continue loop to continue and enter the reset loop