### PR TITLE
Fix debug stream

### DIFF
--- a/uCNC/src/interface/grbl_protocol.c
+++ b/uCNC/src/interface/grbl_protocol.c
@@ -249,9 +249,6 @@ WEAK_EVENT_HANDLER(proto_gcode_modes)
  * all other implementations can use the formated print helper
  */
 
-// #define proto_itoa(value) prt_int((void*)proto_putc, PRINT_CALLBACK, (uint32_t)(value), 0)
-// #define proto_ftoa(value) prt_flt((void*)proto_putc, PRINT_CALLBACK, (float)(value), ((!g_settings.report_inches) ? 3 : 5))
-
 void proto_puts(const char *str)
 {
 	for (;;)

--- a/uCNC/src/interface/grbl_stream.c
+++ b/uCNC/src/interface/grbl_stream.c
@@ -111,12 +111,14 @@ static void FORCEINLINE debug_putc(char c)
 	if (BUFFER_FULL(debug_tx))
 	{
 		BUFFER_CLEAR(debug_tx);
-		rom_strcpy((char*)debug_tx_bufferdata, __romstr__("Debug buffer overflow!\0"));
-		debug_tx.count = strlen((char*)debug_tx_bufferdata);
+		rom_strcpy((char *)debug_tx_bufferdata, __romstr__("Debug buffer overflow!!\n"));
+		debug_tx_lines = 1;
+		debug_tx.count = strlen((char *)debug_tx_bufferdata);
 	}
 
 	BUFFER_ENQUEUE(debug_tx, &c);
-	if(c == '\n'){
+	if (c == '\n')
+	{
 		debug_tx_lines++;
 		debug_flush();
 	}
@@ -395,7 +397,7 @@ void grbl_stream_printf(const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-	prt_fmtva((void*)grbl_stream_putc, PRINT_CALLBACK, fmt, &args);
+	prt_fmtva((void *)grbl_stream_putc, PRINT_CALLBACK, fmt, &args);
 	va_end(args);
 }
 
@@ -435,4 +437,3 @@ void grbl_stream_print_cb(void *arg, char c)
 {
 	grbl_stream_putc(c);
 }
-

--- a/uCNC/src/interface/grbl_stream.c
+++ b/uCNC/src/interface/grbl_stream.c
@@ -111,7 +111,7 @@ static void FORCEINLINE debug_putc(char c)
 	if (BUFFER_FULL(debug_tx))
 	{
 		BUFFER_CLEAR(debug_tx);
-		rom_strcpy((char *)debug_tx_bufferdata, __romstr__("Debug buffer overflow!!\n"));
+		rom_strcpy((char *)debug_tx_bufferdata, __romstr__("Debug buffer overflow!!\n\0"));
 		debug_tx_lines = 1;
 		debug_tx.count = strlen((char *)debug_tx_bufferdata);
 	}

--- a/uCNC/src/utils.h
+++ b/uCNC/src/utils.h
@@ -425,7 +425,7 @@ extern "C"
 
 #define __TIMEOUT_US__(timeout) for (uint32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = curr_us_##timeout, curr_us_##timeout = mcu_free_micros(), elap_us_##timeout = (curr_us_##timeout > elap_us_##timeout) ? (curr_us_##timeout - elap_us_##timeout) : (1000 + curr_us_##timeout - elap_us_##timeout), timeout -= MIN(timeout, elap_us_##timeout))
 #define __TIMEOUT_MS__(timeout)                                               \
-	timeout = (timeout < (UINT32_MAX / 1000)) ? (timeout *= 1000) : UINT32_MAX; \
+	timeout = (((uint32_t)timeout) < (UINT32_MAX / 1000)) ? (timeout *= 1000) : UINT32_MAX; \
 	__TIMEOUT_US__(timeout)
 #define __TIMEOUT_ASSERT__(timeout) if (timeout == 0)
 

--- a/uCNC/src/utils.h
+++ b/uCNC/src/utils.h
@@ -423,16 +423,9 @@ extern "C"
 	}
 #endif
 
-#define __TIMEOUT_US__(timeout) for (int32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = mcu_free_micros() - curr_us_##timeout, timeout -= MIN(timeout, ABS(elap_us_##timeout)), curr_us_##timeout = mcu_free_micros())
-#define __TIMEOUT_MS__(timeout)      \
-	if (timeout < (UINT32_MAX / 1000)) \
-	{                                  \
-		timeout *= 1000;                 \
-	}                                  \
-	else                               \
-	{                                  \
-		timeout = 0xFFFFFFFF;            \
-	}                                  \
+#define __TIMEOUT_US__(timeout) for (uint32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = curr_us_##timeout, curr_us_##timeout = mcu_free_micros(), elap_us_##timeout = (curr_us_##timeout > elap_us_##timeout) ? (curr_us_##timeout - elap_us_##timeout) : (1000 + curr_us_##timeout - elap_us_##timeout), timeout -= MIN(timeout, elap_us_##timeout))
+#define __TIMEOUT_MS__(timeout)                                               \
+	timeout = (timeout < (UINT32_MAX / 1000)) ? (timeout *= 1000) : UINT32_MAX; \
 	__TIMEOUT_US__(timeout)
 #define __TIMEOUT_ASSERT__(timeout) if (timeout == 0)
 

--- a/uCNC/src/utils.h
+++ b/uCNC/src/utils.h
@@ -424,7 +424,7 @@ extern "C"
 #endif
 
 #define __TIMEOUT_US__(timeout) for (uint32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = curr_us_##timeout, curr_us_##timeout = mcu_free_micros(), elap_us_##timeout = (curr_us_##timeout > elap_us_##timeout) ? (curr_us_##timeout - elap_us_##timeout) : (1000 + curr_us_##timeout - elap_us_##timeout), timeout -= MIN(timeout, elap_us_##timeout))
-#define __TIMEOUT_MS__(timeout)                                               \
+#define __TIMEOUT_MS__(timeout)                                                           \
 	timeout = (((uint32_t)timeout) < (UINT32_MAX / 1000)) ? (timeout *= 1000) : UINT32_MAX; \
 	__TIMEOUT_US__(timeout)
 #define __TIMEOUT_ASSERT__(timeout) if (timeout == 0)


### PR DESCRIPTION
- fix debug stream overflow reset not reseting properlly (credits to [ricochet1k](https://github.com/ricochet1k))
- fix timeout macro when free_micros turns around (credits to [ricochet1k](https://github.com/ricochet1k))
- modified timeout to uint32_t. Setting a timeout of -1 will take 71 minutes to occur