### PR TITLE
fix UART ISR vector macro for AVR

### DIFF
--- a/uCNC/src/hal/boards/avr/avr.ini
+++ b/uCNC/src/hal/boards/avr/avr.ini
@@ -23,6 +23,7 @@ build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_M
 extends = common_avr
 board = Atmega328PB
 ;saves a bit of flash
+platform_packages=platformio/framework-arduino-avr-minicore@^3.0.0
 build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL -D DISABLE_RTC_CODE
 
 [env:AVR-UNO]

--- a/uCNC/src/hal/boards/avr/avr.ini
+++ b/uCNC/src/hal/boards/avr/avr.ini
@@ -19,6 +19,12 @@ board = uno
 ;saves a bit of flash
 build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL -D DISABLE_RTC_CODE
 
+[atmega328pb]
+extends = common_avr
+board = Atmega328PB
+;saves a bit of flash
+build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL -D DISABLE_RTC_CODE
+
 [env:AVR-UNO]
 extends = atmega328p
 build_flags = ${atmega328p.build_flags} -D BOARD=BOARD_UNO

--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -4332,14 +4332,18 @@ extern "C"
 #define MCU_HAS_UART2
 #endif
 
+#ifndef USART0_RX_vect
 #define USART0_RX_vect USART_RX_vect
+#endif
+#ifndef USART0_UDRE_vect
 #define USART0_UDRE_vect USART_UDRE_vect
+#endif
 
 // COM registers
 #ifdef MCU_HAS_UART
 #ifndef UART_PORT
-#define COM_RX_vect USART_RX_vect
-#define COM_TX_vect USART_UDRE_vect
+#define COM_RX_vect USART0_RX_vect
+#define COM_TX_vect USART0_UDRE_vect
 #define UART_PORT 0
 #else
 #define COM_RX_vect __comrxvect__(UART_PORT)


### PR DESCRIPTION
- fix UART ISR vector macro for AVR (single and multiple UART capable MCU's)
- added configuration for Atmega328PB variants