### PR TITLE
fixed custom MCU build flags

### DIFF
--- a/uCNC/src/hal/boards/avr/avr.ini
+++ b/uCNC/src/hal/boards/avr/avr.ini
@@ -74,4 +74,5 @@ build_flags = ${common_avr.build_flags} -D BOARD=\"src/hal/boards/avr/boardmap_m
 
 [env:AVR-CUSTOM]
 extends = common_avr
+build_flags = ${common_avr.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}

--- a/uCNC/src/hal/boards/esp32/esp32.ini
+++ b/uCNC/src/hal/boards/esp32/esp32.ini
@@ -50,6 +50,7 @@ build_flags = ${common_esp32.build_flags} -D BOARD=BOARDMAP_FILE("src/hal/boards
 
 [env:ESP32-CUSTOM]
 extends = common_esp32
+build_flags = ${common_esp32.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}
 
 #################

--- a/uCNC/src/hal/boards/lpc176x/lpc176x.ini
+++ b/uCNC/src/hal/boards/lpc176x/lpc176x.ini
@@ -30,4 +30,5 @@ build_flags = ${common_lpc176x.build_flags} -D BOARD=\"src/hal/boards/lpc176x/bo
 
 [env:LPC176X-CUSTOM]
 extends = common_lpc176x
+build_flags = ${common_lpc176x.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}

--- a/uCNC/src/hal/boards/rp2040/rp2040.ini
+++ b/uCNC/src/hal/boards/rp2040/rp2040.ini
@@ -62,4 +62,5 @@ build_flags = -D BOARD=\"src/hal/boards/rp2040/boardmap_rpi_pico_w.h\" -D ENABLE
 
 [env:RP2040-CUSTOM]
 extends = common_rp2040
+build_flags = ${common_rp2040.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}

--- a/uCNC/src/hal/boards/samd21/samd21.ini
+++ b/uCNC/src/hal/boards/samd21/samd21.ini
@@ -35,4 +35,5 @@ board_upload.offset_address = 0x00004000
 
 [env:SAMD21-CUSTOM]
 extends = common_samd21
+build_flags = ${common_samd21.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}

--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -97,4 +97,5 @@ build_flags = ${common_stm32.build_flags} -D BOARD=\"src/hal/boards/stm32/boardm
 
 [env:STM32-CUSTOM]
 extends = common_stm32
+build_flags = ${common_stm32.build_flags} -DMCU=MCU_CUSTOM
 board = ${env.board}

--- a/uCNC/src/hal/mcus/mcus.h
+++ b/uCNC/src/hal/mcus/mcus.h
@@ -24,7 +24,7 @@ extern "C"
 {
 #endif
 
-#define MCU_NONE 0
+#define MCU_CUSTOM 0
 #define MCU_AVR 1
 #define MCU_STM32F1X 10
 #define MCU_STM32F4X 11


### PR DESCRIPTION
- Preset the MCU when building to a custom MCU to prevent the default boardmap include in the code resulting in compilation errors