### PR TITLE
Make system_menu_goto global

### DIFF
--- a/uCNC/src/modules/system_menu.c
+++ b/uCNC/src/modules/system_menu.c
@@ -31,7 +31,7 @@ static bool system_menu_action_overrides(uint8_t action, system_menu_item_t *ite
 static void system_menu_render_axis_position(uint8_t render_flags, system_menu_item_t *item);
 static bool system_menu_action_nav_back(uint8_t action, const system_menu_page_t *item);
 
-static void system_menu_goto(uint8_t id)
+void system_menu_goto(uint8_t id)
 {
 	g_system_menu.current_menu = id;
 	g_system_menu.current_index = 0;
@@ -42,6 +42,10 @@ static void system_menu_goto(uint8_t id)
 	{
 		g_system_menu.total_items = system_menu_get_item_count(id);
 	}
+
+	// Set correct flags in case go to is called from outside of this module
+	g_system_menu.flags |= SYSTEM_MENU_MODE_REDRAW;
+	system_menu_action_timeout(SYSTEM_MENU_GO_IDLE_MS);
 }
 
 // declarate startup screen

--- a/uCNC/src/modules/system_menu.h
+++ b/uCNC/src/modules/system_menu.h
@@ -169,7 +169,7 @@ extern "C"
 	void system_menu_render(void);
 	void system_menu_show_modal_popup(uint32_t timeout, const char *__s);
 	void system_menu_action_timeout(uint32_t delay);
-	void system_menu_goto(uint8_t id)
+	void system_menu_goto(uint8_t id);
 
 	void system_menu_set_render_callback(uint8_t menu_id, system_menu_page_render_cb callback);
 	void system_menu_set_action_callback(uint8_t menu_id, system_menu_page_action_cb callback);

--- a/uCNC/src/modules/system_menu.h
+++ b/uCNC/src/modules/system_menu.h
@@ -169,6 +169,7 @@ extern "C"
 	void system_menu_render(void);
 	void system_menu_show_modal_popup(uint32_t timeout, const char *__s);
 	void system_menu_action_timeout(uint32_t delay);
+	void system_menu_goto(uint8_t id)
 
 	void system_menu_set_render_callback(uint8_t menu_id, system_menu_page_render_cb callback);
 	void system_menu_set_action_callback(uint8_t menu_id, system_menu_page_action_cb callback);


### PR DESCRIPTION
This PR makes the system_menu_goto a global function. It also makes the function set action timeout and redraw flags to make sure the new screen gets shown even if it's not called from system_menu_action.