### PR TITLE
Interpolator loop feed as a task

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -486,13 +486,20 @@ extern "C"
 	// #define FORCE_SOFT_POLLING
 
 	/**
-	 * Runs a check for state change inside the scheduler. This is a failsafe
-	 * check to pin ISR checking The value sets the frequency of this safety
+	 * Runs a check for state change inside the RTC ISR/task. This is a failsafe
+	 * check monitor the pins in a regular interval. The value sets the frequency of this safety
 	 * check that is executed every 2^(CTRL_SCHED_CHECK) milliseconds. A
 	 * negative value will disable this feature. The maximum is 7
 	 * */
 
 #define CTRL_SCHED_CHECK 4
+
+	/**
+	 * EXPERIMENTAL! Uncomment to enable itp step generation to run inside the RTC ISR/task.
+	 * This ensures ITP starving prevention. Usually this will be executed at the same sample
+	 * rate as the interpolator with an upper bound of 1Khz and a lower bound of 3Hz
+	 * */
+// #define ENABLE_ITP_FEED_TASK
 
 /**
  * Uncomment to invert Emergency stop button
@@ -592,12 +599,6 @@ extern "C"
 	 * */
 
 	// #define ENABLE_FAST_MATH
-
-	/**
-	 * EXPERIMENTAL! Uncomment to enable itp buffer feeding to be run as a task
-	 * that runs inside the RTC ISR. This ensures ITP starving prevention
-	 * */
-	// #define ENABLE_ITP_FEED_TASK
 
 /**
  *

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -593,6 +593,12 @@ extern "C"
 
 	// #define ENABLE_FAST_MATH
 
+	/**
+	 * EXPERIMENTAL! Uncomment to enable itp buffer feeding to be run as a task
+	 * that runs inside the RTC ISR. This ensures ITP starving prevention
+	 * */
+	// #define ENABLE_ITP_FEED_TASK
+
 /**
  *
  * HAL offsets

--- a/uCNC/src/cnc_hal_config_helper.h
+++ b/uCNC/src/cnc_hal_config_helper.h
@@ -1821,6 +1821,10 @@ extern "C"
 #define CTRL_SCHED_CHECK_VAL (1 << (CTRL_SCHED_CHECK))
 #endif
 
+#ifdef DISABLE_RTC_CODE
+#undef ENABLE_ITP_FEED_TASK
+#endif
+
 #ifndef BRESENHAM_16BIT
 	typedef uint32_t step_t;
 #define MAX_STEPS_PER_LINE_BITS (32 - (2 + DSS_MAX_OVERSAMPLING))

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -28,11 +28,6 @@
 #define INTERPOLATOR_BUFFER_SIZE 5 // number of windows in the buffer
 #endif
 
-// sets the sample frequency for the Riemann sum integral
-#ifndef INTERPOLATOR_FREQ
-#define INTERPOLATOR_FREQ 100
-#endif
-
 #define INTERPOLATOR_DELTA_T (1.0f / INTERPOLATOR_FREQ)
 // determines the size of the maximum riemann sample that can be performed taking in acount the maximum allowable step rate
 #define INTERPOLATOR_DELTA_CONST_T (MIN((1.0f / INTERPOLATOR_BUFFER_SIZE), ((float)(0xFFFF >> DSS_MAX_OVERSAMPLING) / (float)F_STEP_MAX)))

--- a/uCNC/src/core/interpolator.h
+++ b/uCNC/src/core/interpolator.h
@@ -45,6 +45,11 @@ extern "C"
 #define ITP_STEP_MODE_REALTIME 2
 #define ITP_STEP_MODE_SYNC 4
 
+// sets the sample frequency for the Riemann sum integral
+#ifndef INTERPOLATOR_FREQ
+#define INTERPOLATOR_FREQ 100
+#endif
+
 	// contains data of the block being executed by the pulse routine
 	// this block has the necessary data to execute the Bresenham line algorithm
 	typedef struct itp_blk_

--- a/uCNC/src/hal/boards/avr/avr.ini
+++ b/uCNC/src/hal/boards/avr/avr.ini
@@ -17,14 +17,14 @@ build_flags = ${common.build_flags} -mcall-prologues -mrelax -flto -fno-fat-lto-
 extends = common_avr
 board = uno
 ;saves a bit of flash
-build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL -D DISABLE_RTC_CODE
+build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL
 
 [atmega328pb]
 extends = common_avr
 board = Atmega328PB
 ;saves a bit of flash
 platform_packages=platformio/framework-arduino-avr-minicore@^3.0.0
-build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL -D DISABLE_RTC_CODE
+build_flags = ${common_avr.build_flags} -D DISABLE_SETTINGS_MODULES -D DISABLE_MULTISTREAM_SERIAL
 
 [env:AVR-UNO]
 extends = atmega328p


### PR DESCRIPTION
Experimental ITP loop running inside an ISR/task.

This has the advantage of preventing the step generation starving when running very long and intensive calculations tasks and run independent from the main loop.