### PR TITLE
Fix prescaler "value computed and is not used"

### DIFF
--- a/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
+++ b/uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c
@@ -749,7 +749,7 @@ void mcu_freq_to_clocks(float frequency, uint16_t *ticks, uint16_t *prescaller)
 	*prescaller = 0;
 	while (totalticks > 0x0000FFFFUL)
 	{
-		*prescaller++;
+		(*prescaller) += 1;
 		totalticks >>= 1;
 	}
 


### PR DESCRIPTION
Fixes this warning:
```
uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c: In function 'mcu_freq_to_clocks':
uCNC/src/hal/mcus/lpc176x/mcu_lpc176x.c:755:17: warning: value computed is not used [-Wunused-value]
  755 |                 *prescaller++;
      |                 ^~~~~~~~~~~~~
```

since `*(prescaller++)` is definitely not right.