### PR TITLE
redesigned M2/M30 to match LinuxCNC

### DIFF
--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -508,7 +508,7 @@ uint8_t cnc_unlock(bool force)
 
 		io_set_steps(g_settings.step_invert_mask);
 		io_enable_steppers(g_settings.step_enable_invert);
-		parser_reset(true); // reset stop group only
+		parser_reset(false); // reset parser
 
 		// hard reset
 		// if homing not enabled run startup blocks

--- a/uCNC/src/core/parser.h
+++ b/uCNC/src/core/parser.h
@@ -323,7 +323,7 @@ extern "C"
 	void parser_parameters_reset(void);
 	void parser_parameters_save(void);
 	void parser_sync_position(void);
-	void parser_reset(bool stopgroup_only);
+	void parser_reset(bool fullreset);
 	void parser_machine_to_work(float *axis);
 	uint8_t parser_get_float(float *value);
 	void parser_discard_command(void);


### PR DESCRIPTION
- redesigned M2/M30 to match LinuxCNC reseting the parser parameters
- default mode with program locking
- option mode without lock (similar to Grbl)