### PR TITLE
System menu changes

### DIFF
--- a/uCNC/src/modules/system_menu.c
+++ b/uCNC/src/modules/system_menu.c
@@ -967,6 +967,50 @@ bool system_menu_action_edit(uint8_t action, system_menu_item_t *item)
 			return false;
 		}
 		break;
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('0'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('1'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('2'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('3'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('4'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('5'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('6'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('7'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('8'):
+	case SYSTEM_MENU_ACTION_CHAR_INPUT('9'):
+		{
+			int digit = action - SYSTEM_MENU_ACTION_CHAR_INPUT('0');
+			flags |= SYSTEM_MENU_MODE_MODIFY;
+			switch(vartype)
+			{
+			case VAR_TYPE_BOOLEAN:
+				modifier = digit;
+				break;
+			case VAR_TYPE_FLOAT:
+				int current_digit = (int)((*(float *)item->argptr) / powf(10.0f, (currentmult - 3))) % 10;
+				modifier = (digit - current_digit) * powf(10.0f, (currentmult - 3));
+				break;
+			case VAR_TYPE_INT8:
+			case VAR_TYPE_UINT8:
+				int current_digit = ((*(uint8_t *)item->argptr) / powf(10.0f, currentmult)) % 10;
+				modifier = (digit - current_digit) * powf(10.0f, currentmult);
+				break;
+			case VAR_TYPE_INT16:
+			case VAR_TYPE_UINT16:
+				int current_digit = ((*(uint16_t *)item->argptr) / powf(10.0f, currentmult)) % 10;
+				modifier = (digit - current_digit) * powf(10.0f, currentmult);
+				break;
+			case VAR_TYPE_INT32:
+			case VAR_TYPE_UINT32:
+				int current_digit = ((*(uint32_t *)item->argptr) / powf(10.0f, currentmult)) % 10;
+				modifier = (digit - current_digit) * powf(10.0f, currentmult);
+				break;
+			default:
+				modifier = digit * powf(10.0f, currentmult);
+				break;
+			}
+			currentmult -= 1;
+		}
+		break;
 	default:
 		// allow to propagate
 		return false;

--- a/uCNC/src/modules/system_menu.h
+++ b/uCNC/src/modules/system_menu.h
@@ -69,6 +69,13 @@ extern "C"
 #define SYSTEM_MENU_ACTION_NEXT 2
 #define SYSTEM_MENU_ACTION_PREV 3
 
+// Characters given to this macro should be in range of printable ASCII characters (32-127)
+#define SYSTEM_MENU_ACTION_CHAR_INPUT(c) (c)
+// Action ID range from 128 - 137
+#define SYSTEM_MENU_ACTION_SIDE_BUTTON(b) ((b) + 128)
+// Action ID range from 138 - 147
+#define SYSTEM_MENU_ACTION_SPECIAL_BUTTON(b) ((b) + 138)
+
 #define VAR_TYPE_BOOLEAN 1
 #define VAR_TYPE_UINT8 2
 #define VAR_TYPE_INT8 3


### PR DESCRIPTION
As I've described before. The first thing this PR adds is more predefined system menu action IDs.

Here is an example utilization of them:
![IMG_20240801_163722](https://github.com/user-attachments/assets/9c0cd73a-9542-42b0-8415-0a287449f65c)

1. This is of course the keypad. It emits standard numeric actions (0, 1, 2...) as well as X, Y, Z (here A, B, C).
2. Side buttons. These can be used as shortcuts inside of different menus. These will probably not be used in the standard system menu functions and only inside of custom display drivers.
3. XY jog buttons. These are assigned to special buttons 0 - 3 (or maybe these should be arrow buttons?)
4. Z jog buttons. These are assigned to special buttons 4 - 5. Special buttons won't be used inside of the standard system menu functions (only used by display driver implementations)