### PR TITLE
fix parser backtracking char cleaning

### DIFF
--- a/uCNC/src/core/parser_expr.c
+++ b/uCNC/src/core/parser_expr.c
@@ -422,6 +422,7 @@ static FORCEINLINE uint8_t parser_get_operation(uint8_t stack_depth, parser_stac
 
 	if ((c >= '0' && c <= '9') || c == '.')
 	{
+		parser_backtrack = 0;
 		return OP_REAL;
 	}
 #ifdef ENABLE_NAMED_PARAMETERS


### PR DESCRIPTION
- fix parser backtracking char cleaning
- this caused an error if the value of the last parameter on a line was negative for example (G1F500X-10)