### PR TITLE
settings crc takes data size in account

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -1050,14 +1050,12 @@ static void cnc_io_dotasks(void)
 
 void cnc_run_startup_blocks(void)
 {
-	serial_broadcast(true);
 	if (settings_check_startup_gcode(STARTUP_BLOCK0_ADDRESS_OFFSET))
 	{
 		serial_stream_eeprom(STARTUP_BLOCK0_ADDRESS_OFFSET);
 		cnc_exec_cmd();
 	}
 
-	serial_broadcast(true);
 	if (settings_check_startup_gcode(STARTUP_BLOCK1_ADDRESS_OFFSET))
 	{
 		serial_stream_eeprom(STARTUP_BLOCK1_ADDRESS_OFFSET);

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -438,15 +438,18 @@ static uint8_t parser_grbl_command(void)
 					return STATUS_INVALID_STATEMENT;
 				}
 
-				settings_save_startup_gcode(block_address);
+				settings_save(block_address, NULL, UINT16_MAX);
 				// run startup block
 				serial_broadcast(true);
 				serial_stream_eeprom(block_address);
+				// checks the command validity
 				error = parser_fetch_command(&next_state, &words, &cmd);
-				if (error == STATUS_OK)
-				{
-					error = parser_validate_command(&next_state, &words, &cmd);
-				}
+				// if uncomment will also check if any gcode rules are violated
+				// allow bad rules for now to fit UNO. Will be catched when trying to execute the line
+				// if (error == STATUS_OK)
+				// {
+				// 	error = parser_validate_command(&next_state, &words, &cmd);
+				// }
 
 				serial_broadcast(false);
 				// reset streams
@@ -455,7 +458,7 @@ static uint8_t parser_grbl_command(void)
 				if (error != STATUS_OK)
 				{
 					// the Gcode is not valid then erase the startup block
-					mcu_eeprom_putc(block_address, 0);
+					settings_erase(block_address, NULL, 1);
 				}
 
 				return error;

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -248,18 +248,16 @@ uint8_t parser_get_probe_result(void)
 void parser_parameters_reset(void)
 {
 	// erase all parameters for G54..G59.x coordinate systems
-	memset(parser_parameters.coord_system_offset, 0, sizeof(parser_parameters.coord_system_offset));
 #ifndef DISABLE_COORD_SYS_SUPPORT
 	for (uint8_t i = 0; i < COORD_SYS_COUNT; i++)
 	{
-		settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET + (i * PARSER_PARAM_ADDR_OFFSET), PARSER_PARAM_SIZE);
+		settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET + (i * PARSER_PARAM_ADDR_OFFSET), (uint8_t *)&parser_parameters.coord_system_offset, PARSER_PARAM_SIZE);
 	}
 #endif
 
 // erase G92
 #ifdef G92_STORE_NONVOLATILE
-	settings_erase(G92ADDRESS, PARSER_PARAM_SIZE);
-	memset(g92permanentoffset, 0, sizeof(g92permanentoffset));
+	settings_erase(G92ADDRESS, (uint8_t *)&g92permanentoffset, PARSER_PARAM_SIZE);
 #endif
 }
 
@@ -2594,8 +2592,7 @@ void parser_parameters_load(void)
 #ifdef G92_STORE_NONVOLATILE
 	if (settings_load(G92ADDRESS, (uint8_t *)&parser_parameters.g92_offset, PARSER_PARAM_SIZE))
 	{
-		memset(parser_parameters.g92_offset, 0, sizeof(parser_parameters.g92_offset));
-		settings_erase(G92ADDRESS, PARSER_PARAM_SIZE);
+		settings_erase(G92ADDRESS, (uint8_t *)&parser_parameters.g92_offset, PARSER_PARAM_SIZE);
 	}
 	memcpy(g92permanentoffset, parser_parameters.g92_offset, sizeof(g92permanentoffset));
 #else
@@ -2607,7 +2604,7 @@ void parser_parameters_load(void)
 	{
 		if (settings_load(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET + (i * PARSER_PARAM_ADDR_OFFSET), (uint8_t *)&parser_parameters.coord_system_offset, PARSER_PARAM_SIZE))
 		{
-			settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET + (i * PARSER_PARAM_ADDR_OFFSET), PARSER_PARAM_SIZE);
+			settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET + (i * PARSER_PARAM_ADDR_OFFSET), (uint8_t *)&parser_parameters.coord_system_offset, PARSER_PARAM_SIZE);
 		}
 	}
 
@@ -2615,8 +2612,7 @@ void parser_parameters_load(void)
 #ifndef DISABLE_COORD_SYS_SUPPORT
 	if (settings_load(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET, (uint8_t *)&parser_parameters.coord_system_offset, PARSER_PARAM_SIZE))
 	{
-		memset(parser_parameters.coord_system_offset, 0, sizeof(parser_parameters.coord_system_offset));
-		settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET, PARSER_PARAM_SIZE);
+		settings_erase(SETTINGS_PARSER_PARAMETERS_ADDRESS_OFFSET, (uint8_t *)&parser_parameters.coord_system_offset, PARSER_PARAM_SIZE);
 	}
 #endif
 }

