### PR TITLE
Lock RP2040 framework version

### DIFF
--- a/uCNC/src/hal/boards/rp2040/rp2040.ini
+++ b/uCNC/src/hal/boards/rp2040/rp2040.ini
@@ -5,7 +5,7 @@
 [common_rp2040]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 platform_packages =
-   framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
+   framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#3.9.4
 ; board = pico
 framework = arduino
 board_build.core = earlephilhower


### PR DESCRIPTION
- Lock RP2040 framework version to fix compilation error