### PR TITLE
fix status report send when sender adds LF after ?

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -212,6 +212,9 @@ uint8_t cnc_parse_cmd(void)
 #endif
 			break;
 		}
+		// runs any rt command in queue
+		// this catches for example a ?\n situation sent by some GUI like UGS
+		cnc_exec_rt_commands();
 		if (!error)
 		{
 			protocol_send_ok();


### PR DESCRIPTION
- fix status report send when sender adds LF after ?. This seems to cause issues in UGS
- Arduino Mega board also seems to respond better with this change