--- a/uCNC/src/hal/mcus/esp32/esp32_arduino.cpp
+++ b/uCNC/src/hal/mcus/esp32/esp32_arduino.cpp
@@ -233,8 +233,7 @@ extern "C"
 
 			if (!strcmp((const char*)&grbl_cmd_str[4], "RESET"))
 			{
-				settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-				memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+				settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 				protocol_send_feedback("WiFi settings deleted");
 				return STATUS_OK;
 			}
@@ -384,8 +383,7 @@ extern "C"
 		wifi_settings_offset = settings_register_external_setting(sizeof(wifi_settings_t));
 		if (settings_load(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t)))
 		{
-			settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-			memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+			settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 		}
 
 		WiFi.begin();
@@ -402,8 +400,7 @@ extern "C"
 		bt_settings_offset = settings_register_external_setting(1);
 		if (settings_load(bt_settings_offset, &bt_on, 1))
 		{
-			settings_erase(bt_settings_offset, 1);
-			bt_on = 0;
+			settings_erase(bt_settings_offset,(uint8_t *)&bt_on, 1);
 		}
 
 		if (bt_on)

--- a/uCNC/src/hal/mcus/esp8266/esp8266_arduino.cpp
+++ b/uCNC/src/hal/mcus/esp8266/esp8266_arduino.cpp
@@ -195,8 +195,7 @@ extern "C"
 
 			if (!strcmp((const char *)&grbl_cmd_str[4], "RESET"))
 			{
-				settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-				memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+				settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 				protocol_send_feedback((const char *)"WiFi settings deleted");
 				return STATUS_OK;
 			}
@@ -346,8 +345,7 @@ extern "C"
 		wifi_settings_offset = settings_register_external_setting(sizeof(wifi_settings_t));
 		if (settings_load(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t)))
 		{
-			settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-			memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+			settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 		}
 
 		WiFi.begin();

--- a/uCNC/src/hal/mcus/rp2040/rp2040_arduino.cpp
+++ b/uCNC/src/hal/mcus/rp2040/rp2040_arduino.cpp
@@ -233,8 +233,7 @@ uint8_t mcu_custom_grbl_cmd(uint8_t *grbl_cmd_str, uint8_t grbl_cmd_len, uint8_t
 
 		if (!strcmp((const char*)&grbl_cmd_str[4], "RESET"))
 		{
-			settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-			memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+			settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 			protocol_send_feedback((const char*)"WiFi settings deleted");
 			return STATUS_OK;
 		}
@@ -385,8 +384,7 @@ void rp2040_wifi_bt_init(void)
 	wifi_settings_offset = settings_register_external_setting(sizeof(wifi_settings_t));
 	if (settings_load(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t)))
 	{
-		settings_erase(wifi_settings_offset, sizeof(wifi_settings_t));
-		memset(&wifi_settings, 0, sizeof(wifi_settings_t));
+		settings_erase(wifi_settings_offset, (uint8_t *)&wifi_settings, sizeof(wifi_settings_t));
 	}
 
 	WiFi.begin(wifi_settings.ssid, wifi_settings.pass);
@@ -403,8 +401,7 @@ void rp2040_wifi_bt_init(void)
 	bt_settings_offset = settings_register_external_setting(1);
 	if (settings_load(bt_settings_offset, &bt_on, 1))
 	{
-		settings_erase(bt_settings_offset, 1);
-		bt_on = 0;
+		settings_erase(bt_settings_offset, (uint8_t *)&bt_on, 1);
 	}
 
 	if (bt_on)

--- a/uCNC/src/interface/serial.c
+++ b/uCNC/src/interface/serial.c
@@ -147,7 +147,9 @@ void serial_stream_readonly(stream_getc_cb getc_cb, stream_available_cb availabl
 static uint16_t stream_eeprom_address;
 static uint8_t stream_eeprom_getc(void)
 {
-	return mcu_eeprom_getc(stream_eeprom_address++);
+	uint8_t c = mcu_eeprom_getc(stream_eeprom_address++);
+	serial_putc((c != EOL) ? c : ':');
+	return c;
 }
 
 void serial_stream_eeprom(uint16_t address)
@@ -313,7 +315,8 @@ void serial_putc(char c)
 }
 
 #ifdef ENABLE_DEBUG_STREAM
