### PR TITLE
Allow I2C low speed clocks

### DIFF
--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -4484,20 +4484,6 @@ extern bool tud_cdc_n_connected (uint8_t itf);
 #define I2C_FREQ 400000UL
 #endif
 
-// I2C freq
-#if (I2C_FREQ < 5000UL)
-#define I2C_PRESC 3
-#define I2C_DIV (HAL_RCC_GetPCLK1Freq() / (I2C_FREQ << 6))
-#elif (I2C_FREQ < 20000UL)
-#define I2C_PRESC 2
-#define I2C_DIV (HAL_RCC_GetPCLK1Freq() / (I2C_FREQ << 4))
-#elif (I2C_FREQ < 80000UL)
-#define I2C_PRESC 1
-#define I2C_DIV (HAL_RCC_GetPCLK1Freq() / (I2C_FREQ << 2))
-#else
-#define I2C_PRESC 0
-#define I2C_DIV (HAL_RCC_GetPCLK1Freq() / I2C_FREQ)
-#endif
 #endif
 
 // Timer registers


### PR DESCRIPTION
- allow use of standard speed mode for I2C
- remove deprecated code