### PR TITLE
Fix STM32 compilation error if probe not defined

### DIFF
--- a/uCNC/src/hal/boards/stm32/boardmap_blackpill.h
+++ b/uCNC/src/hal/boards/stm32/boardmap_blackpill.h
@@ -74,8 +74,8 @@ extern "C"
 #define SAFETY_DOOR_BIT 8
 #define SAFETY_DOOR_PORT B
 // Setup probe pin
-#define PROBE_BIT 9
-#define PROBE_PORT B
+// #define PROBE_BIT 9
+// #define PROBE_PORT B
 
 // Enable controls switch interrupt
 #define ESTOP_ISR

--- a/uCNC/src/hal/mcus/avr/mcumap_avr.h
+++ b/uCNC/src/hal/mcus/avr/mcumap_avr.h
@@ -4633,7 +4633,7 @@ extern "C"
 		(0x3FF & ((ADCH << 8) | ADCL));                 \
 	}
 
-#ifdef PROBE_ISR
+#if defined(PROBE) && defined(PROBE_ISR)
 #define mcu_enable_probe_isr() (SETFLAG(PROBE_ISRREG, PROBE_ISR_MASK))
 #define mcu_disable_probe_isr() (CLEARFLAG(PROBE_ISRREG, PROBE_ISR_MASK))
 #else

--- a/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
+++ b/uCNC/src/hal/mcus/stm32f1x/mcumap_stm32f1x.h
@@ -4743,14 +4743,12 @@ extern "C"
 		(0x3FF & (ADC1->DR >> 2));                  \
 	})
 
-#ifdef PROBE
-#ifdef PROBE_ISR
+#if defined(PROBE) && defined(PROBE_ISR)
 #define mcu_enable_probe_isr() SETBIT(EXTI->IMR, PROBE_BIT)
 #define mcu_disable_probe_isr() CLEARBIT(EXTI->IMR, PROBE_BIT)
 #else
 #define mcu_enable_probe_isr()
 #define mcu_disable_probe_isr()
-#endif
 #endif
 
 	extern volatile bool stm32_global_isr_enabled;

--- a/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
+++ b/uCNC/src/hal/mcus/stm32f4x/mcumap_stm32f4x.h
@@ -3765,14 +3765,12 @@ extern "C"
 		(0x3FF & (ADC1->DR >> 2));                  \
 	})
 
-#ifdef PROBE
-#ifdef PROBE_ISR
+#if defined(PROBE) && defined(PROBE_ISR)
 #define mcu_enable_probe_isr() SETBIT(EXTI->IMR, PROBE_BIT)
 #define mcu_disable_probe_isr() CLEARBIT(EXTI->IMR, PROBE_BIT)
 #else
 #define mcu_enable_probe_isr()
 #define mcu_disable_probe_isr()
-#endif
 #endif
 
 	extern volatile bool stm32_global_isr_enabled;


### PR DESCRIPTION
Fix STM32 compilation error if probe not defined. This caused mcu_enable_probe_isr and mcu_disable_probe_isr not to be defined.