### PR TITLE
Locked STM32 platform version

### DIFF
--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -3,7 +3,7 @@
 ################
 
 [common_stm32]
-platform = ststm32
+platform = platformio/ststm32@^17.5.0
 ; debug with st-link
 upload_protocol = cmsis-dap
 debug_tool = cmsis-dap
@@ -35,7 +35,7 @@ upload_flags = -c set CPUTAPID 0x2ba01477
 [env:STM32F1-MKS-Robin-Nano-V1_2]
 extends = common_stm32
 board = genericSTM32F103VE
-board_build.offset  = 0x7000
+board_build.flash_offset  = 0x7000
 board_upload.offset_address = 0x08007000
 board_build.f_cpu = 72000000L
 build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_MKS_ROBIN_NANO_V1_2
@@ -55,10 +55,12 @@ build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_BLACKPILL
 [env:STM32F4-SKR-Pro-V1_2]
 extends = common_stm32
 board = black_f407zg
-board_build.offset  = 0x8000
-board_upload.offset_address = 0x08008000
+board_build.flash_offset = 0x8000
 board_build.f_cpu = 168000000L
-build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_SKR_PRO_V1_2
+board_upload.offset_address = 0x08008000
+board_upload.maximum_ram_size = 196608
+board_upload.maximum_size = 1048576
+build_flags = ${common_stm32.build_flags} -D BOARD=BOARD_SKR_PRO_V1_2 -D HSE_VALUE=8000000
 
 [env:STM32F4-Nucleo-F411RE-Shield-V3]
 extends = common_stm32

--- a/uCNC/src/module.h
+++ b/uCNC/src/module.h
@@ -65,7 +65,7 @@ extern "C"
 #define EVENT_HANDLER_NAME(name) event_##name##_handler
 #define EVENT_INVOKE(name, args) EVENT_HANDLER_NAME(name)(args)
 #define CREATE_EVENT_LISTENER(name, handler) __attribute__((used)) name##_delegate_event_t name##_delegate_##handler = {&handler, LISTENER_NO_LOCK, NULL}
-#define CREATE_EVENT_LISTENER_WITHLOCK(name, handler, lock_flags) __attribute__((used)) name##_delegate_event_t name##_delegate_##handler = {&handler, CLEARFLAG(lock_flags, LISTENER_RUNNING_LOCK), NULL}
+#define CREATE_EVENT_LISTENER_WITHLOCK(name, handler, lock_flags) __attribute__((used)) name##_delegate_event_t name##_delegate_##handler = {&handler, (lock_flags & (~LISTENER_RUNNING_LOCK)), NULL}
 #define ADD_EVENT_LISTENER(name, handler)                     \
 	{                                                           \
 		extern name##_delegate_event_t name##_delegate_##handler; \


### PR DESCRIPTION
- locked STM32 platform version to prevent compilation issues from breaking changes in the platform/framework
- updated flash offset setting on boards with bootloader