### PR TITLE
make EEPROM arduino library the default for ESP32

### DIFF
--- a/uCNC/src/hal/boards/esp32/esp32.ini
+++ b/uCNC/src/hal/boards/esp32/esp32.ini
@@ -7,7 +7,7 @@ platform = espressif32@6.3.2
 framework = arduino
 board = esp32dev
 ; build_src_filter = +<*>-<src/tinyusb>
-build_flags = -mlongcalls -Wno-frame-address -ffunction-sections -fdata-sections -ggdb -Os -freorder-blocks -Wwrite-strings -fstack-protector -fstrict-volatile-bitfields -Wall -fno-jump-tables -fno-tree-switch-conversion -std=gnu++11 -fexceptions -MMD -c -DUSE_ARDUINO_EEPROM_LIBRARY -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_NONE  -DENABLE_WIFI -DENABLE_BLUETOOTH
+build_flags = -mlongcalls -Wno-frame-address -ffunction-sections -fdata-sections -ggdb -Os -freorder-blocks -Wwrite-strings -fstack-protector -fstrict-volatile-bitfields -Wall -fno-jump-tables -fno-tree-switch-conversion -std=gnu++11 -fexceptions -MMD -c -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_NONE  -DENABLE_WIFI -DENABLE_BLUETOOTH
 board_build.f_flash = 80000000L
 board_build.f_cpu = 240000000L
 board_build.partitions = min_spiffs.csv

--- a/uCNC/src/hal/mcus/esp32/mcumap_esp32.h
+++ b/uCNC/src/hal/mcus/esp32/mcumap_esp32.h
@@ -53,6 +53,12 @@ extern "C"
 #define F_STEP_MIN 1
 #endif
 
+#ifndef USE_CUSTOM_EEPROM_LIBRARY
+#ifndef USE_ARDUINO_EEPROM_LIBRARY
+#define USE_ARDUINO_EEPROM_LIBRARY
+#endif
+#endif
+
 // defines special mcu to access flash strings and arrays
 #define __rom__
 #define __romstr__


### PR DESCRIPTION
- make EEPROM arduino library the default for ESP32