### PR TITLE
fix inversion of status_report_mask position type bit

### DIFF
--- a/uCNC/src/interface/grbl_protocol.c
+++ b/uCNC/src/interface/grbl_protocol.c
@@ -496,7 +496,7 @@ void proto_status(void)
 	}
 
 	proto_putc('|');
-	if (!(g_settings.status_report_mask & 1))
+	if ((g_settings.status_report_mask & 1))
 	{
 		proto_putc('M');
 	}


### PR DESCRIPTION
issue was introduced in 0caa36f4; without this, the behaviour is the opposite of GRBL