### PR TITLE
prevent spindle restore message at restart

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -577,7 +577,7 @@ void cnc_clear_exec_state(uint8_t statemask)
 		// if something goes wrong the tool can reinstate the HOLD state
 		itp_sync_spindle();
 #if (DELAY_ON_RESUME_SPINDLE > 0)
-		if (!g_settings.laser_mode)
+		if (!g_settings.laser_mode && cnc_state.loop_state == LOOP_RUNNING)
 		{
 			protocol_send_feedback(MSG_FEEDBACK_10);
 			if (!planner_buffer_is_empty())
@@ -822,7 +822,8 @@ void cnc_exec_rt_commands(void)
 			if (cnc_get_exec_state(EXEC_HOLD | EXEC_DOOR | EXEC_RUN) == EXEC_HOLD) // only available if a TRUE hold is active
 			{
 				// toogle state
-				if(planner_spindle_ovr_toggle()){
+				if (planner_spindle_ovr_toggle())
+				{
 					protocol_send_feedback(MSG_FEEDBACK_10);
 				}
 			}


### PR DESCRIPTION
- prevent spindle restore message at restart. This bug was introduced by #631