### PR TITLE
Fix SPI implementation for STM32 MCUs

### DIFF
--- a/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
+++ b/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
@@ -961,9 +961,9 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 	}
 
 	// disable SPI
-	SPI_REG->CR1 &= SPI_CR1_SPE;
+	SPI_REG->CR1 &= ~SPI_CR1_SPE;
 	// clear speed and mode
-	SPI_REG->CR1 &= 0x3B;
+	SPI_REG->CR1 &= ~0x3B;
 	SPI_REG->CR1 |= (speed << 3) | mode;
 	// enable SPI
 	SPI_REG->CR1 |= SPI_CR1_SPE;
@@ -972,10 +972,10 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 uint8_t mcu_spi_xmit(uint8_t c)
 {
 	SPI_REG->DR = c;
-	while (!(SPI1->SR & SPI_SR_TXE) && !(SPI1->SR & SPI_SR_RXNE))
+	while (!(SPI_REG->SR & SPI_SR_TXE) && !(SPI_REG->SR & SPI_SR_RXNE))
 		;
 	uint8_t data = SPI_REG->DR;
-	while (SPI1->SR & SPI_SR_BSY)
+	while (SPI_REG->SR & SPI_SR_BSY)
 		;
 	return data;
 }

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -989,9 +989,9 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 	}
 
 	// disable SPI
-	SPI_REG->CR1 &= SPI_CR1_SPE;
+	SPI_REG->CR1 &= ~SPI_CR1_SPE;
 	// clear speed and mode
-	SPI_REG->CR1 &= 0x3B;
+	SPI_REG->CR1 &= ~0x3B;
 	SPI_REG->CR1 |= (speed << 3) | mode;
 	// enable SPI
 	SPI_REG->CR1 |= SPI_CR1_SPE;
@@ -1000,10 +1000,10 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 uint8_t mcu_spi_xmit(uint8_t c)
 {
 	SPI_REG->DR = c;
-	while (!(SPI1->SR & SPI_SR_TXE) && !(SPI1->SR & SPI_SR_RXNE))
+	while (!(SPI_REG->SR & SPI_SR_TXE) && !(SPI_REG->SR & SPI_SR_RXNE))
 		;
 	uint8_t data = SPI_REG->DR;
-	while (SPI1->SR & SPI_SR_BSY)
+	while (SPI_REG->SR & SPI_SR_BSY)
 		;
 	return data;
 }

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -1012,9 +1012,9 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 	}
 
 	// disable SPI
-	SPI_REG->CR1 &= SPI_CR1_SPE;
+	SPI_REG->CR1 &= ~SPI_CR1_SPE;
 	// clear speed and mode
-	SPI_REG->CR1 &= 0x3B;
+	SPI_REG->CR1 &= ~0x3B;
 	SPI_REG->CR1 |= (speed << 3) | mode;
 	// enable SPI
 	SPI_REG->CR1 |= SPI_CR1_SPE;
@@ -1023,10 +1023,10 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 uint8_t mcu_spi_xmit(uint8_t c)
 {
 	SPI_REG->DR = c;
-	while (!(SPI1->SR & SPI_SR_TXE) && !(SPI1->SR & SPI_SR_RXNE))
+	while (!(SPI_REG->SR & SPI_SR_TXE) && !(SPI_REG->SR & SPI_SR_RXNE))
 		;
 	uint8_t data = SPI_REG->DR;
-	while (SPI1->SR & SPI_SR_BSY)
+	while (SPI_REG->SR & SPI_SR_BSY)
 		;
 	return data;
 }


### PR DESCRIPTION
Fixed some minor issues with the SPI implementation in STM32 family microcontrollers.
- Missing 'bitwise not' operator before clearing bits in control register 1
- Polling SPI1 in xmit instead of the configured SPI_REG