### PR TITLE
fix timeout macro

### DIFF
--- a/uCNC/src/utils.h
+++ b/uCNC/src/utils.h
@@ -423,9 +423,9 @@ extern "C"
 	}
 #endif
 
-#define __TIMEOUT_US__(timeout) for (uint32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = curr_us_##timeout, curr_us_##timeout = mcu_free_micros(), elap_us_##timeout = (curr_us_##timeout > elap_us_##timeout) ? (curr_us_##timeout - elap_us_##timeout) : (1000 + curr_us_##timeout - elap_us_##timeout), timeout -= MIN(timeout, elap_us_##timeout))
+#define __TIMEOUT_US__(timeout) for (uint32_t elap_us_##timeout, curr_us_##timeout = mcu_free_micros(); timeout > 0; elap_us_##timeout = mcu_free_micros() - curr_us_##timeout, timeout -= MIN(timeout, ((elap_us_##timeout<1000) ? elap_us_##timeout : 1000 + elap_us_##timeout)), curr_us_##timeout = mcu_free_micros())
 #define __TIMEOUT_MS__(timeout)                                                           \
-	timeout = (((uint32_t)timeout) < (UINT32_MAX / 1000)) ? (timeout *= 1000) : UINT32_MAX; \
+	timeout = (((uint32_t)timeout) < (UINT32_MAX / 1000)) ? (timeout * 1000) : UINT32_MAX; \
 	__TIMEOUT_US__(timeout)
 #define __TIMEOUT_ASSERT__(timeout) if (timeout == 0)
 


### PR DESCRIPTION
- fix timeout macro typo in converting from ms to us
- reverted timeout_us macro to prevent compiler optimizations that would lead to out of order execution