### PR TITLE
CNC state flags cleaning

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -395,15 +395,13 @@ void cnc_home(void)
 	planner_clear();
 	mc_sync_position();
 
-	if (error)
-	{
-		// disables homing and reenables alarm messages
-		cnc_clear_exec_state(EXEC_HOMING);
-		// cnc_alarm(error);
-		return;
-	}
+	// disables homing and reenables limits alarm messages
+	cnc_clear_exec_state(EXEC_HOMING);
 
-	cnc_run_startup_blocks();
+	if (error == STATUS_OK)
+	{
+		cnc_run_startup_blocks();
+	}
 }
 
 void cnc_alarm(int8_t code)
@@ -451,7 +449,6 @@ void cnc_stop(void)
 #ifdef ENABLE_MAIN_LOOP_MODULES
 	EVENT_INVOKE(cnc_stop, NULL);
 #endif
-	cnc_clear_exec_state(EXEC_RUN);
 }
 
 uint8_t cnc_unlock(bool force)
@@ -969,7 +966,8 @@ bool cnc_check_interlocking(void)
 			itp_clear();
 			planner_clear();
 			mc_sync_position();
-			cnc_clear_exec_state(EXEC_HOMING | EXEC_JOG | EXEC_HOLD);
+			// homing will be cleared inside homing cycle
+			cnc_clear_exec_state(EXEC_JOG | EXEC_HOLD);
 		}
 
 		return false;
@@ -1005,11 +1003,6 @@ bool cnc_check_interlocking(void)
 		{
 			cnc_clear_exec_state(EXEC_JOG);
 		}
-	}
-
-	if (itp_is_empty() && planner_buffer_is_empty())
-	{
-		cnc_clear_exec_state(EXEC_RUN);
 	}
 
 	return true;

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -84,7 +84,7 @@ extern "C"
 #define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)					// Interlocking check failed
 #define EXEC_ALARM (EXEC_UNHOMED | EXEC_INTERLOCKING_FAIL)					// System alarms
 #define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD)				// System reset locked
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOMING | EXEC_JOG) // Gcode is locked by an alarm or any special motion state
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG) 				// Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 255													// All states
 
 // creates a set of helper masks used to configure the controller

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -746,6 +746,7 @@ void itp_stop(void)
 #endif
 
 	mcu_stop_itp_isr();
+	cnc_clear_exec_state(EXEC_RUN);
 }
 
 void itp_stop_tools(void)

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -795,8 +795,6 @@ uint8_t mc_home_axis(uint8_t axis_mask, uint8_t axis_limit)
 	block_data.motion_mode = MOTIONCONTROL_MODE_FEED;
 
 	cnc_unlock(true);
-	// re-flags homing clear by the unlock
-	cnc_set_exec_state(EXEC_HOMING);
 	mc_line(target, &block_data);
 
 	if (itp_sync() != STATUS_OK)
@@ -849,8 +847,6 @@ uint8_t mc_home_axis(uint8_t axis_mask, uint8_t axis_limit)
 	io_invert_limits(axis_limit);
 
 	cnc_unlock(true);
-	// flags homing clear by the unlock
-	cnc_set_exec_state(EXEC_HOMING);
 	mc_line(target, &block_data);
 
 	if (itp_sync() != STATUS_OK)

--- a/uCNC/src/hal/kinematics/kinematic_cartesian.c
+++ b/uCNC/src/hal/kinematics/kinematic_cartesian.c
@@ -114,8 +114,6 @@ uint8_t kinematics_home(void)
 #endif
 
 	cnc_unlock(true);
-	// flags homing clear by the unlock
-	cnc_set_exec_state(EXEC_HOMING);
 	motion_data_t block_data = {0};
 	mc_get_position(target);
 
@@ -131,8 +129,6 @@ uint8_t kinematics_home(void)
 	mc_line(target, &block_data);
 	itp_sync();
 #endif
-	// unlocks the machine to go to offset
-	cnc_clear_exec_state(EXEC_HOMING);
 
 #ifdef SET_ORIGIN_AT_HOME_POS
 	memset(target, 0, sizeof(target));

--- a/uCNC/src/hal/kinematics/kinematic_corexy.c
+++ b/uCNC/src/hal/kinematics/kinematic_corexy.c
@@ -124,8 +124,6 @@ uint8_t kinematics_home(void)
 #endif
 
 	cnc_unlock(true);
-	// flags homing clear by the unlock
-	cnc_set_exec_state(EXEC_HOMING);
 	motion_data_t block_data = {0};
 	mc_get_position(target);
 
@@ -142,8 +140,6 @@ uint8_t kinematics_home(void)
 	mc_line(target, &block_data);
 	itp_sync();
 #endif
-	// unlocks the machine to go to offset
-	cnc_clear_exec_state(EXEC_HOMING);
 
 #ifdef SET_ORIGIN_AT_HOME_POS
 	memset(target, 0, sizeof(target));

--- a/uCNC/src/hal/kinematics/kinematic_delta.c
+++ b/uCNC/src/hal/kinematics/kinematic_delta.c
@@ -362,9 +362,7 @@ uint8_t kinematics_home(void)
 	}
 #endif
 
-	// unlocks the machine to go to offset
 	cnc_unlock(true);
-	cnc_set_exec_state(EXEC_HOMING);
 	float target[AXIS_COUNT];
 	motion_data_t block_data = {0};
 
@@ -396,8 +394,6 @@ uint8_t kinematics_home(void)
 	memset(target, 0, sizeof(target));
 	itp_reset_rt_position(target);
 	mc_sync_position();
-
-	cnc_clear_exec_state(EXEC_HOMING);
 
 	return STATUS_OK;
 }

--- a/uCNC/src/hal/kinematics/kinematic_linear_delta.c
+++ b/uCNC/src/hal/kinematics/kinematic_linear_delta.c
@@ -174,7 +174,6 @@ uint8_t kinematics_home(void)
 
 	// unlocks the machine to go to offset
 	cnc_unlock(true);
-	cnc_set_exec_state(EXEC_HOMING);
 	float target[AXIS_COUNT];
 	motion_data_t block_data = {0};
 	mc_get_position(target);
@@ -188,8 +187,6 @@ uint8_t kinematics_home(void)
 	// starts offset and waits to finnish
 	mc_line(target, &block_data);
 	itp_sync();
-
-	cnc_clear_exec_state(EXEC_HOMING);
 
 	memset(target, 0, sizeof(target));
 #ifndef SET_ORIGIN_AT_HOME_POS

--- a/uCNC/src/hal/kinematics/kinematic_scara.c
+++ b/uCNC/src/hal/kinematics/kinematic_scara.c
@@ -144,7 +144,6 @@ uint8_t kinematics_home(void)
 	itp_reset_rt_position(target);
 	mc_sync_position();
 
-	cnc_set_exec_state(EXEC_HOMING);
 	motion_data_t block_data = {0};
 	mc_get_position(target);
 
@@ -160,8 +159,6 @@ uint8_t kinematics_home(void)
 	mc_line(target, &block_data);
 	itp_sync();
 #endif
-	// unlocks the machine to go to offset
-	cnc_clear_exec_state(EXEC_HOMING);
 	
 	return STATUS_OK;
 }


### PR DESCRIPTION
- exec states cleaning
- homing flag state is set and cleared inside the homing cnc call
- run flag is cleared and set only at the ITP level