### PR TITLE
Change homing alarm failure type

### DIFF
--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -890,7 +890,7 @@ uint8_t mc_home_axis(uint8_t axis_mask, uint8_t axis_limit)
 	if (CHECKFLAG(limits_flags, axis_limit))
 	{
 		cnc_set_exec_state(EXEC_UNHOMED);
-		cnc_alarm(EXEC_ALARM_HOMING_FAIL_APPROACH);
+		cnc_alarm(EXEC_ALARM_HOMING_FAIL_PULLOFF);
 		return STATUS_CRITICAL_FAIL;
 	}
 


### PR DESCRIPTION
There seems to be a mistake in the alarm triggered after homing axis pull off fails, instead of firing `EXEC_ALARM_HOMING_FAIL_PULLOFF`, `EXEC_ALARM_HOMING_FAIL_APPROACH` gets sent and confusion ensues. This small pull request addresses this issue. After a quick check, the definition of `EXEC_ALARM_HOMING_FAIL_PULLOFF` didn't seem to be used anywhere in the project which is why I believe this is a simple typo.