### PR TITLE
Corrected PID implementation.

### DIFF
--- a/uCNC/src/hal/tools/tools/spindle_pwm.c
+++ b/uCNC/src/hal/tools/tools/spindle_pwm.c
@@ -59,6 +59,9 @@
 #include "../../../modules/pid.h"
 static pid_data_t spindle_pwm_pid;
 DECL_EXTENDED_SETTING(SPINDLE_PWM_PID_SETTING_ID, spindle_pwm_pid.k, float, 3, protocol_send_gcode_setting_line_flt);
+#if (HZ_TO_MS(SPINDLE_PWM_PID_SAMPLE_RATE_HZ) == 0)
+#error "Period of SPINDLE_PWM_PID_SAMPLE_RATE_HZ is zero (not enough integer precision)"
+#endif
 #endif
 
 static void

--- a/uCNC/src/hal/tools/tools/vfd_pwm.c
+++ b/uCNC/src/hal/tools/tools/vfd_pwm.c
@@ -56,6 +56,9 @@
 #include "../../../modules/pid.h"
 static pid_data_t vfd_pwm_pid;
 DECL_EXTENDED_SETTING(VFD_PWM_PID_SETTING_ID, vfd_pwm_pid.k, float, 3, protocol_send_gcode_setting_line_flt);
+#if (HZ_TO_MS(VFD_PWM_PID_SAMPLE_RATE_HZ) == 0)
+#error "Period of VFD_PWM_PID_SAMPLE_RATE_HZ is zero (not enough integer precision)"
+#endif
 #endif
 
 static void startup_code(void)

--- a/uCNC/src/modules/pid.c
+++ b/uCNC/src/modules/pid.c
@@ -23,7 +23,7 @@
 
 bool pid_compute(pid_data_t *pid, float *output, float setpoint, float input, uint32_t sample_rate_ms)
 {
-	if (mcu_millis() < pid->next_sample)																						 
+	if (mcu_millis() < pid->next_sample)
 	{
 		return false;
 	}

--- a/uCNC/src/modules/pid.c
+++ b/uCNC/src/modules/pid.c
@@ -33,7 +33,7 @@ bool pid_compute(pid_data_t *pid, float *output, float setpoint, float input, ui
 	pid->next_sample = next_sample;
 	float pidkp = pid->k[0];
 	float pidki = pid->k[1] * delta_t;
-	float pidkd = delta_t > 0 ? pid->k[2] / delta_t : 0;
+	float pidkd = pid->k[2] / delta_t;
 	*output = 0;
 	float error = setpoint - input;
 	float input_delta = input - pid->last_input;

--- a/uCNC/src/modules/pid.c
+++ b/uCNC/src/modules/pid.c
@@ -13,7 +13,7 @@
 
 	µCNC is distributed WITHOUT ANY WARRANTY;
 	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the	GNU General Public License for more details.
+	See the GNU General Public License for more details.
 */
 
 #include "../cnc.h"
@@ -23,17 +23,17 @@
 
 bool pid_compute(pid_data_t *pid, float *output, float setpoint, float input, uint32_t sample_rate_ms)
 {
-	if (mcu_millis() < pid->next_sample)                                             
+	if (mcu_millis() < pid->next_sample)																						 
 	{
 		return false;
 	}
 
 	uint32_t next_sample = mcu_millis() + sample_rate_ms;
-	float delta_t = ((next_sample - pid->next_sample) * 0.001f); // convert to seconds     
-	pid->next_sample = next_sample;                                              
+	float delta_t = ((next_sample - pid->next_sample) * 0.001f); // convert to seconds
+	pid->next_sample = next_sample;
 	float pidkp = pid->k[0];
 	float pidki = pid->k[1] * delta_t;
-	float pidkd = pid->k[2] / delta_t;
+	float pidkd = delta_t > 0 ? pid->k[2] / delta_t : 0;
 	*output = 0;
 	float error = setpoint - input;
 	float input_delta = input - pid->last_input;

--- a/uCNC/src/modules/pid.h
+++ b/uCNC/src/modules/pid.h
@@ -13,7 +13,7 @@
 
 	µCNC is distributed WITHOUT ANY WARRANTY;
 	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the	GNU General Public License for more details.
+	See the GNU General Public License for more details.
 */
 
 #ifndef PID_H
@@ -30,7 +30,7 @@ extern "C"
 #include <float.h>
 #include <stdio.h>
 
-#define HZ_TO_MS(hz) ((uint32_t)(0.001f*hz))
+#define HZ_TO_MS(hz) ((uint32_t)(1000.0f/(hz)))
 
 	typedef struct pid_data_
 	{

--- a/uCNC/src/modules/pid.h
+++ b/uCNC/src/modules/pid.h
@@ -30,7 +30,7 @@ extern "C"
 #include <float.h>
 #include <stdio.h>
 
-#define HZ_TO_MS(hz) ((uint32_t)(1000.0f/(hz)))
+#define HZ_TO_MS(hz) (1000/(hz))
 
 	typedef struct pid_data_
 	{


### PR DESCRIPTION
- Changed `HZ_TO_MS` macro to calculate the period of the given frequency in milliseconds
- Added a check to PID update period to make sure we are not dividing by zero.