### PR TITLE
Prevent using debug stream before initialization

### DIFF
--- a/uCNC/src/interface/serial.c
+++ b/uCNC/src/interface/serial.c
@@ -342,11 +342,14 @@ void serial_putc(char c)
 #ifdef ENABLE_DEBUG_STREAM
 void debug_putc(char c)
 {
-	DEBUG_STREAM->stream_putc(c);
-
-	if (c == '\n')
+	if (DEBUG_STREAM)
 	{
-		DEBUG_STREAM->stream_flush();
+		DEBUG_STREAM->stream_putc(c);
+
+		if (c == '\n')
+		{
+			DEBUG_STREAM->stream_flush();
+		}
 	}
 }
 #endif


### PR DESCRIPTION
- Prevent using debug stream before initialization causing a crash