### PR TITLE
Fix compile warning about I2C_REG

### DIFF
--- a/uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp
+++ b/uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp
@@ -81,7 +81,6 @@ extern "C"
 
 #if defined(MCU_HAS_I2C) && defined(USE_ARDUINO_WIRE)
 #include <Wire.h>
-#define I2C_REG Wire
 #if I2C_ADDRESS!=0
 #error "I2C slave mode not supported"
 #endif
@@ -108,27 +107,27 @@ extern "C"
 	void mcu_i2c_config(uint32_t frequency)
 	{
 #if I2C_ADDRESS == 0
-		I2C_REG.begin();
+		Wire.begin();
 #else
-		I2C_REG.onReceive(lpc176x_i2c_onreceive);
-		I2C_REG.onRequest(lpc176x_i2c_onrequest);
-		I2C_REG.begin(I2C_ADDRESS);
+		Wire.onReceive(lpc176x_i2c_onreceive);
+		Wire.onRequest(lpc176x_i2c_onrequest);
+		Wire.begin(I2C_ADDRESS);
 #endif
 	}
 
 	uint8_t mcu_i2c_send(uint8_t address, uint8_t *data, uint8_t datalen, bool release, uint32_t ms_timeout)
 	{
-		I2C_REG.beginTransmission(address);
-		I2C_REG.write(data, datalen);
-		return (I2C_REG.endTransmission() == 0) ? I2C_OK : I2C_NOTOK;
+		Wire.beginTransmission(address);
+		Wire.write(data, datalen);
+		return (Wire.endTransmission() == 0) ? I2C_OK : I2C_NOTOK;
 	}
 
 	uint8_t mcu_i2c_receive(uint8_t address, uint8_t *data, uint8_t datalen, uint32_t ms_timeout)
 	{
-		if (I2C_REG.requestFrom(address, datalen) == datalen)
+		if (Wire.requestFrom(address, datalen) == datalen)
 		{
 			while(datalen--){
-				*data = (uint8_t)I2C_REG.read();
+				*data = (uint8_t)Wire.read();
 				data++;
 			}
 			


### PR DESCRIPTION
I2C_REG doesn't even look like the right name, and it's never defined to anything else, so just get rid of it and replace with Wire

Warning looked like this:
```
uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp:84: warning: "I2C_REG" redefined
   84 | #define I2C_REG Wire
      | 
In file included from uCNC/src/hal/mcus/lpc176x/../../../hal/boards/../mcus/mcudefs.h:57,
                 from uCNC/src/hal/mcus/lpc176x/../../../hal/boards/boarddefs.h:44,
                 from uCNC/src/hal/mcus/lpc176x/../../../cnc_hal_config_helper.h:49,
                 from uCNC/src/hal/mcus/lpc176x/../../../cnc.h:135,
                 from uCNC/src/hal/mcus/lpc176x/lpc176x_arduino.cpp:34:
uCNC/src/hal/mcus/lpc176x/../../../hal/boards/../mcus/lpc176x/mcumap_lpc176x.h:4558: note: this is the location of the previous definition
 4558 | #define I2C_REG __helper__(LPC_I2C, I2C_PORT, )
      | 
```