### PR TITLE
New pin mapping helper

### DIFF
--- a/uCNC/src/hal/boards/boarddefs.h
+++ b/uCNC/src/hal/boards/boarddefs.h
@@ -185,6 +185,7 @@ extern "C"
 #endif
 
 #include "../../../boardmap_overrides.h"
+#include "pin_mapping_helper.h"
 #include "../mcus/mcudefs.h" //configures the MCU for the selected board
 
 #ifdef __cplusplus

--- a/uCNC/src/hal/boards/pin_mapping_helper.h
+++ b/uCNC/src/hal/boards/pin_mapping_helper.h
@@ -1,0 +1,1428 @@
+/*
+	Name: pin_mapping_helper.h
+	Description: Allows for easier way to define pins in the boardmap file.
+
+	Copyright: Copyright (c) João Martins
+	Author: João Martins
+	Date: 02-08-2024
+
+	µCNC is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+
+	µCNC is distributed WITHOUT ANY WARRANTY;
+	Also without the implied warranty of	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the	GNU General Public License for more details.
+*/
+
+#ifndef PIN_MAPPING_HELPER_H
+#define PIN_MAPPING_HELPER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define MCU_PIN_A0_BIT 0
+#define MCU_PIN_A1_BIT 1
+#define MCU_PIN_A2_BIT 2
+#define MCU_PIN_A3_BIT 3
+#define MCU_PIN_A4_BIT 4
+#define MCU_PIN_A5_BIT 5
+#define MCU_PIN_A6_BIT 6
+#define MCU_PIN_A7_BIT 7
+#define MCU_PIN_A8_BIT 8
+#define MCU_PIN_A9_BIT 9
+#define MCU_PIN_A10_BIT 10
+#define MCU_PIN_A11_BIT 11
+#define MCU_PIN_A12_BIT 12
+#define MCU_PIN_A13_BIT 13
+#define MCU_PIN_A14_BIT 14
+#define MCU_PIN_A15_BIT 15
+#define MCU_PIN_A16_BIT 16
+#define MCU_PIN_A17_BIT 17
+#define MCU_PIN_A18_BIT 18
+#define MCU_PIN_A19_BIT 19
+#define MCU_PIN_A20_BIT 20
+#define MCU_PIN_A21_BIT 21
+#define MCU_PIN_A22_BIT 22
+#define MCU_PIN_A23_BIT 23
+#define MCU_PIN_A24_BIT 24
+#define MCU_PIN_A25_BIT 25
+#define MCU_PIN_A26_BIT 26
+#define MCU_PIN_A27_BIT 27
+#define MCU_PIN_A28_BIT 28
+#define MCU_PIN_A29_BIT 29
+#define MCU_PIN_A30_BIT 30
+#define MCU_PIN_A31_BIT 31
+
+#define MCU_PIN_B0_BIT 0
+#define MCU_PIN_B1_BIT 1
+#define MCU_PIN_B2_BIT 2
+#define MCU_PIN_B3_BIT 3
+#define MCU_PIN_B4_BIT 4
+#define MCU_PIN_B5_BIT 5
+#define MCU_PIN_B6_BIT 6
+#define MCU_PIN_B7_BIT 7
+#define MCU_PIN_B8_BIT 8
+#define MCU_PIN_B9_BIT 9
+#define MCU_PIN_B10_BIT 10
+#define MCU_PIN_B11_BIT 11
+#define MCU_PIN_B12_BIT 12
+#define MCU_PIN_B13_BIT 13
+#define MCU_PIN_B14_BIT 14
+#define MCU_PIN_B15_BIT 15
+#define MCU_PIN_B16_BIT 16
+#define MCU_PIN_B17_BIT 17
+#define MCU_PIN_B18_BIT 18
+#define MCU_PIN_B19_BIT 19
+#define MCU_PIN_B20_BIT 20
+#define MCU_PIN_B21_BIT 21
+#define MCU_PIN_B22_BIT 22
+#define MCU_PIN_B23_BIT 23
+#define MCU_PIN_B24_BIT 24
+#define MCU_PIN_B25_BIT 25
+#define MCU_PIN_B26_BIT 26
+#define MCU_PIN_B27_BIT 27
+#define MCU_PIN_B28_BIT 28
+#define MCU_PIN_B29_BIT 29
+#define MCU_PIN_B30_BIT 30
+#define MCU_PIN_B31_BIT 31
+
+#define MCU_PIN_C0_BIT 0
+#define MCU_PIN_C1_BIT 1
+#define MCU_PIN_C2_BIT 2
+#define MCU_PIN_C3_BIT 3
+#define MCU_PIN_C4_BIT 4
+#define MCU_PIN_C5_BIT 5
+#define MCU_PIN_C6_BIT 6
+#define MCU_PIN_C7_BIT 7
+#define MCU_PIN_C8_BIT 8
+#define MCU_PIN_C9_BIT 9
+#define MCU_PIN_C10_BIT 10
+#define MCU_PIN_C11_BIT 11
+#define MCU_PIN_C12_BIT 12
+#define MCU_PIN_C13_BIT 13
+#define MCU_PIN_C14_BIT 14
+#define MCU_PIN_C15_BIT 15
+#define MCU_PIN_C16_BIT 16
+#define MCU_PIN_C17_BIT 17
+#define MCU_PIN_C18_BIT 18
+#define MCU_PIN_C19_BIT 19
+#define MCU_PIN_C20_BIT 20
+#define MCU_PIN_C21_BIT 21
+#define MCU_PIN_C22_BIT 22
+#define MCU_PIN_C23_BIT 23
+#define MCU_PIN_C24_BIT 24
+#define MCU_PIN_C25_BIT 25
+#define MCU_PIN_C26_BIT 26
+#define MCU_PIN_C27_BIT 27
+#define MCU_PIN_C28_BIT 28
+#define MCU_PIN_C29_BIT 29
+#define MCU_PIN_C30_BIT 30
+#define MCU_PIN_C31_BIT 31
+
+#define MCU_PIN_D0_BIT 0
+#define MCU_PIN_D1_BIT 1
+#define MCU_PIN_D2_BIT 2
+#define MCU_PIN_D3_BIT 3
+#define MCU_PIN_D4_BIT 4
+#define MCU_PIN_D5_BIT 5
+#define MCU_PIN_D6_BIT 6
+#define MCU_PIN_D7_BIT 7
+#define MCU_PIN_D8_BIT 8
+#define MCU_PIN_D9_BIT 9
+#define MCU_PIN_D10_BIT 10
+#define MCU_PIN_D11_BIT 11
+#define MCU_PIN_D12_BIT 12
+#define MCU_PIN_D13_BIT 13
+#define MCU_PIN_D14_BIT 14
+#define MCU_PIN_D15_BIT 15
+#define MCU_PIN_D16_BIT 16
+
+#define MCU_PIN_D17_BIT 17
+#define MCU_PIN_D18_BIT 18
+#define MCU_PIN_D19_BIT 19
+#define MCU_PIN_D20_BIT 20
+#define MCU_PIN_D21_BIT 21
+#define MCU_PIN_D22_BIT 22
+#define MCU_PIN_D23_BIT 23
+#define MCU_PIN_D24_BIT 24
+#define MCU_PIN_D25_BIT 25
+#define MCU_PIN_D26_BIT 26
+#define MCU_PIN_D27_BIT 27
+#define MCU_PIN_D28_BIT 28
+#define MCU_PIN_D29_BIT 29
+#define MCU_PIN_D30_BIT 30
+#define MCU_PIN_D31_BIT 31
+
+#define MCU_PIN_E0_BIT 0
+#define MCU_PIN_E1_BIT 1
+#define MCU_PIN_E2_BIT 2
+#define MCU_PIN_E3_BIT 3
+#define MCU_PIN_E4_BIT 4
+#define MCU_PIN_E5_BIT 5
+#define MCU_PIN_E6_BIT 6
+#define MCU_PIN_E7_BIT 7
+#define MCU_PIN_E8_BIT 8
+#define MCU_PIN_E9_BIT 9
+#define MCU_PIN_E10_BIT 10
+#define MCU_PIN_E11_BIT 11
+#define MCU_PIN_E12_BIT 12
+#define MCU_PIN_E13_BIT 13
+#define MCU_PIN_E14_BIT 14
+#define MCU_PIN_E15_BIT 15
+#define MCU_PIN_E16_BIT 16
+#define MCU_PIN_E17_BIT 17
+#define MCU_PIN_E18_BIT 18
+#define MCU_PIN_E19_BIT 19
+#define MCU_PIN_E20_BIT 20
+#define MCU_PIN_E21_BIT 21
+#define MCU_PIN_E22_BIT 22
+#define MCU_PIN_E23_BIT 23
+#define MCU_PIN_E24_BIT 24
+#define MCU_PIN_E25_BIT 25
+#define MCU_PIN_E26_BIT 26
+#define MCU_PIN_E27_BIT 27
+#define MCU_PIN_E28_BIT 28
+#define MCU_PIN_E29_BIT 29
+#define MCU_PIN_E30_BIT 30
+#define MCU_PIN_E31_BIT 31
+
+#define MCU_PIN_F0_BIT 0
+#define MCU_PIN_F1_BIT 1
+#define MCU_PIN_F2_BIT 2
+#define MCU_PIN_F3_BIT 3
+#define MCU_PIN_F4_BIT 4
+#define MCU_PIN_F5_BIT 5
+#define MCU_PIN_F6_BIT 6
+#define MCU_PIN_F7_BIT 7
+#define MCU_PIN_F8_BIT 8
+#define MCU_PIN_F9_BIT 9
+#define MCU_PIN_F10_BIT 10
+#define MCU_PIN_F11_BIT 11
+#define MCU_PIN_F12_BIT 12
+#define MCU_PIN_F13_BIT 13
+#define MCU_PIN_F14_BIT 14
+#define MCU_PIN_F15_BIT 15
+#define MCU_PIN_F16_BIT 16
+#define MCU_PIN_F17_BIT 17
+#define MCU_PIN_F18_BIT 18
+#define MCU_PIN_F19_BIT 19
+#define MCU_PIN_F20_BIT 20
+#define MCU_PIN_F21_BIT 21
+#define MCU_PIN_F22_BIT 22
+#define MCU_PIN_F23_BIT 23
+#define MCU_PIN_F24_BIT 24
+#define MCU_PIN_F25_BIT 25
+#define MCU_PIN_F26_BIT 26
+#define MCU_PIN_F27_BIT 27
+#define MCU_PIN_F28_BIT 28
+#define MCU_PIN_F29_BIT 29
+#define MCU_PIN_F30_BIT 30
+#define MCU_PIN_F31_BIT 31
+
+#define MCU_PIN_G0_BIT 0
+#define MCU_PIN_G1_BIT 1
+#define MCU_PIN_G2_BIT 2
+#define MCU_PIN_G3_BIT 3
+#define MCU_PIN_G4_BIT 4
+#define MCU_PIN_G5_BIT 5
+#define MCU_PIN_G6_BIT 6
+#define MCU_PIN_G7_BIT 7
+#define MCU_PIN_G8_BIT 8
+#define MCU_PIN_G9_BIT 9
+#define MCU_PIN_G10_BIT 10
+#define MCU_PIN_G11_BIT 11
+#define MCU_PIN_G12_BIT 12
+#define MCU_PIN_G13_BIT 13
+#define MCU_PIN_G14_BIT 14
+#define MCU_PIN_G15_BIT 15
+#define MCU_PIN_G16_BIT 16
+#define MCU_PIN_G17_BIT 17
+#define MCU_PIN_G18_BIT 18
+#define MCU_PIN_G19_BIT 19
+#define MCU_PIN_G20_BIT 20
+#define MCU_PIN_G21_BIT 21
+#define MCU_PIN_G22_BIT 22
+#define MCU_PIN_G23_BIT 23
+#define MCU_PIN_G24_BIT 24
+#define MCU_PIN_G25_BIT 25
+#define MCU_PIN_G26_BIT 26
+#define MCU_PIN_G27_BIT 27
+#define MCU_PIN_G28_BIT 28
+#define MCU_PIN_G29_BIT 29
+#define MCU_PIN_G30_BIT 30
+#define MCU_PIN_G31_BIT 31
+
+#define MCU_PIN_H0_BIT 0
+#define MCU_PIN_H1_BIT 1
+#define MCU_PIN_H2_BIT 2
+#define MCU_PIN_H3_BIT 3
+#define MCU_PIN_H4_BIT 4
+#define MCU_PIN_H5_BIT 5
+#define MCU_PIN_H6_BIT 6
+#define MCU_PIN_H7_BIT 7
+#define MCU_PIN_H8_BIT 8
+#define MCU_PIN_H9_BIT 9
+#define MCU_PIN_H10_BIT 10
+#define MCU_PIN_H11_BIT 11
+#define MCU_PIN_H12_BIT 12
+#define MCU_PIN_H13_BIT 13
+#define MCU_PIN_H14_BIT 14
+#define MCU_PIN_H15_BIT 15
+#define MCU_PIN_H16_BIT 16
+#define MCU_PIN_H17_BIT 17
+#define MCU_PIN_H18_BIT 18
+#define MCU_PIN_H19_BIT 19
+#define MCU_PIN_H20_BIT 20
+#define MCU_PIN_H21_BIT 21
+#define MCU_PIN_H22_BIT 22
+#define MCU_PIN_H23_BIT 23
+#define MCU_PIN_H24_BIT 24
+#define MCU_PIN_H25_BIT 25
+#define MCU_PIN_H26_BIT 26
+#define MCU_PIN_H27_BIT 27
+#define MCU_PIN_H28_BIT 28
+#define MCU_PIN_H29_BIT 29
+#define MCU_PIN_H30_BIT 30
+#define MCU_PIN_H31_BIT 31
+
+#define MCU_PIN_I0_BIT 0
+#define MCU_PIN_I1_BIT 1
+#define MCU_PIN_I2_BIT 2
+#define MCU_PIN_I3_BIT 3
+#define MCU_PIN_I4_BIT 4
+#define MCU_PIN_I5_BIT 5
+#define MCU_PIN_I6_BIT 6
+#define MCU_PIN_I7_BIT 7
+#define MCU_PIN_I8_BIT 8
+#define MCU_PIN_I9_BIT 9
+#define MCU_PIN_I10_BIT 10
+#define MCU_PIN_I11_BIT 11
+#define MCU_PIN_I12_BIT 12
+#define MCU_PIN_I13_BIT 13
+#define MCU_PIN_I14_BIT 14
+#define MCU_PIN_I15_BIT 15
+#define MCU_PIN_I16_BIT 16
+#define MCU_PIN_I17_BIT 17
+#define MCU_PIN_I18_BIT 18
+#define MCU_PIN_I19_BIT 19
+#define MCU_PIN_I20_BIT 20
+#define MCU_PIN_I21_BIT 21
+#define MCU_PIN_I22_BIT 22
+#define MCU_PIN_I23_BIT 23
+#define MCU_PIN_I24_BIT 24
+#define MCU_PIN_I25_BIT 25
+#define MCU_PIN_I26_BIT 26
+#define MCU_PIN_I27_BIT 27
+#define MCU_PIN_I28_BIT 28
+#define MCU_PIN_I29_BIT 29
+#define MCU_PIN_I30_BIT 30
+#define MCU_PIN_I31_BIT 31
+
+#define MCU_PIN_J0_BIT 0
+#define MCU_PIN_J1_BIT 1
+#define MCU_PIN_J2_BIT 2
+#define MCU_PIN_J3_BIT 3
+#define MCU_PIN_J4_BIT 4
+#define MCU_PIN_J5_BIT 5
+#define MCU_PIN_J6_BIT 6
+#define MCU_PIN_J7_BIT 7
+#define MCU_PIN_J8_BIT 8
+#define MCU_PIN_J9_BIT 9
+#define MCU_PIN_J10_BIT 10
+#define MCU_PIN_J11_BIT 11
+#define MCU_PIN_J12_BIT 12
+#define MCU_PIN_J13_BIT 13
+#define MCU_PIN_J14_BIT 14
+#define MCU_PIN_J15_BIT 15
+#define MCU_PIN_J16_BIT 16
+#define MCU_PIN_J17_BIT 17
+#define MCU_PIN_J18_BIT 18
+#define MCU_PIN_J19_BIT 19
+#define MCU_PIN_J20_BIT 20
+#define MCU_PIN_J21_BIT 21
+#define MCU_PIN_J22_BIT 22
+#define MCU_PIN_J23_BIT 23
+#define MCU_PIN_J24_BIT 24
+#define MCU_PIN_J25_BIT 25
+#define MCU_PIN_J26_BIT 26
+#define MCU_PIN_J27_BIT 27
+#define MCU_PIN_J28_BIT 28
+#define MCU_PIN_J29_BIT 29
+#define MCU_PIN_J30_BIT 30
+#define MCU_PIN_J31_BIT 31
+
+#define MCU_PIN_A0_PORT A
+#define MCU_PIN_A1_PORT A
+#define MCU_PIN_A2_PORT A
+#define MCU_PIN_A3_PORT A
+#define MCU_PIN_A4_PORT A
+#define MCU_PIN_A5_PORT A
+#define MCU_PIN_A6_PORT A
+#define MCU_PIN_A7_PORT A
+#define MCU_PIN_A8_PORT A
+#define MCU_PIN_A9_PORT A
+#define MCU_PIN_A10_PORT A
+#define MCU_PIN_A11_PORT A
+#define MCU_PIN_A12_PORT A
+#define MCU_PIN_A13_PORT A
+#define MCU_PIN_A14_PORT A
+#define MCU_PIN_A15_PORT A
+#define MCU_PIN_A16_PORT A
+#define MCU_PIN_A17_PORT A
+#define MCU_PIN_A18_PORT A
+#define MCU_PIN_A19_PORT A
+#define MCU_PIN_A20_PORT A
+#define MCU_PIN_A21_PORT A
+#define MCU_PIN_A22_PORT A
+#define MCU_PIN_A23_PORT A
+#define MCU_PIN_A24_PORT A
+#define MCU_PIN_A25_PORT A
+#define MCU_PIN_A26_PORT A
+#define MCU_PIN_A27_PORT A
+#define MCU_PIN_A28_PORT A
+#define MCU_PIN_A29_PORT A
+#define MCU_PIN_A30_PORT A
+#define MCU_PIN_A31_PORT A
+#define MCU_PIN_B0_PORT B
+#define MCU_PIN_B1_PORT B
+#define MCU_PIN_B2_PORT B
+#define MCU_PIN_B3_PORT B
+#define MCU_PIN_B4_PORT B
+#define MCU_PIN_B5_PORT B
+#define MCU_PIN_B6_PORT B
+#define MCU_PIN_B7_PORT B
+#define MCU_PIN_B8_PORT B
+#define MCU_PIN_B9_PORT B
+#define MCU_PIN_B10_PORT B
+#define MCU_PIN_B11_PORT B
+#define MCU_PIN_B12_PORT B
+#define MCU_PIN_B13_PORT B
+#define MCU_PIN_B14_PORT B
+#define MCU_PIN_B15_PORT B
+#define MCU_PIN_B16_PORT B
+#define MCU_PIN_B17_PORT B
+#define MCU_PIN_B18_PORT B
+#define MCU_PIN_B19_PORT B
+#define MCU_PIN_B20_PORT B
+#define MCU_PIN_B21_PORT B
+#define MCU_PIN_B22_PORT B
+#define MCU_PIN_B23_PORT B
+#define MCU_PIN_B24_PORT B
+#define MCU_PIN_B25_PORT B
+#define MCU_PIN_B26_PORT B
+#define MCU_PIN_B27_PORT B
+#define MCU_PIN_B28_PORT B
+#define MCU_PIN_B29_PORT B
+#define MCU_PIN_B30_PORT B
+#define MCU_PIN_B31_PORT B
+#define MCU_PIN_C0_PORT C
+#define MCU_PIN_C1_PORT C
+#define MCU_PIN_C2_PORT C
+#define MCU_PIN_C3_PORT C
+#define MCU_PIN_C4_PORT C
+#define MCU_PIN_C5_PORT C
+#define MCU_PIN_C6_PORT C
+#define MCU_PIN_C7_PORT C
+#define MCU_PIN_C8_PORT C
+#define MCU_PIN_C9_PORT C
+#define MCU_PIN_C10_PORT C
+#define MCU_PIN_C11_PORT C
+#define MCU_PIN_C12_PORT C
+#define MCU_PIN_C13_PORT C
+#define MCU_PIN_C14_PORT C
+#define MCU_PIN_C15_PORT C
+#define MCU_PIN_C16_PORT C
+#define MCU_PIN_C17_PORT C
+#define MCU_PIN_C18_PORT C
+#define MCU_PIN_C19_PORT C
+#define MCU_PIN_C20_PORT C
+#define MCU_PIN_C21_PORT C
+#define MCU_PIN_C22_PORT C
+#define MCU_PIN_C23_PORT C
+#define MCU_PIN_C24_PORT C
+#define MCU_PIN_C25_PORT C
+#define MCU_PIN_C26_PORT C
+#define MCU_PIN_C27_PORT C
+#define MCU_PIN_C28_PORT C
+#define MCU_PIN_C29_PORT C
+#define MCU_PIN_C30_PORT C
+#define MCU_PIN_C31_PORT C
+#define MCU_PIN_D0_PORT D
+#define MCU_PIN_D1_PORT D
+#define MCU_PIN_D2_PORT D
+#define MCU_PIN_D3_PORT D
+#define MCU_PIN_D4_PORT D
+#define MCU_PIN_D5_PORT D
+#define MCU_PIN_D6_PORT D
+#define MCU_PIN_D7_PORT D
+#define MCU_PIN_D8_PORT D
+#define MCU_PIN_D9_PORT D
+#define MCU_PIN_D10_PORT D
+#define MCU_PIN_D11_PORT D
+#define MCU_PIN_D12_PORT D
+#define MCU_PIN_D13_PORT D
+#define MCU_PIN_D14_PORT D
+#define MCU_PIN_D15_PORT D
+#define MCU_PIN_D16_PORT D
+#define MCU_PIN_D17_PORT D
+#define MCU_PIN_D18_PORT D
+#define MCU_PIN_D19_PORT D
+#define MCU_PIN_D20_PORT D
+#define MCU_PIN_D21_PORT D
+#define MCU_PIN_D22_PORT D
+#define MCU_PIN_D23_PORT D
+#define MCU_PIN_D24_PORT D
+#define MCU_PIN_D25_PORT D
+#define MCU_PIN_D26_PORT D
+#define MCU_PIN_D27_PORT D
+#define MCU_PIN_D28_PORT D
+#define MCU_PIN_D29_PORT D
+#define MCU_PIN_D30_PORT D
+#define MCU_PIN_D31_PORT D
+
+#define MCU_PIN_E0_PORT E
+#define MCU_PIN_E1_PORT E
+#define MCU_PIN_E2_PORT E
+#define MCU_PIN_E3_PORT E
+#define MCU_PIN_E4_PORT E
+#define MCU_PIN_E5_PORT E
+#define MCU_PIN_E6_PORT E
+#define MCU_PIN_E7_PORT E
+#define MCU_PIN_E8_PORT E
+#define MCU_PIN_E9_PORT E
+#define MCU_PIN_E10_PORT E
+#define MCU_PIN_E11_PORT E
+#define MCU_PIN_E12_PORT E
+#define MCU_PIN_E13_PORT E
+#define MCU_PIN_E14_PORT E
+#define MCU_PIN_E15_PORT E
+#define MCU_PIN_E16_PORT E
+#define MCU_PIN_E17_PORT E
+#define MCU_PIN_E18_PORT E
+#define MCU_PIN_E19_PORT E
+#define MCU_PIN_E20_PORT E
+#define MCU_PIN_E21_PORT E
+#define MCU_PIN_E22_PORT E
+#define MCU_PIN_E23_PORT E
+#define MCU_PIN_E24_PORT E
+#define MCU_PIN_E25_PORT E
+#define MCU_PIN_E26_PORT E
+#define MCU_PIN_E27_PORT E
+#define MCU_PIN_E28_PORT E
+#define MCU_PIN_E29_PORT E
+#define MCU_PIN_E30_PORT E
+#define MCU_PIN_E31_PORT E
+#define MCU_PIN_F0_PORT F
+#define MCU_PIN_F1_PORT F
+#define MCU_PIN_F2_PORT F
+#define MCU_PIN_F3_PORT F
+#define MCU_PIN_F4_PORT F
+#define MCU_PIN_F5_PORT F
+#define MCU_PIN_F6_PORT F
+#define MCU_PIN_F7_PORT F
+#define MCU_PIN_F8_PORT F
+#define MCU_PIN_F9_PORT F
+#define MCU_PIN_F10_PORT F
+#define MCU_PIN_F11_PORT F
+#define MCU_PIN_F12_PORT F
+#define MCU_PIN_F13_PORT F
+#define MCU_PIN_F14_PORT F
+#define MCU_PIN_F15_PORT F
+#define MCU_PIN_F16_PORT F
+#define MCU_PIN_F17_PORT F
+#define MCU_PIN_F18_PORT F
+#define MCU_PIN_F19_PORT F
+#define MCU_PIN_F20_PORT F
+#define MCU_PIN_F21_PORT F
+#define MCU_PIN_F22_PORT F
+#define MCU_PIN_F23_PORT F
+#define MCU_PIN_F24_PORT F
+#define MCU_PIN_F25_PORT F
+#define MCU_PIN_F26_PORT F
+#define MCU_PIN_F27_PORT F
+#define MCU_PIN_F28_PORT F
+#define MCU_PIN_F29_PORT F
+#define MCU_PIN_F30_PORT F
+#define MCU_PIN_F31_PORT F
+#define MCU_PIN_G0_PORT G
+#define MCU_PIN_G1_PORT G
+#define MCU_PIN_G2_PORT G
+#define MCU_PIN_G3_PORT G
+#define MCU_PIN_G4_PORT G
+#define MCU_PIN_G5_PORT G
+#define MCU_PIN_G6_PORT G
+#define MCU_PIN_G7_PORT G
+#define MCU_PIN_G8_PORT G
+#define MCU_PIN_G9_PORT G
+#define MCU_PIN_G10_PORT G
+#define MCU_PIN_G11_PORT G
+#define MCU_PIN_G12_PORT G
+#define MCU_PIN_G13_PORT G
+#define MCU_PIN_G14_PORT G
+#define MCU_PIN_G15_PORT G
+#define MCU_PIN_G16_PORT G
+#define MCU_PIN_G17_PORT G
+#define MCU_PIN_G18_PORT G
+#define MCU_PIN_G19_PORT G
+#define MCU_PIN_G20_PORT G
+#define MCU_PIN_G21_PORT G
+#define MCU_PIN_G22_PORT G
+#define MCU_PIN_G23_PORT G
+#define MCU_PIN_G24_PORT G
+#define MCU_PIN_G25_PORT G
+#define MCU_PIN_G26_PORT G
+#define MCU_PIN_G27_PORT G
+#define MCU_PIN_G28_PORT G
+#define MCU_PIN_G29_PORT G
+#define MCU_PIN_G30_PORT G
+#define MCU_PIN_G31_PORT G
+
+#define MCU_PIN_H0_PORT H
+#define MCU_PIN_H1_PORT H
+#define MCU_PIN_H2_PORT H
+#define MCU_PIN_H3_PORT H
+#define MCU_PIN_H4_PORT H
+#define MCU_PIN_H5_PORT H
+#define MCU_PIN_H6_PORT H
+#define MCU_PIN_H7_PORT H
+#define MCU_PIN_H8_PORT H
+#define MCU_PIN_H9_PORT H
+#define MCU_PIN_H10_PORT H
+#define MCU_PIN_H11_PORT H
+#define MCU_PIN_H12_PORT H
+#define MCU_PIN_H13_PORT H
+#define MCU_PIN_H14_PORT H
+#define MCU_PIN_H15_PORT H
+#define MCU_PIN_H16_PORT H
+#define MCU_PIN_H17_PORT H
+#define MCU_PIN_H18_PORT H
+#define MCU_PIN_H19_PORT H
+#define MCU_PIN_H20_PORT H
+#define MCU_PIN_H21_PORT H
+#define MCU_PIN_H22_PORT H
+#define MCU_PIN_H23_PORT H
+#define MCU_PIN_H24_PORT H
+#define MCU_PIN_H25_PORT H
+#define MCU_PIN_H26_PORT H
+#define MCU_PIN_H27_PORT H
+#define MCU_PIN_H28_PORT H
+#define MCU_PIN_H29_PORT H
+#define MCU_PIN_H30_PORT H
+#define MCU_PIN_H31_PORT H
+#define MCU_PIN_I0_PORT I
+#define MCU_PIN_I1_PORT I
+#define MCU_PIN_I2_PORT I
+#define MCU_PIN_I3_PORT I
+#define MCU_PIN_I4_PORT I
+#define MCU_PIN_I5_PORT I
+#define MCU_PIN_I6_PORT I
+#define MCU_PIN_I7_PORT I
+#define MCU_PIN_I8_PORT I
+#define MCU_PIN_I9_PORT I
+#define MCU_PIN_I10_PORT I
+#define MCU_PIN_I11_PORT I
+#define MCU_PIN_I12_PORT I
+#define MCU_PIN_I13_PORT I
+#define MCU_PIN_I14_PORT I
+#define MCU_PIN_I15_PORT I
+#define MCU_PIN_I16_PORT I
+#define MCU_PIN_I17_PORT I
+#define MCU_PIN_I18_PORT I
+#define MCU_PIN_I19_PORT I
+#define MCU_PIN_I20_PORT I
+#define MCU_PIN_I21_PORT I
+#define MCU_PIN_I22_PORT I
+#define MCU_PIN_I23_PORT I
+#define MCU_PIN_I24_PORT I
+#define MCU_PIN_I25_PORT I
+#define MCU_PIN_I26_PORT I
+#define MCU_PIN_I27_PORT I
+#define MCU_PIN_I28_PORT I
+#define MCU_PIN_I29_PORT I
+#define MCU_PIN_I30_PORT I
+#define MCU_PIN_I31_PORT I
+
+#define MCU_PIN_J0_PORT J
+#define MCU_PIN_J1_PORT J
+#define MCU_PIN_J2_PORT J
+#define MCU_PIN_J3_PORT J
+#define MCU_PIN_J4_PORT J
+#define MCU_PIN_J5_PORT J
+#define MCU_PIN_J6_PORT J
+#define MCU_PIN_J7_PORT J
+#define MCU_PIN_J8_PORT J
+#define MCU_PIN_J9_PORT J
+#define MCU_PIN_J10_PORT J
+#define MCU_PIN_J11_PORT J
+#define MCU_PIN_J12_PORT J
+#define MCU_PIN_J13_PORT J
+#define MCU_PIN_J14_PORT J
+#define MCU_PIN_J15_PORT J
+#define MCU_PIN_J16_PORT J
+#define MCU_PIN_J17_PORT J
+#define MCU_PIN_J18_PORT J
+#define MCU_PIN_J19_PORT J
+#define MCU_PIN_J20_PORT J
+#define MCU_PIN_J21_PORT J
+#define MCU_PIN_J22_PORT J
+#define MCU_PIN_J23_PORT J
+#define MCU_PIN_J24_PORT J
+#define MCU_PIN_J25_PORT J
+#define MCU_PIN_J26_PORT J
+#define MCU_PIN_J27_PORT J
+#define MCU_PIN_J28_PORT J
+#define MCU_PIN_J29_PORT J
+#define MCU_PIN_J30_PORT J
+#define MCU_PIN_J31_PORT J
+
+#define MCU_PIN_GPIO0_BIT 0
+#define MCU_PIN_GPIO1_BIT 1
+#define MCU_PIN_GPIO2_BIT 2
+#define MCU_PIN_GPIO3_BIT 3
+#define MCU_PIN_GPIO4_BIT 4
+#define MCU_PIN_GPIO5_BIT 5
+#define MCU_PIN_GPIO6_BIT 6
+#define MCU_PIN_GPIO7_BIT 7
+#define MCU_PIN_GPIO8_BIT 8
+#define MCU_PIN_GPIO9_BIT 9
+#define MCU_PIN_GPIO10_BIT 10
+#define MCU_PIN_GPIO11_BIT 11
+#define MCU_PIN_GPIO12_BIT 12
+#define MCU_PIN_GPIO13_BIT 13
+#define MCU_PIN_GPIO14_BIT 14
+#define MCU_PIN_GPIO15_BIT 15
+#define MCU_PIN_GPIO16_BIT 16
+#define MCU_PIN_GPIO17_BIT 17
+#define MCU_PIN_GPIO18_BIT 18
+#define MCU_PIN_GPIO19_BIT 19
+#define MCU_PIN_GPIO20_BIT 20
+#define MCU_PIN_GPIO21_BIT 21
+#define MCU_PIN_GPIO22_BIT 22
+#define MCU_PIN_GPIO23_BIT 23
+#define MCU_PIN_GPIO24_BIT 24
+#define MCU_PIN_GPIO25_BIT 25
+#define MCU_PIN_GPIO26_BIT 26
+#define MCU_PIN_GPIO27_BIT 27
+#define MCU_PIN_GPIO28_BIT 28
+#define MCU_PIN_GPIO29_BIT 29
+#define MCU_PIN_GPIO30_BIT 30
+#define MCU_PIN_GPIO31_BIT 31
+#define MCU_PIN_GPIO32_BIT 32
+#define MCU_PIN_GPIO33_BIT 33
+#define MCU_PIN_GPIO34_BIT 34
+#define MCU_PIN_GPIO35_BIT 35
+#define MCU_PIN_GPIO36_BIT 36
+#define MCU_PIN_GPIO37_BIT 37
+#define MCU_PIN_GPIO38_BIT 38
+#define MCU_PIN_GPIO39_BIT 39
+#define MCU_PIN_GPIO40_BIT 40
+#define MCU_PIN_GPIO41_BIT 41
+#define MCU_PIN_GPIO42_BIT 42
+#define MCU_PIN_GPIO43_BIT 43
+#define MCU_PIN_GPIO44_BIT 44
+#define MCU_PIN_GPIO45_BIT 45
+#define MCU_PIN_GPIO46_BIT 46
+#define MCU_PIN_GPIO47_BIT 47
+#define MCU_PIN_GPIO48_BIT 48
+#define MCU_PIN_GPIO49_BIT 49
+#define MCU_PIN_GPIO50_BIT 50
+#define MCU_PIN_GPIO51_BIT 51
+#define MCU_PIN_GPIO52_BIT 52
+#define MCU_PIN_GPIO53_BIT 53
+#define MCU_PIN_GPIO54_BIT 54
+#define MCU_PIN_GPIO55_BIT 55
+#define MCU_PIN_GPIO56_BIT 56
+#define MCU_PIN_GPIO57_BIT 57
+#define MCU_PIN_GPIO58_BIT 58
+#define MCU_PIN_GPIO59_BIT 59
+#define MCU_PIN_GPIO60_BIT 60
+#define MCU_PIN_GPIO61_BIT 61
+#define MCU_PIN_GPIO62_BIT 62
+#define MCU_PIN_GPIO63_BIT 63
+
+#define MCU_PIN_GPIO0_PORT
+#define MCU_PIN_GPIO1_PORT
+#define MCU_PIN_GPIO2_PORT
+#define MCU_PIN_GPIO3_PORT
+#define MCU_PIN_GPIO4_PORT
+#define MCU_PIN_GPIO5_PORT
+#define MCU_PIN_GPIO6_PORT
+#define MCU_PIN_GPIO7_PORT
+#define MCU_PIN_GPIO8_PORT
+#define MCU_PIN_GPIO9_PORT
+#define MCU_PIN_GPIO10_PORT
+#define MCU_PIN_GPIO11_PORT
+#define MCU_PIN_GPIO12_PORT
+#define MCU_PIN_GPIO13_PORT
+#define MCU_PIN_GPIO14_PORT
+#define MCU_PIN_GPIO15_PORT
+#define MCU_PIN_GPIO16_PORT
+#define MCU_PIN_GPIO17_PORT
+#define MCU_PIN_GPIO18_PORT
+#define MCU_PIN_GPIO19_PORT
+#define MCU_PIN_GPIO20_PORT
+#define MCU_PIN_GPIO21_PORT
+#define MCU_PIN_GPIO22_PORT
+#define MCU_PIN_GPIO23_PORT
+#define MCU_PIN_GPIO24_PORT
+#define MCU_PIN_GPIO25_PORT
+#define MCU_PIN_GPIO26_PORT
+#define MCU_PIN_GPIO27_PORT
+#define MCU_PIN_GPIO28_PORT
+#define MCU_PIN_GPIO29_PORT
+#define MCU_PIN_GPIO30_PORT
+#define MCU_PIN_GPIO31_PORT
+#define MCU_PIN_GPIO32_PORT
+#define MCU_PIN_GPIO33_PORT
+#define MCU_PIN_GPIO34_PORT
+#define MCU_PIN_GPIO35_PORT
+#define MCU_PIN_GPIO36_PORT
+#define MCU_PIN_GPIO37_PORT
+#define MCU_PIN_GPIO38_PORT
+#define MCU_PIN_GPIO39_PORT
+#define MCU_PIN_GPIO40_PORT
+#define MCU_PIN_GPIO41_PORT
+#define MCU_PIN_GPIO42_PORT
+#define MCU_PIN_GPIO43_PORT
+#define MCU_PIN_GPIO44_PORT
+#define MCU_PIN_GPIO45_PORT
+#define MCU_PIN_GPIO46_PORT
+#define MCU_PIN_GPIO47_PORT
+#define MCU_PIN_GPIO48_PORT
+#define MCU_PIN_GPIO49_PORT
+#define MCU_PIN_GPIO50_PORT
+#define MCU_PIN_GPIO51_PORT
+#define MCU_PIN_GPIO52_PORT
+#define MCU_PIN_GPIO53_PORT
+#define MCU_PIN_GPIO54_PORT
+#define MCU_PIN_GPIO55_PORT
+#define MCU_PIN_GPIO56_PORT
+#define MCU_PIN_GPIO57_PORT
+#define MCU_PIN_GPIO58_PORT
+#define MCU_PIN_GPIO59_PORT
+#define MCU_PIN_GPIO60_PORT
+#define MCU_PIN_GPIO61_PORT
+#define MCU_PIN_GPIO62_PORT
+#define MCU_PIN_GPIO63_PORT
+
+#define _MCU_PIN_(X, Y) MCU_PIN_##X##_##Y
+#define MCU_PIN(X, Y) _MCU_PIN_(X, Y)
+
+#if (defined(STEP0_PIN) && !(defined(STEP0_BIT) || defined(STEP0_PORT)))
+#define STEP0_BIT MCU_PIN(STEP0_PIN,BIT)
+#define STEP0_PORT MCU_PIN(STEP0_PIN,PORT)
+#endif
+#if (defined(STEP1_PIN) && !(defined(STEP1_BIT) || defined(STEP1_PORT)))
+#define STEP1_BIT MCU_PIN(STEP1_PIN,BIT)
+#define STEP1_PORT MCU_PIN(STEP1_PIN,PORT)
+#endif
+#if (defined(STEP2_PIN) && !(defined(STEP2_BIT) || defined(STEP2_PORT)))
+#define STEP2_BIT MCU_PIN(STEP2_PIN,BIT)
+#define STEP2_PORT MCU_PIN(STEP2_PIN,PORT)
+#endif
+#if (defined(STEP3_PIN) && !(defined(STEP3_BIT) || defined(STEP3_PORT)))
+#define STEP3_BIT MCU_PIN(STEP3_PIN,BIT)
+#define STEP3_PORT MCU_PIN(STEP3_PIN,PORT)
+#endif
+#if (defined(STEP4_PIN) && !(defined(STEP4_BIT) || defined(STEP4_PORT)))
+#define STEP4_BIT MCU_PIN(STEP4_PIN,BIT)
+#define STEP4_PORT MCU_PIN(STEP4_PIN,PORT)
+#endif
+#if (defined(STEP5_PIN) && !(defined(STEP5_BIT) || defined(STEP5_PORT)))
+#define STEP5_BIT MCU_PIN(STEP5_PIN,BIT)
+#define STEP5_PORT MCU_PIN(STEP5_PIN,PORT)
+#endif
+#if (defined(STEP6_PIN) && !(defined(STEP6_BIT) || defined(STEP6_PORT)))
+#define STEP6_BIT MCU_PIN(STEP6_PIN,BIT)
+#define STEP6_PORT MCU_PIN(STEP6_PIN,PORT)
+#endif
+#if (defined(STEP7_PIN) && !(defined(STEP7_BIT) || defined(STEP7_PORT)))
+#define STEP7_BIT MCU_PIN(STEP7_PIN,BIT)
+#define STEP7_PORT MCU_PIN(STEP7_PIN,PORT)
+#endif
+#if (defined(DIR0_PIN) && !(defined(DIR0_BIT) || defined(DIR0_PORT)))
+#define DIR0_BIT MCU_PIN(DIR0_PIN,BIT)
+#define DIR0_PORT MCU_PIN(DIR0_PIN,PORT)
+#endif
+#if (defined(DIR1_PIN) && !(defined(DIR1_BIT) || defined(DIR1_PORT)))
+#define DIR1_BIT MCU_PIN(DIR1_PIN,BIT)
+#define DIR1_PORT MCU_PIN(DIR1_PIN,PORT)
+#endif
+#if (defined(DIR2_PIN) && !(defined(DIR2_BIT) || defined(DIR2_PORT)))
+#define DIR2_BIT MCU_PIN(DIR2_PIN,BIT)
+#define DIR2_PORT MCU_PIN(DIR2_PIN,PORT)
+#endif
+#if (defined(DIR3_PIN) && !(defined(DIR3_BIT) || defined(DIR3_PORT)))
+#define DIR3_BIT MCU_PIN(DIR3_PIN,BIT)
+#define DIR3_PORT MCU_PIN(DIR3_PIN,PORT)
+#endif
+#if (defined(DIR4_PIN) && !(defined(DIR4_BIT) || defined(DIR4_PORT)))
+#define DIR4_BIT MCU_PIN(DIR4_PIN,BIT)
+#define DIR4_PORT MCU_PIN(DIR4_PIN,PORT)
+#endif
+#if (defined(DIR5_PIN) && !(defined(DIR5_BIT) || defined(DIR5_PORT)))
+#define DIR5_BIT MCU_PIN(DIR5_PIN,BIT)
+#define DIR5_PORT MCU_PIN(DIR5_PIN,PORT)
+#endif
+#if (defined(DIR6_PIN) && !(defined(DIR6_BIT) || defined(DIR6_PORT)))
+#define DIR6_BIT MCU_PIN(DIR6_PIN,BIT)
+#define DIR6_PORT MCU_PIN(DIR6_PIN,PORT)
+#endif
+#if (defined(DIR7_PIN) && !(defined(DIR7_BIT) || defined(DIR7_PORT)))
+#define DIR7_BIT MCU_PIN(DIR7_PIN,BIT)
+#define DIR7_PORT MCU_PIN(DIR7_PIN,PORT)
+#endif
+#if (defined(STEP0_EN_PIN) && !(defined(STEP0_EN_BIT) || defined(STEP0_EN_PORT)))
+#define STEP0_EN_BIT MCU_PIN(STEP0_EN_PIN,BIT)
+#define STEP0_EN_PORT MCU_PIN(STEP0_EN_PIN,PORT)
+#endif
+#if (defined(STEP1_EN_PIN) && !(defined(STEP1_EN_BIT) || defined(STEP1_EN_PORT)))
+#define STEP1_EN_BIT MCU_PIN(STEP1_EN_PIN,BIT)
+#define STEP1_EN_PORT MCU_PIN(STEP1_EN_PIN,PORT)
+#endif
+#if (defined(STEP2_EN_PIN) && !(defined(STEP2_EN_BIT) || defined(STEP2_EN_PORT)))
+#define STEP2_EN_BIT MCU_PIN(STEP2_EN_PIN,BIT)
+#define STEP2_EN_PORT MCU_PIN(STEP2_EN_PIN,PORT)
+#endif
+#if (defined(STEP3_EN_PIN) && !(defined(STEP3_EN_BIT) || defined(STEP3_EN_PORT)))
+#define STEP3_EN_BIT MCU_PIN(STEP3_EN_PIN,BIT)
+#define STEP3_EN_PORT MCU_PIN(STEP3_EN_PIN,PORT)
+#endif
+#if (defined(STEP4_EN_PIN) && !(defined(STEP4_EN_BIT) || defined(STEP4_EN_PORT)))
+#define STEP4_EN_BIT MCU_PIN(STEP4_EN_PIN,BIT)
+#define STEP4_EN_PORT MCU_PIN(STEP4_EN_PIN,PORT)
+#endif
+#if (defined(STEP5_EN_PIN) && !(defined(STEP5_EN_BIT) || defined(STEP5_EN_PORT)))
+#define STEP5_EN_BIT MCU_PIN(STEP5_EN_PIN,BIT)
+#define STEP5_EN_PORT MCU_PIN(STEP5_EN_PIN,PORT)
+#endif
+#if (defined(STEP6_EN_PIN) && !(defined(STEP6_EN_BIT) || defined(STEP6_EN_PORT)))
+#define STEP6_EN_BIT MCU_PIN(STEP6_EN_PIN,BIT)
+#define STEP6_EN_PORT MCU_PIN(STEP6_EN_PIN,PORT)
+#endif
+#if (defined(STEP7_EN_PIN) && !(defined(STEP7_EN_BIT) || defined(STEP7_EN_PORT)))
+#define STEP7_EN_BIT MCU_PIN(STEP7_EN_PIN,BIT)
+#define STEP7_EN_PORT MCU_PIN(STEP7_EN_PIN,PORT)
+#endif
+#if (defined(PWM0_PIN) && !(defined(PWM0_BIT) || defined(PWM0_PORT)))
+#define PWM0_BIT MCU_PIN(PWM0_PIN,BIT)
+#define PWM0_PORT MCU_PIN(PWM0_PIN,PORT)
+#endif
+#if (defined(PWM1_PIN) && !(defined(PWM1_BIT) || defined(PWM1_PORT)))
+#define PWM1_BIT MCU_PIN(PWM1_PIN,BIT)
+#define PWM1_PORT MCU_PIN(PWM1_PIN,PORT)
+#endif
+#if (defined(PWM2_PIN) && !(defined(PWM2_BIT) || defined(PWM2_PORT)))
+#define PWM2_BIT MCU_PIN(PWM2_PIN,BIT)
+#define PWM2_PORT MCU_PIN(PWM2_PIN,PORT)
+#endif
+#if (defined(PWM3_PIN) && !(defined(PWM3_BIT) || defined(PWM3_PORT)))
+#define PWM3_BIT MCU_PIN(PWM3_PIN,BIT)
+#define PWM3_PORT MCU_PIN(PWM3_PIN,PORT)
+#endif
+#if (defined(PWM4_PIN) && !(defined(PWM4_BIT) || defined(PWM4_PORT)))
+#define PWM4_BIT MCU_PIN(PWM4_PIN,BIT)
+#define PWM4_PORT MCU_PIN(PWM4_PIN,PORT)
+#endif
+#if (defined(PWM5_PIN) && !(defined(PWM5_BIT) || defined(PWM5_PORT)))
+#define PWM5_BIT MCU_PIN(PWM5_PIN,BIT)
+#define PWM5_PORT MCU_PIN(PWM5_PIN,PORT)
+#endif
+#if (defined(PWM6_PIN) && !(defined(PWM6_BIT) || defined(PWM6_PORT)))
+#define PWM6_BIT MCU_PIN(PWM6_PIN,BIT)
+#define PWM6_PORT MCU_PIN(PWM6_PIN,PORT)
+#endif
+#if (defined(PWM7_PIN) && !(defined(PWM7_BIT) || defined(PWM7_PORT)))
+#define PWM7_BIT MCU_PIN(PWM7_PIN,BIT)
+#define PWM7_PORT MCU_PIN(PWM7_PIN,PORT)
+#endif
+#if (defined(PWM8_PIN) && !(defined(PWM8_BIT) || defined(PWM8_PORT)))
+#define PWM8_BIT MCU_PIN(PWM8_PIN,BIT)
+#define PWM8_PORT MCU_PIN(PWM8_PIN,PORT)
+#endif
+#if (defined(PWM9_PIN) && !(defined(PWM9_BIT) || defined(PWM9_PORT)))
+#define PWM9_BIT MCU_PIN(PWM9_PIN,BIT)
+#define PWM9_PORT MCU_PIN(PWM9_PIN,PORT)
+#endif
+#if (defined(PWM10_PIN) && !(defined(PWM10_BIT) || defined(PWM10_PORT)))
+#define PWM10_BIT MCU_PIN(PWM10_PIN,BIT)
+#define PWM10_PORT MCU_PIN(PWM10_PIN,PORT)
+#endif
+#if (defined(PWM11_PIN) && !(defined(PWM11_BIT) || defined(PWM11_PORT)))
+#define PWM11_BIT MCU_PIN(PWM11_PIN,BIT)
+#define PWM11_PORT MCU_PIN(PWM11_PIN,PORT)
+#endif
+#if (defined(PWM12_PIN) && !(defined(PWM12_BIT) || defined(PWM12_PORT)))
+#define PWM12_BIT MCU_PIN(PWM12_PIN,BIT)
+#define PWM12_PORT MCU_PIN(PWM12_PIN,PORT)
+#endif
+#if (defined(PWM13_PIN) && !(defined(PWM13_BIT) || defined(PWM13_PORT)))
+#define PWM13_BIT MCU_PIN(PWM13_PIN,BIT)
+#define PWM13_PORT MCU_PIN(PWM13_PIN,PORT)
+#endif
+#if (defined(PWM14_PIN) && !(defined(PWM14_BIT) || defined(PWM14_PORT)))
+#define PWM14_BIT MCU_PIN(PWM14_PIN,BIT)
+#define PWM14_PORT MCU_PIN(PWM14_PIN,PORT)
+#endif
+#if (defined(PWM15_PIN) && !(defined(PWM15_BIT) || defined(PWM15_PORT)))
+#define PWM15_BIT MCU_PIN(PWM15_PIN,BIT)
+#define PWM15_PORT MCU_PIN(PWM15_PIN,PORT)
+#endif
+#if (defined(SERVO0_PIN) && !(defined(SERVO0_BIT) || defined(SERVO0_PORT)))
+#define SERVO0_BIT MCU_PIN(SERVO0_PIN,BIT)
+#define SERVO0_PORT MCU_PIN(SERVO0_PIN,PORT)
+#endif
+#if (defined(SERVO1_PIN) && !(defined(SERVO1_BIT) || defined(SERVO1_PORT)))
+#define SERVO1_BIT MCU_PIN(SERVO1_PIN,BIT)
+#define SERVO1_PORT MCU_PIN(SERVO1_PIN,PORT)
+#endif
+#if (defined(SERVO2_PIN) && !(defined(SERVO2_BIT) || defined(SERVO2_PORT)))
+#define SERVO2_BIT MCU_PIN(SERVO2_PIN,BIT)
+#define SERVO2_PORT MCU_PIN(SERVO2_PIN,PORT)
+#endif
+#if (defined(SERVO3_PIN) && !(defined(SERVO3_BIT) || defined(SERVO3_PORT)))
+#define SERVO3_BIT MCU_PIN(SERVO3_PIN,BIT)
+#define SERVO3_PORT MCU_PIN(SERVO3_PIN,PORT)
+#endif
+#if (defined(SERVO4_PIN) && !(defined(SERVO4_BIT) || defined(SERVO4_PORT)))
+#define SERVO4_BIT MCU_PIN(SERVO4_PIN,BIT)
+#define SERVO4_PORT MCU_PIN(SERVO4_PIN,PORT)
+#endif
+#if (defined(SERVO5_PIN) && !(defined(SERVO5_BIT) || defined(SERVO5_PORT)))
+#define SERVO5_BIT MCU_PIN(SERVO5_PIN,BIT)
+#define SERVO5_PORT MCU_PIN(SERVO5_PIN,PORT)
+#endif
+#if (defined(DOUT0_PIN) && !(defined(DOUT0_BIT) || defined(DOUT0_PORT)))
+#define DOUT0_BIT MCU_PIN(DOUT0_PIN,BIT)
+#define DOUT0_PORT MCU_PIN(DOUT0_PIN,PORT)
+#endif
+#if (defined(DOUT1_PIN) && !(defined(DOUT1_BIT) || defined(DOUT1_PORT)))
+#define DOUT1_BIT MCU_PIN(DOUT1_PIN,BIT)
+#define DOUT1_PORT MCU_PIN(DOUT1_PIN,PORT)
+#endif
+#if (defined(DOUT2_PIN) && !(defined(DOUT2_BIT) || defined(DOUT2_PORT)))
+#define DOUT2_BIT MCU_PIN(DOUT2_PIN,BIT)
+#define DOUT2_PORT MCU_PIN(DOUT2_PIN,PORT)
+#endif
+#if (defined(DOUT3_PIN) && !(defined(DOUT3_BIT) || defined(DOUT3_PORT)))
+#define DOUT3_BIT MCU_PIN(DOUT3_PIN,BIT)
+#define DOUT3_PORT MCU_PIN(DOUT3_PIN,PORT)
+#endif
+#if (defined(DOUT4_PIN) && !(defined(DOUT4_BIT) || defined(DOUT4_PORT)))
+#define DOUT4_BIT MCU_PIN(DOUT4_PIN,BIT)
+#define DOUT4_PORT MCU_PIN(DOUT4_PIN,PORT)
+#endif
+#if (defined(DOUT5_PIN) && !(defined(DOUT5_BIT) || defined(DOUT5_PORT)))
+#define DOUT5_BIT MCU_PIN(DOUT5_PIN,BIT)
+#define DOUT5_PORT MCU_PIN(DOUT5_PIN,PORT)
+#endif
+#if (defined(DOUT6_PIN) && !(defined(DOUT6_BIT) || defined(DOUT6_PORT)))
+#define DOUT6_BIT MCU_PIN(DOUT6_PIN,BIT)
+#define DOUT6_PORT MCU_PIN(DOUT6_PIN,PORT)
+#endif
+#if (defined(DOUT7_PIN) && !(defined(DOUT7_BIT) || defined(DOUT7_PORT)))
+#define DOUT7_BIT MCU_PIN(DOUT7_PIN,BIT)
+#define DOUT7_PORT MCU_PIN(DOUT7_PIN,PORT)
+#endif
+#if (defined(DOUT8_PIN) && !(defined(DOUT8_BIT) || defined(DOUT8_PORT)))
+#define DOUT8_BIT MCU_PIN(DOUT8_PIN,BIT)
+#define DOUT8_PORT MCU_PIN(DOUT8_PIN,PORT)
+#endif
+#if (defined(DOUT9_PIN) && !(defined(DOUT9_BIT) || defined(DOUT9_PORT)))
+#define DOUT9_BIT MCU_PIN(DOUT9_PIN,BIT)
+#define DOUT9_PORT MCU_PIN(DOUT9_PIN,PORT)
+#endif
+#if (defined(DOUT10_PIN) && !(defined(DOUT10_BIT) || defined(DOUT10_PORT)))
+#define DOUT10_BIT MCU_PIN(DOUT10_PIN,BIT)
+#define DOUT10_PORT MCU_PIN(DOUT10_PIN,PORT)
+#endif
+#if (defined(DOUT11_PIN) && !(defined(DOUT11_BIT) || defined(DOUT11_PORT)))
+#define DOUT11_BIT MCU_PIN(DOUT11_PIN,BIT)
+#define DOUT11_PORT MCU_PIN(DOUT11_PIN,PORT)
+#endif
+#if (defined(DOUT12_PIN) && !(defined(DOUT12_BIT) || defined(DOUT12_PORT)))
+#define DOUT12_BIT MCU_PIN(DOUT12_PIN,BIT)
+#define DOUT12_PORT MCU_PIN(DOUT12_PIN,PORT)
+#endif
+#if (defined(DOUT13_PIN) && !(defined(DOUT13_BIT) || defined(DOUT13_PORT)))
+#define DOUT13_BIT MCU_PIN(DOUT13_PIN,BIT)
+#define DOUT13_PORT MCU_PIN(DOUT13_PIN,PORT)
+#endif
+#if (defined(DOUT14_PIN) && !(defined(DOUT14_BIT) || defined(DOUT14_PORT)))
+#define DOUT14_BIT MCU_PIN(DOUT14_PIN,BIT)
+#define DOUT14_PORT MCU_PIN(DOUT14_PIN,PORT)
+#endif
+#if (defined(DOUT15_PIN) && !(defined(DOUT15_BIT) || defined(DOUT15_PORT)))
+#define DOUT15_BIT MCU_PIN(DOUT15_PIN,BIT)
+#define DOUT15_PORT MCU_PIN(DOUT15_PIN,PORT)
+#endif
+#if (defined(DOUT16_PIN) && !(defined(DOUT16_BIT) || defined(DOUT16_PORT)))
+#define DOUT16_BIT MCU_PIN(DOUT16_PIN,BIT)
+#define DOUT16_PORT MCU_PIN(DOUT16_PIN,PORT)
+#endif
+#if (defined(DOUT17_PIN) && !(defined(DOUT17_BIT) || defined(DOUT17_PORT)))
+#define DOUT17_BIT MCU_PIN(DOUT17_PIN,BIT)
+#define DOUT17_PORT MCU_PIN(DOUT17_PIN,PORT)
+#endif
+#if (defined(DOUT18_PIN) && !(defined(DOUT18_BIT) || defined(DOUT18_PORT)))
+#define DOUT18_BIT MCU_PIN(DOUT18_PIN,BIT)
+#define DOUT18_PORT MCU_PIN(DOUT18_PIN,PORT)
+#endif
+#if (defined(DOUT19_PIN) && !(defined(DOUT19_BIT) || defined(DOUT19_PORT)))
+#define DOUT19_BIT MCU_PIN(DOUT19_PIN,BIT)
+#define DOUT19_PORT MCU_PIN(DOUT19_PIN,PORT)
+#endif
+#if (defined(DOUT20_PIN) && !(defined(DOUT20_BIT) || defined(DOUT20_PORT)))
+#define DOUT20_BIT MCU_PIN(DOUT20_PIN,BIT)
+#define DOUT20_PORT MCU_PIN(DOUT20_PIN,PORT)
+#endif
+#if (defined(DOUT21_PIN) && !(defined(DOUT21_BIT) || defined(DOUT21_PORT)))
+#define DOUT21_BIT MCU_PIN(DOUT21_PIN,BIT)
+#define DOUT21_PORT MCU_PIN(DOUT21_PIN,PORT)
+#endif
+#if (defined(DOUT22_PIN) && !(defined(DOUT22_BIT) || defined(DOUT22_PORT)))
+#define DOUT22_BIT MCU_PIN(DOUT22_PIN,BIT)
+#define DOUT22_PORT MCU_PIN(DOUT22_PIN,PORT)
+#endif
+#if (defined(DOUT23_PIN) && !(defined(DOUT23_BIT) || defined(DOUT23_PORT)))
+#define DOUT23_BIT MCU_PIN(DOUT23_PIN,BIT)
+#define DOUT23_PORT MCU_PIN(DOUT23_PIN,PORT)
+#endif
+#if (defined(DOUT24_PIN) && !(defined(DOUT24_BIT) || defined(DOUT24_PORT)))
+#define DOUT24_BIT MCU_PIN(DOUT24_PIN,BIT)
+#define DOUT24_PORT MCU_PIN(DOUT24_PIN,PORT)
+#endif
+#if (defined(DOUT25_PIN) && !(defined(DOUT25_BIT) || defined(DOUT25_PORT)))
+#define DOUT25_BIT MCU_PIN(DOUT25_PIN,BIT)
+#define DOUT25_PORT MCU_PIN(DOUT25_PIN,PORT)
+#endif
+#if (defined(DOUT26_PIN) && !(defined(DOUT26_BIT) || defined(DOUT26_PORT)))
+#define DOUT26_BIT MCU_PIN(DOUT26_PIN,BIT)
+#define DOUT26_PORT MCU_PIN(DOUT26_PIN,PORT)
+#endif
+#if (defined(DOUT27_PIN) && !(defined(DOUT27_BIT) || defined(DOUT27_PORT)))
+#define DOUT27_BIT MCU_PIN(DOUT27_PIN,BIT)
+#define DOUT27_PORT MCU_PIN(DOUT27_PIN,PORT)
+#endif
+#if (defined(DOUT28_PIN) && !(defined(DOUT28_BIT) || defined(DOUT28_PORT)))
+#define DOUT28_BIT MCU_PIN(DOUT28_PIN,BIT)
+#define DOUT28_PORT MCU_PIN(DOUT28_PIN,PORT)
+#endif
+#if (defined(DOUT29_PIN) && !(defined(DOUT29_BIT) || defined(DOUT29_PORT)))
+#define DOUT29_BIT MCU_PIN(DOUT29_PIN,BIT)
+#define DOUT29_PORT MCU_PIN(DOUT29_PIN,PORT)
+#endif
+#if (defined(DOUT30_PIN) && !(defined(DOUT30_BIT) || defined(DOUT30_PORT)))
+#define DOUT30_BIT MCU_PIN(DOUT30_PIN,BIT)
+#define DOUT30_PORT MCU_PIN(DOUT30_PIN,PORT)
+#endif
+#if (defined(DOUT31_PIN) && !(defined(DOUT31_BIT) || defined(DOUT31_PORT)))
+#define DOUT31_BIT MCU_PIN(DOUT31_PIN,BIT)
+#define DOUT31_PORT MCU_PIN(DOUT31_PIN,PORT)
+#endif
+#if (defined(LIMIT_X_PIN) && !(defined(LIMIT_X_BIT) || defined(LIMIT_X_PORT)))
+#define LIMIT_X_BIT MCU_PIN(LIMIT_X_PIN,BIT)
+#define LIMIT_X_PORT MCU_PIN(LIMIT_X_PIN,PORT)
+#endif
+#if (defined(LIMIT_Y_PIN) && !(defined(LIMIT_Y_BIT) || defined(LIMIT_Y_PORT)))
+#define LIMIT_Y_BIT MCU_PIN(LIMIT_Y_PIN,BIT)
+#define LIMIT_Y_PORT MCU_PIN(LIMIT_Y_PIN,PORT)
+#endif
+#if (defined(LIMIT_Z_PIN) && !(defined(LIMIT_Z_BIT) || defined(LIMIT_Z_PORT)))
+#define LIMIT_Z_BIT MCU_PIN(LIMIT_Z_PIN,BIT)
+#define LIMIT_Z_PORT MCU_PIN(LIMIT_Z_PIN,PORT)
+#endif
+#if (defined(LIMIT_X2_PIN) && !(defined(LIMIT_X2_BIT) || defined(LIMIT_X2_PORT)))
+#define LIMIT_X2_BIT MCU_PIN(LIMIT_X2_PIN,BIT)
+#define LIMIT_X2_PORT MCU_PIN(LIMIT_X2_PIN,PORT)
+#endif
+#if (defined(LIMIT_Y2_PIN) && !(defined(LIMIT_Y2_BIT) || defined(LIMIT_Y2_PORT)))
+#define LIMIT_Y2_BIT MCU_PIN(LIMIT_Y2_PIN,BIT)
+#define LIMIT_Y2_PORT MCU_PIN(LIMIT_Y2_PIN,PORT)
+#endif
+#if (defined(LIMIT_Z2_PIN) && !(defined(LIMIT_Z2_BIT) || defined(LIMIT_Z2_PORT)))
+#define LIMIT_Z2_BIT MCU_PIN(LIMIT_Z2_PIN,BIT)
+#define LIMIT_Z2_PORT MCU_PIN(LIMIT_Z2_PIN,PORT)
+#endif
+#if (defined(LIMIT_A_PIN) && !(defined(LIMIT_A_BIT) || defined(LIMIT_A_PORT)))
+#define LIMIT_A_BIT MCU_PIN(LIMIT_A_PIN,BIT)
+#define LIMIT_A_PORT MCU_PIN(LIMIT_A_PIN,PORT)
+#endif
+#if (defined(LIMIT_B_PIN) && !(defined(LIMIT_B_BIT) || defined(LIMIT_B_PORT)))
+#define LIMIT_B_BIT MCU_PIN(LIMIT_B_PIN,BIT)
+#define LIMIT_B_PORT MCU_PIN(LIMIT_B_PIN,PORT)
+#endif
+#if (defined(LIMIT_C_PIN) && !(defined(LIMIT_C_BIT) || defined(LIMIT_C_PORT)))
+#define LIMIT_C_BIT MCU_PIN(LIMIT_C_PIN,BIT)
+#define LIMIT_C_PORT MCU_PIN(LIMIT_C_PIN,PORT)
+#endif
+#if (defined(PROBE_PIN) && !(defined(PROBE_BIT) || defined(PROBE_PORT)))
+#define PROBE_BIT MCU_PIN(PROBE_PIN,BIT)
+#define PROBE_PORT MCU_PIN(PROBE_PIN,PORT)
+#endif
+#if (defined(ESTOP_PIN) && !(defined(ESTOP_BIT) || defined(ESTOP_PORT)))
+#define ESTOP_BIT MCU_PIN(ESTOP_PIN,BIT)
+#define ESTOP_PORT MCU_PIN(ESTOP_PIN,PORT)
+#endif
+#if (defined(SAFETY_DOOR_PIN) && !(defined(SAFETY_DOOR_BIT) || defined(SAFETY_DOOR_PORT)))
+#define SAFETY_DOOR_BIT MCU_PIN(SAFETY_DOOR_PIN,BIT)
+#define SAFETY_DOOR_PORT MCU_PIN(SAFETY_DOOR_PIN,PORT)
+#endif
+#if (defined(FHOLD_PIN) && !(defined(FHOLD_BIT) || defined(FHOLD_PORT)))
+#define FHOLD_BIT MCU_PIN(FHOLD_PIN,BIT)
+#define FHOLD_PORT MCU_PIN(FHOLD_PIN,PORT)
+#endif
+#if (defined(CS_RES_PIN) && !(defined(CS_RES_BIT) || defined(CS_RES_PORT)))
+#define CS_RES_BIT MCU_PIN(CS_RES_PIN,BIT)
+#define CS_RES_PORT MCU_PIN(CS_RES_PIN,PORT)
+#endif
+#if (defined(ANALOG0_PIN) && !(defined(ANALOG0_BIT) || defined(ANALOG0_PORT)))
+#define ANALOG0_BIT MCU_PIN(ANALOG0_PIN,BIT)
+#define ANALOG0_PORT MCU_PIN(ANALOG0_PIN,PORT)
+#endif
+#if (defined(ANALOG1_PIN) && !(defined(ANALOG1_BIT) || defined(ANALOG1_PORT)))
+#define ANALOG1_BIT MCU_PIN(ANALOG1_PIN,BIT)
+#define ANALOG1_PORT MCU_PIN(ANALOG1_PIN,PORT)
+#endif
+#if (defined(ANALOG2_PIN) && !(defined(ANALOG2_BIT) || defined(ANALOG2_PORT)))
+#define ANALOG2_BIT MCU_PIN(ANALOG2_PIN,BIT)
+#define ANALOG2_PORT MCU_PIN(ANALOG2_PIN,PORT)
+#endif
+#if (defined(ANALOG3_PIN) && !(defined(ANALOG3_BIT) || defined(ANALOG3_PORT)))
+#define ANALOG3_BIT MCU_PIN(ANALOG3_PIN,BIT)
+#define ANALOG3_PORT MCU_PIN(ANALOG3_PIN,PORT)
+#endif
+#if (defined(ANALOG4_PIN) && !(defined(ANALOG4_BIT) || defined(ANALOG4_PORT)))
+#define ANALOG4_BIT MCU_PIN(ANALOG4_PIN,BIT)
+#define ANALOG4_PORT MCU_PIN(ANALOG4_PIN,PORT)
+#endif
+#if (defined(ANALOG5_PIN) && !(defined(ANALOG5_BIT) || defined(ANALOG5_PORT)))
+#define ANALOG5_BIT MCU_PIN(ANALOG5_PIN,BIT)
+#define ANALOG5_PORT MCU_PIN(ANALOG5_PIN,PORT)
+#endif
+#if (defined(ANALOG6_PIN) && !(defined(ANALOG6_BIT) || defined(ANALOG6_PORT)))
+#define ANALOG6_BIT MCU_PIN(ANALOG6_PIN,BIT)
+#define ANALOG6_PORT MCU_PIN(ANALOG6_PIN,PORT)
+#endif
+#if (defined(ANALOG7_PIN) && !(defined(ANALOG7_BIT) || defined(ANALOG7_PORT)))
+#define ANALOG7_BIT MCU_PIN(ANALOG7_PIN,BIT)
+#define ANALOG7_PORT MCU_PIN(ANALOG7_PIN,PORT)
+#endif
+#if (defined(ANALOG8_PIN) && !(defined(ANALOG8_BIT) || defined(ANALOG8_PORT)))
+#define ANALOG8_BIT MCU_PIN(ANALOG8_PIN,BIT)
+#define ANALOG8_PORT MCU_PIN(ANALOG8_PIN,PORT)
+#endif
+#if (defined(ANALOG9_PIN) && !(defined(ANALOG9_BIT) || defined(ANALOG9_PORT)))
+#define ANALOG9_BIT MCU_PIN(ANALOG9_PIN,BIT)
+#define ANALOG9_PORT MCU_PIN(ANALOG9_PIN,PORT)
+#endif
+#if (defined(ANALOG10_PIN) && !(defined(ANALOG10_BIT) || defined(ANALOG10_PORT)))
+#define ANALOG10_BIT MCU_PIN(ANALOG10_PIN,BIT)
+#define ANALOG10_PORT MCU_PIN(ANALOG10_PIN,PORT)
+#endif
+#if (defined(ANALOG11_PIN) && !(defined(ANALOG11_BIT) || defined(ANALOG11_PORT)))
+#define ANALOG11_BIT MCU_PIN(ANALOG11_PIN,BIT)
+#define ANALOG11_PORT MCU_PIN(ANALOG11_PIN,PORT)
+#endif
+#if (defined(ANALOG12_PIN) && !(defined(ANALOG12_BIT) || defined(ANALOG12_PORT)))
+#define ANALOG12_BIT MCU_PIN(ANALOG12_PIN,BIT)
+#define ANALOG12_PORT MCU_PIN(ANALOG12_PIN,PORT)
+#endif
+#if (defined(ANALOG13_PIN) && !(defined(ANALOG13_BIT) || defined(ANALOG13_PORT)))
+#define ANALOG13_BIT MCU_PIN(ANALOG13_PIN,BIT)
+#define ANALOG13_PORT MCU_PIN(ANALOG13_PIN,PORT)
+#endif
+#if (defined(ANALOG14_PIN) && !(defined(ANALOG14_BIT) || defined(ANALOG14_PORT)))
+#define ANALOG14_BIT MCU_PIN(ANALOG14_PIN,BIT)
+#define ANALOG14_PORT MCU_PIN(ANALOG14_PIN,PORT)
+#endif
+#if (defined(ANALOG15_PIN) && !(defined(ANALOG15_BIT) || defined(ANALOG15_PORT)))
+#define ANALOG15_BIT MCU_PIN(ANALOG15_PIN,BIT)
+#define ANALOG15_PORT MCU_PIN(ANALOG15_PIN,PORT)
+#endif
+#if (defined(DIN0_PIN) && !(defined(DIN0_BIT) || defined(DIN0_PORT)))
+#define DIN0_BIT MCU_PIN(DIN0_PIN,BIT)
+#define DIN0_PORT MCU_PIN(DIN0_PIN,PORT)
+#endif
+#if (defined(DIN1_PIN) && !(defined(DIN1_BIT) || defined(DIN1_PORT)))
+#define DIN1_BIT MCU_PIN(DIN1_PIN,BIT)
+#define DIN1_PORT MCU_PIN(DIN1_PIN,PORT)
+#endif
+#if (defined(DIN2_PIN) && !(defined(DIN2_BIT) || defined(DIN2_PORT)))
+#define DIN2_BIT MCU_PIN(DIN2_PIN,BIT)
+#define DIN2_PORT MCU_PIN(DIN2_PIN,PORT)
+#endif
+#if (defined(DIN3_PIN) && !(defined(DIN3_BIT) || defined(DIN3_PORT)))
+#define DIN3_BIT MCU_PIN(DIN3_PIN,BIT)
+#define DIN3_PORT MCU_PIN(DIN3_PIN,PORT)
+#endif
+#if (defined(DIN4_PIN) && !(defined(DIN4_BIT) || defined(DIN4_PORT)))
+#define DIN4_BIT MCU_PIN(DIN4_PIN,BIT)
+#define DIN4_PORT MCU_PIN(DIN4_PIN,PORT)
+#endif
+#if (defined(DIN5_PIN) && !(defined(DIN5_BIT) || defined(DIN5_PORT)))
+#define DIN5_BIT MCU_PIN(DIN5_PIN,BIT)
+#define DIN5_PORT MCU_PIN(DIN5_PIN,PORT)
+#endif
+#if (defined(DIN6_PIN) && !(defined(DIN6_BIT) || defined(DIN6_PORT)))
+#define DIN6_BIT MCU_PIN(DIN6_PIN,BIT)
+#define DIN6_PORT MCU_PIN(DIN6_PIN,PORT)
+#endif
+#if (defined(DIN7_PIN) && !(defined(DIN7_BIT) || defined(DIN7_PORT)))
+#define DIN7_BIT MCU_PIN(DIN7_PIN,BIT)
+#define DIN7_PORT MCU_PIN(DIN7_PIN,PORT)
+#endif
+#if (defined(DIN8_PIN) && !(defined(DIN8_BIT) || defined(DIN8_PORT)))
+#define DIN8_BIT MCU_PIN(DIN8_PIN,BIT)
+#define DIN8_PORT MCU_PIN(DIN8_PIN,PORT)
+#endif
+#if (defined(DIN9_PIN) && !(defined(DIN9_BIT) || defined(DIN9_PORT)))
+#define DIN9_BIT MCU_PIN(DIN9_PIN,BIT)
+#define DIN9_PORT MCU_PIN(DIN9_PIN,PORT)
+#endif
+#if (defined(DIN10_PIN) && !(defined(DIN10_BIT) || defined(DIN10_PORT)))
+#define DIN10_BIT MCU_PIN(DIN10_PIN,BIT)
+#define DIN10_PORT MCU_PIN(DIN10_PIN,PORT)
+#endif
+#if (defined(DIN11_PIN) && !(defined(DIN11_BIT) || defined(DIN11_PORT)))
+#define DIN11_BIT MCU_PIN(DIN11_PIN,BIT)
+#define DIN11_PORT MCU_PIN(DIN11_PIN,PORT)
+#endif
+#if (defined(DIN12_PIN) && !(defined(DIN12_BIT) || defined(DIN12_PORT)))
+#define DIN12_BIT MCU_PIN(DIN12_PIN,BIT)
+#define DIN12_PORT MCU_PIN(DIN12_PIN,PORT)
+#endif
+#if (defined(DIN13_PIN) && !(defined(DIN13_BIT) || defined(DIN13_PORT)))
+#define DIN13_BIT MCU_PIN(DIN13_PIN,BIT)
+#define DIN13_PORT MCU_PIN(DIN13_PIN,PORT)
+#endif
+#if (defined(DIN14_PIN) && !(defined(DIN14_BIT) || defined(DIN14_PORT)))
+#define DIN14_BIT MCU_PIN(DIN14_PIN,BIT)
+#define DIN14_PORT MCU_PIN(DIN14_PIN,PORT)
+#endif
+#if (defined(DIN15_PIN) && !(defined(DIN15_BIT) || defined(DIN15_PORT)))
+#define DIN15_BIT MCU_PIN(DIN15_PIN,BIT)
+#define DIN15_PORT MCU_PIN(DIN15_PIN,PORT)
+#endif
+#if (defined(DIN16_PIN) && !(defined(DIN16_BIT) || defined(DIN16_PORT)))
+#define DIN16_BIT MCU_PIN(DIN16_PIN,BIT)
+#define DIN16_PORT MCU_PIN(DIN16_PIN,PORT)
+#endif
+#if (defined(DIN17_PIN) && !(defined(DIN17_BIT) || defined(DIN17_PORT)))
+#define DIN17_BIT MCU_PIN(DIN17_PIN,BIT)
+#define DIN17_PORT MCU_PIN(DIN17_PIN,PORT)
+#endif
+#if (defined(DIN18_PIN) && !(defined(DIN18_BIT) || defined(DIN18_PORT)))
+#define DIN18_BIT MCU_PIN(DIN18_PIN,BIT)
+#define DIN18_PORT MCU_PIN(DIN18_PIN,PORT)
+#endif
+#if (defined(DIN19_PIN) && !(defined(DIN19_BIT) || defined(DIN19_PORT)))
+#define DIN19_BIT MCU_PIN(DIN19_PIN,BIT)
+#define DIN19_PORT MCU_PIN(DIN19_PIN,PORT)
+#endif
+#if (defined(DIN20_PIN) && !(defined(DIN20_BIT) || defined(DIN20_PORT)))
+#define DIN20_BIT MCU_PIN(DIN20_PIN,BIT)
+#define DIN20_PORT MCU_PIN(DIN20_PIN,PORT)
+#endif
+#if (defined(DIN21_PIN) && !(defined(DIN21_BIT) || defined(DIN21_PORT)))
+#define DIN21_BIT MCU_PIN(DIN21_PIN,BIT)
+#define DIN21_PORT MCU_PIN(DIN21_PIN,PORT)
+#endif
+#if (defined(DIN22_PIN) && !(defined(DIN22_BIT) || defined(DIN22_PORT)))
+#define DIN22_BIT MCU_PIN(DIN22_PIN,BIT)
+#define DIN22_PORT MCU_PIN(DIN22_PIN,PORT)
+#endif
+#if (defined(DIN23_PIN) && !(defined(DIN23_BIT) || defined(DIN23_PORT)))
+#define DIN23_BIT MCU_PIN(DIN23_PIN,BIT)
+#define DIN23_PORT MCU_PIN(DIN23_PIN,PORT)
+#endif
+#if (defined(DIN24_PIN) && !(defined(DIN24_BIT) || defined(DIN24_PORT)))
+#define DIN24_BIT MCU_PIN(DIN24_PIN,BIT)
+#define DIN24_PORT MCU_PIN(DIN24_PIN,PORT)
+#endif
+#if (defined(DIN25_PIN) && !(defined(DIN25_BIT) || defined(DIN25_PORT)))
+#define DIN25_BIT MCU_PIN(DIN25_PIN,BIT)
+#define DIN25_PORT MCU_PIN(DIN25_PIN,PORT)
+#endif
+#if (defined(DIN26_PIN) && !(defined(DIN26_BIT) || defined(DIN26_PORT)))
+#define DIN26_BIT MCU_PIN(DIN26_PIN,BIT)
+#define DIN26_PORT MCU_PIN(DIN26_PIN,PORT)
+#endif
+#if (defined(DIN27_PIN) && !(defined(DIN27_BIT) || defined(DIN27_PORT)))
+#define DIN27_BIT MCU_PIN(DIN27_PIN,BIT)
+#define DIN27_PORT MCU_PIN(DIN27_PIN,PORT)
+#endif
+#if (defined(DIN28_PIN) && !(defined(DIN28_BIT) || defined(DIN28_PORT)))
+#define DIN28_BIT MCU_PIN(DIN28_PIN,BIT)
+#define DIN28_PORT MCU_PIN(DIN28_PIN,PORT)
+#endif
+#if (defined(DIN29_PIN) && !(defined(DIN29_BIT) || defined(DIN29_PORT)))
+#define DIN29_BIT MCU_PIN(DIN29_PIN,BIT)
+#define DIN29_PORT MCU_PIN(DIN29_PIN,PORT)
+#endif
+#if (defined(DIN30_PIN) && !(defined(DIN30_BIT) || defined(DIN30_PORT)))
+#define DIN30_BIT MCU_PIN(DIN30_PIN,BIT)
+#define DIN30_PORT MCU_PIN(DIN30_PIN,PORT)
+#endif
+#if (defined(DIN31_PIN) && !(defined(DIN31_BIT) || defined(DIN31_PORT)))
+#define DIN31_BIT MCU_PIN(DIN31_PIN,BIT)
+#define DIN31_PORT MCU_PIN(DIN31_PIN,PORT)
+#endif
+#if (defined(TX_PIN) && !(defined(TX_BIT) || defined(TX_PORT)))
+#define TX_BIT MCU_PIN(TX_PIN,BIT)
+#define TX_PORT MCU_PIN(TX_PIN,PORT)
+#endif
+#if (defined(RX_PIN) && !(defined(RX_BIT) || defined(RX_PORT)))
+#define RX_BIT MCU_PIN(RX_PIN,BIT)
+#define RX_PORT MCU_PIN(RX_PIN,PORT)
+#endif
+#if (defined(USB_DM_PIN) && !(defined(USB_DM_BIT) || defined(USB_DM_PORT)))
+#define USB_DM_BIT MCU_PIN(USB_DM_PIN,BIT)
+#define USB_DM_PORT MCU_PIN(USB_DM_PIN,PORT)
+#endif
+#if (defined(USB_DP_PIN) && !(defined(USB_DP_BIT) || defined(USB_DP_PORT)))
+#define USB_DP_BIT MCU_PIN(USB_DP_PIN,BIT)
+#define USB_DP_PORT MCU_PIN(USB_DP_PIN,PORT)
+#endif
+#if (defined(SPI_CLK_PIN) && !(defined(SPI_CLK_BIT) || defined(SPI_CLK_PORT)))
+#define SPI_CLK_BIT MCU_PIN(SPI_CLK_PIN,BIT)
+#define SPI_CLK_PORT MCU_PIN(SPI_CLK_PIN,PORT)
+#endif
+#if (defined(SPI_SDI_PIN) && !(defined(SPI_SDI_BIT) || defined(SPI_SDI_PORT)))
+#define SPI_SDI_BIT MCU_PIN(SPI_SDI_PIN,BIT)
+#define SPI_SDI_PORT MCU_PIN(SPI_SDI_PIN,PORT)
+#endif
+#if (defined(SPI_SDO_PIN) && !(defined(SPI_SDO_BIT) || defined(SPI_SDO_PORT)))
+#define SPI_SDO_BIT MCU_PIN(SPI_SDO_PIN,BIT)
+#define SPI_SDO_PORT MCU_PIN(SPI_SDO_PIN,PORT)
+#endif
+#if (defined(SPI_CS_PIN) && !(defined(SPI_CS_BIT) || defined(SPI_CS_PORT)))
+#define SPI_CS_BIT MCU_PIN(SPI_CS_PIN,BIT)
+#define SPI_CS_PORT MCU_PIN(SPI_CS_PIN,PORT)
+#endif
+#if (defined(I2C_SCL_PIN) && !(defined(I2C_SCL_BIT) || defined(I2C_SCL_PORT)))
+#define I2C_SCL_BIT MCU_PIN(I2C_SCL_PIN,BIT)
+#define I2C_SCL_PORT MCU_PIN(I2C_SCL_PIN,PORT)
+#endif
+#if (defined(I2C_SDA_PIN) && !(defined(I2C_SDA_BIT) || defined(I2C_SDA_PORT)))
+#define I2C_SDA_BIT MCU_PIN(I2C_SDA_PIN,BIT)
+#define I2C_SDA_PORT MCU_PIN(I2C_SDA_PIN,PORT)
+#endif
+#if (defined(TX2_PIN) && !(defined(TX2_BIT) || defined(TX2_PORT)))
+#define TX2_BIT MCU_PIN(TX2_PIN,BIT)
+#define TX2_PORT MCU_PIN(TX2_PIN,PORT)
+#endif
+#if (defined(RX2_PIN) && !(defined(RX2_BIT) || defined(RX2_PORT)))
+#define RX2_BIT MCU_PIN(RX2_PIN,BIT)
+#define RX2_PORT MCU_PIN(RX2_PIN,PORT)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
New pin mapping helper that allow an easier pin mapping definition/setup for boardmaps.

To define a pin on a board you needed to define the bit and port of the pin like this

```
#define STEP0_BIT 2	 // assigns STEP0 pin
#define STEP0_PORT D // assigns STEP0 port
```

This now can also be done like this

`#define STEP0_PIN D2	 // assigns STEP0 pin`

On MCU's like the ESP32 and the RP2040 this can be done like this

`#define STEP0_PIN GPIO3	 // assigns STEP0 pin`

The new pin mapping helper will generate under the hood the BIT and PORT definitions.
To prevent configuration errors, if the pin was already defined via BIT and PORT, that will take precedence over the new PIN definition and the PIN definition will have no effect.
