### PR TITLE
moved spindle restore to planner override

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -580,7 +580,6 @@ void cnc_clear_exec_state(uint8_t statemask)
 #if (DELAY_ON_RESUME_SPINDLE > 0)
 			if (!g_settings.laser_mode && cnc_state.loop_state == LOOP_RUNNING)
 			{
-				protocol_send_feedback(MSG_FEEDBACK_10);
 				if (!planner_buffer_is_empty())
 				{
 					cnc_dwell_ms(DELAY_ON_RESUME_SPINDLE * 1000);
@@ -831,14 +830,7 @@ void cnc_exec_rt_commands(void)
 			planner_spindle_ovr(ovr - SPINDLE_OVR_FINE);
 			break;
 		case RT_CMD_SPINDLE_TOGGLE:
-			if (cnc_get_exec_state(EXEC_HOLD | EXEC_DOOR | EXEC_RUN) == EXEC_HOLD) // only available if a TRUE hold is active
-			{
-				// toogle state
-				if (planner_spindle_ovr_toggle())
-				{
-					protocol_send_feedback(MSG_FEEDBACK_10);
-				}
-			}
+			planner_spindle_ovr_toggle();
 			break;
 		}
 #endif

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -943,7 +943,11 @@ uint8_t mc_probe(float *target, uint8_t flags, motion_data_t *block_data)
 	// disables the probe
 	io_disable_probe();
 	itp_clear();
-	planner_clear();
+	// clears the buffer but conserves the tool data
+	while (!planner_buffer_is_empty())
+	{
+		planner_discard_block();
+	}
 	// clears hold
 	cnc_clear_exec_state(EXEC_HOLD);
 

--- a/uCNC/src/core/planner.h
+++ b/uCNC/src/core/planner.h
@@ -100,7 +100,7 @@ extern "C"
 	void planner_rapid_feed_ovr(uint8_t value);
 #if TOOL_COUNT > 0
 	void planner_spindle_ovr(uint8_t value);
-	uint8_t planner_spindle_ovr_toggle(void);
+	void planner_spindle_ovr_toggle(void);
 	void planner_spindle_ovr_reset(void);
 	uint8_t planner_coolant_ovr_toggle(uint8_t value);
 	void planner_coolant_ovr_reset(void);


### PR DESCRIPTION
- moved spindle restore to planner override
- filters the message showing if an override was made during a hold condition only
- prevent probe to clear tool status