### PR TITLE
Minor STM32 fixes

### DIFF
--- a/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
+++ b/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
@@ -1032,6 +1032,8 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 		// Bulk transfer without DMA
 		if(spi_port_state == SPI_IDLE)
 		{
+			spi_port_state = SPI_TRANSMITTING;
+
 			spi_transfer_tx_ptr = tx_data;
 			spi_transfer_tx_len = datalen;
 			SPI_REG->CR2 |= SPI_CR2_TXEIE;
@@ -1046,8 +1048,6 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 				spi_transfer_rx_ptr = 0;
 				spi_transfer_rx_len = 0;
 			}
-
-			spi_port_state = SPI_TRANSMITTING;
 		}
 		else if(spi_port_state == SPI_TRANSMIT_COMPLETE)
 		{

--- a/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
+++ b/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
@@ -935,7 +935,7 @@ typedef enum spi_port_state_enum {
 	SPI_TRANSMITTING = 2,
 	SPI_TRANSMIT_COMPLETE = 3,
 } spi_port_state_t;
-static spi_port_state_t spi_port_state = SPI_UNKNOWN;
+static volatile spi_port_state_t spi_port_state = SPI_UNKNOWN;
 static bool spi_enable_dma = false;
 
 void mcu_spi_config(spi_config_t config, uint32_t frequency)
@@ -985,8 +985,7 @@ void mcu_spi_config(spi_config_t config, uint32_t frequency)
 	SPI_REG->CR1 |= SPI_CR1_SPE;
 
 	spi_port_state = SPI_IDLE;
-	// TODO: Assign this to the configured value in mcu_spi_config
-	spi_enable_dma = false;
+	spi_enable_dma = config.enable_dma;
 }
 
 uint8_t mcu_spi_xmit(uint8_t c)

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -965,10 +965,10 @@ typedef enum spi_port_state_enum {
 	SPI_TRANSMITTING = 2,
 	SPI_TRANSMIT_COMPLETE = 3,
 } spi_port_state_t;
-static spi_port_state_t spi_port_state = SPI_UNKNOWN;
+static volatile  spi_port_state_t spi_port_state = SPI_UNKNOWN;
 static bool spi_enable_dma = false;
 
-void mcu_spi_config(uint8_t mode, uint32_t frequency)
+void mcu_spi_config(spi_config_t config, uint32_t frequency)
 {
 
 	uint8_t div = (uint8_t)(SPI_CLOCK / frequency);
@@ -1016,8 +1016,7 @@ void mcu_spi_config(uint8_t mode, uint32_t frequency)
 	SPI_REG->CR1 |= SPI_CR1_SPE;
 
 	spi_port_state = SPI_IDLE;
-	// TODO: Assign this to the configured value in mcu_spi_config
-	spi_enable_dma = false;
+	spi_enable_dma = config.enable_dma;
 }
 
 uint8_t mcu_spi_xmit(uint8_t c)

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -1063,6 +1063,8 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 		// Bulk transfer without DMA
 		if(spi_port_state == SPI_IDLE)
 		{
+			spi_port_state = SPI_TRANSMITTING;
+
 			spi_transfer_tx_ptr = tx_data;
 			spi_transfer_tx_len = datalen;
 			SPI_REG->CR2 |= SPI_CR2_TXEIE;
@@ -1077,8 +1079,6 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 				spi_transfer_rx_ptr = 0;
 				spi_transfer_rx_len = 0;
 			}
-
-			spi_port_state = SPI_TRANSMITTING;
 		}
 		else if(spi_port_state == SPI_TRANSMIT_COMPLETE)
 		{

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -986,7 +986,7 @@ typedef enum spi_port_state_enum {
 	SPI_TRANSMITTING = 2,
 	SPI_TRANSMIT_COMPLETE = 3,
 } spi_port_state_t;
-static spi_port_state_t spi_port_state = SPI_UNKNOWN;
+static volatile spi_port_state_t spi_port_state = SPI_UNKNOWN;
 static bool spi_enable_dma = false;
 
 void mcu_spi_config(spi_config_t config, uint32_t frequency)
@@ -1036,8 +1036,7 @@ void mcu_spi_config(spi_config_t config, uint32_t frequency)
 	SPI_REG->CR1 |= SPI_CR1_SPE;
 
 	spi_port_state = SPI_IDLE;
-	// TODO: Assign this to the configured value in mcu_spi_config
-	spi_enable_dma = false;
+	spi_enable_dma = config.enable_dma;
 }
 
 uint8_t mcu_spi_xmit(uint8_t c)

--- a/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
+++ b/uCNC/src/hal/mcus/stm32f4x/mcu_stm32f4x.c
@@ -1089,6 +1089,8 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 		// Bulk transfer without DMA
 		if(spi_port_state == SPI_IDLE)
 		{
+			spi_port_state = SPI_TRANSMITTING;
+
 			spi_transfer_tx_ptr = tx_data;
 			spi_transfer_tx_len = datalen;
 			SPI_REG->CR2 |= SPI_CR2_TXEIE;
@@ -1103,8 +1105,6 @@ bool mcu_spi_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t da
 				spi_transfer_rx_ptr = 0;
 				spi_transfer_rx_len = 0;
 			}
-
-			spi_port_state = SPI_TRANSMITTING;
 		}
 		else if(spi_port_state == SPI_TRANSMIT_COMPLETE)
 		{


### PR DESCRIPTION
This fixes some minor issues I found.
- Assign spi_dma_enable to configuration value.
- Fix interrupt driven spi transfers. The code was causing issues at higher SPI clock speeds.