### PR TITLE
Only skip DEBUG_STREAM when it is not default_stream

### DIFF
--- a/uCNC/src/interface/serial.c
+++ b/uCNC/src/interface/serial.c
@@ -250,8 +250,10 @@ uint8_t serial_available(void)
 		while (p != NULL)
 		{
 #ifdef ENABLE_DEBUG_STREAM
-			// skip the debug stream
+#if DEBUG_STREAM != default_stream
+			// skip the debug stream, if it differs from default_stream
 			if (p != DEBUG_STREAM)
+#endif
 			{
 #endif
 				count = (!(p->stream_available)) ? 0 : p->stream_available();


### PR DESCRIPTION
There is a bug in serial_available() that will make the system ignore any incoming bytes from default_stream. With UART as default_stream, the system will stop talking to a sender software on a host machine.

To repro:
1. enable DEBUG_STREAM (mapped to default_stream)
2. register multiple serial streams
3. build and flash
4. connect system to a sender via UART, and verify the two can communicate
5. send data via any stream that is not default_stream (i.e. not UART)
6. sender can no longer communicate with the system

This diff fixes the bug by skipping DEBUG_STREAM only when it is not default_stream.

TBH I am not sure why we want to skip DEBUG_STREAM in serial_available().
serial_available() checks number of bytes in the RX buffer.
In almost all scenarios DEBUG_STREAM is used to send debug messages out; RX buffer isn't that useful. 
We might as well just remove the check