### PR TITLE
Fix random stalls

### DIFF
--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -564,19 +564,23 @@ void itp_run(void)
 		*/
 		current_speed += fast_flt_div2(speed_change);
 
-		if (current_speed <= 0)
+		if (current_speed > 0)
 		{
+			partial_distance += current_speed * integrator;
+		}
+		else{
 			// speed can't be negative
-			current_speed = 0;
 			itp_cur_plan_block->entry_feed_sqr = 0;
 
 			if (cnc_get_exec_state(EXEC_HOLD))
 			{
 				return;
 			}
+			
+			// flush remaining steps
+			partial_distance = remaining_steps;
+			current_speed = fast_flt_div2(speed_change);
 		}
-
-		partial_distance += current_speed * integrator;
 
 		// computes how many steps it will perform at this speed and frame window
 		uint16_t segm_steps = (uint16_t)floorf(partial_distance);

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -562,13 +562,15 @@ void itp_run(void)
 		/*
 			common calculations for all three profiles (accel, constant and deaccel)
 		*/
-		current_speed += fast_flt_div2(speed_change);
+		speed_change = fast_flt_div2(speed_change);
+		current_speed += speed_change;
 
 		if (current_speed > 0)
 		{
 			partial_distance += current_speed * integrator;
 		}
-		else{
+		else
+		{
 			// speed can't be negative
 			itp_cur_plan_block->entry_feed_sqr = 0;
 
@@ -576,10 +578,10 @@ void itp_run(void)
 			{
 				return;
 			}
-			
+
 			// flush remaining steps
 			partial_distance = remaining_steps;
-			current_speed = fast_flt_div2(speed_change);
+			current_speed = -speed_change;
 		}
 
 		// computes how many steps it will perform at this speed and frame window

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -570,7 +570,7 @@ void itp_run(void)
 		{
 			partial_distance += current_speed * integrator;
 			// computes how many steps it will perform at this speed and frame window
-			segm_steps = (uint16_t)floorf(speed_change);
+			segm_steps = (uint16_t)floorf(partial_distance);
 		}
 		else
 		{

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -562,12 +562,15 @@ void itp_run(void)
 		/*
 			common calculations for all three profiles (accel, constant and deaccel)
 		*/
+		uint16_t segm_steps;
 		speed_change = fast_flt_div2(speed_change);
 		current_speed += speed_change;
 
 		if (current_speed > 0)
 		{
 			partial_distance += current_speed * integrator;
+			// computes how many steps it will perform at this speed and frame window
+			segm_steps = (uint16_t)floorf(speed_change);
 		}
 		else
 		{
@@ -580,12 +583,11 @@ void itp_run(void)
 			}
 
 			// flush remaining steps
-			partial_distance = remaining_steps;
+			segm_steps = (uint16_t)remaining_steps;
 			current_speed = -speed_change;
 		}
 
 		// computes how many steps it will perform at this speed and frame window
-		uint16_t segm_steps = (uint16_t)floorf(partial_distance);
 		partial_distance -= segm_steps;
 
 		// if computed steps exceed the remaining steps for the motion shortens the distance


### PR DESCRIPTION
- Fix random stalls at the end of a deacceleration motion to a full stop. Under particular condition and due to float rounding errors speed may reach negative values and the motion being unable to continue.