### PR TITLE
Fixed PWM configuration macro for STM32 F4x family MCUs

### DIFF
--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -3258,7 +3258,7 @@ extern bool tud_cdc_n_connected (uint8_t itf);
 #define mcu_config_pwm(diopin, freq)                                                                                                                                \
 	{                                                                                                                                                               \
 		RCC->AHB1ENR |= __indirect__(diopin, AHB1EN);                                                                                                               \
-		PWM0_ENREG |= PWM0_APBEN;                                                                                                                                   \
+		__indirect__(diopin, ENREG) |= __indirect__(diopin, APBEN);                                                                                                 \
 		__indirect__(diopin, GPIO)->MODER &= ~(GPIO_RESET << ((__indirect__(diopin, BIT)) << 1)); /*reset dir*/                                                     \
 		__indirect__(diopin, GPIO)->MODER |= (GPIO_AF << ((__indirect__(diopin, BIT)) << 1));	  /*af mode*/                                                       \
 		__indirect__(diopin, GPIO)->AFR[(__indirect__(diopin, BIT) >> 3)] &= ~(0xf << ((__indirect__(diopin, BIT) & 0x07) << 2));                                   \


### PR DESCRIPTION
The PWM configuration code had hard-coded usage of the `PWM0_ENREG` and `PWM0_APBEN`, it now uses the `__indirect__` macro to select the correct registers depending on the specified PWM pin.