-void debug_putc(char c){
+void debug_putc(char c)
+{
 	DEBUG_STREAM->stream_putc(c);
 
 	if (c == '\n')

--- a/uCNC/src/interface/serial.h
+++ b/uCNC/src/interface/serial.h
@@ -96,7 +96,7 @@ extern serial_stream_t *default_stream;
 #endif
 
 extern void debug_putc(char c);
-#define DEBUG_PUTC debug_putc
+#define DEBUG_PUTC(c) debug_putc(c)
 #define DEBUG_STR(__s) print_str(debug_putc, __s)
 #define DEBUG_BYTES(data, count) print_bytes(debug_putc, data, count)
 #define DEBUG_INT(num) print_int(debug_putc, num)
@@ -105,6 +105,7 @@ extern void debug_putc(char c);
 #define DEBUG_INTARR(arr, count) print_intarr(debug_putc, arr, count)
 #define DEBUG_FLTARR(arr, count) print_fltarr(debug_putc, arr, count)
 #else
+#define DEBUG_PUTC(c)
 #define DEBUG_STR(__s)
 #define DEBUG_BYTES(data, count)
 #define DEBUG_INT(num)

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -217,6 +217,10 @@ void settings_init(void)
 
 uint8_t settings_load(uint16_t address, uint8_t *__ptr, uint16_t size)
 {
+	DEBUG_STR("EEPROM load @ ");
+	DEBUG_INT(address);
+	DEBUG_PUTC('\n');
+
 	// settiing address invalid
 	if (address == UINT16_MAX)
 	{
@@ -285,6 +289,10 @@ void settings_reset(bool erase_startup_blocks)
 
 void settings_save(uint16_t address, uint8_t *__ptr, uint16_t size)
 {
+	DEBUG_STR("EEPROM save @ ");
+	DEBUG_INT(address);
+	DEBUG_PUTC('\n');
+
 	if (address == UINT16_MAX)
 	{
 		return;
@@ -592,6 +600,10 @@ uint8_t settings_change(setting_offset_t id, float value)
 
 void settings_erase(uint16_t address, uint8_t *__ptr, uint16_t size)
 {
+	DEBUG_STR("EEPROM erase @ ");
+	DEBUG_INT(address);
+	DEBUG_PUTC('\n');
+
 	if (address == UINT16_MAX)
 	{
 		return;

--- a/uCNC/src/interface/settings.c
+++ b/uCNC/src/interface/settings.c
@@ -313,7 +313,7 @@ void settings_save(uint16_t address, uint8_t *__ptr, uint16_t size)
 		crc = crc7(c, crc);
 		mcu_eeprom_putc(address++, c);
 		i++;
-		if (__ptr == NULL && (c == EOL))
+		if (!__ptr && (c == EOL))
 		{
 			size = i;
 			break;
@@ -648,13 +648,6 @@ bool settings_check_startup_gcode(uint16_t address)
 	serial_putc(':');
 	protocol_send_ok();
 	return false;
-#endif
-}
-
-void settings_save_startup_gcode(uint16_t address)
-{
-#ifndef RAM_ONLY_SETTINGS
-	settings_save(address, NULL, UINT16_MAX);
 #endif
 }
 

--- a/uCNC/src/interface/settings.h
+++ b/uCNC/src/interface/settings.h
@@ -133,14 +133,14 @@ typedef uint16_t setting_offset_t;
 
 	void settings_init(void);
 	// Assumes that no structure being saved is bigger than 255 bytes
-	uint8_t settings_load(uint16_t address, uint8_t *__ptr, uint8_t size);
-	void settings_save(uint16_t address, uint8_t *__ptr, uint8_t size);
+	uint8_t settings_load(uint16_t address, uint8_t *__ptr, uint16_t size);
+	void settings_save(uint16_t address, uint8_t *__ptr, uint16_t size);
 	void settings_reset(bool erase_startup_blocks);
 	uint8_t settings_change(setting_offset_t id, float value);
-	void settings_erase(uint16_t address, uint8_t size);
+	void settings_erase(uint16_t address, uint8_t *__ptr, uint16_t size);
 	bool settings_check_startup_gcode(uint16_t address);
 	void settings_save_startup_gcode(uint16_t address);
-	uint16_t settings_register_external_setting(uint8_t size);
+	uint16_t settings_register_external_setting(uint16_t size);
 
 #if (defined(ENABLE_SETTINGS_MODULES) || defined(BOARD_HAS_CUSTOM_SYSTEM_COMMANDS))
 	// event_settings_change_handler

--- a/uCNC/src/interface/settings.h
+++ b/uCNC/src/interface/settings.h
@@ -139,7 +139,6 @@ typedef uint16_t setting_offset_t;
 	uint8_t settings_change(setting_offset_t id, float value);
 	void settings_erase(uint16_t address, uint8_t *__ptr, uint16_t size);
 	bool settings_check_startup_gcode(uint16_t address);
-	void settings_save_startup_gcode(uint16_t address);
 	uint16_t settings_register_external_setting(uint16_t size);
 
 #if (defined(ENABLE_SETTINGS_MODULES) || defined(BOARD_HAS_CUSTOM_SYSTEM_COMMANDS))


### PR DESCRIPTION
- settings crc takes data size in account
- modified function call flow to reduce code size in AVR UNO
- modified settings to allow data size from 8bit to 16bit (prevent clipping saved data)