### PR TITLE
fix ignored G53

### DIFF
--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1668,6 +1668,7 @@ static uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *wo
 		break;
 	case G53:
 		index = 254;
+		new_state->groups.nonmodal = 0; // this command is compatible with motion commands
 		break;
 	}
 


### PR DESCRIPTION
issue was introduced in fc0d9d31

without this, the ["perform motion" check](https://github.com/tomjnixon/uCNC/blob/74dda7286e2f7b189394fadee4711bdf473c6317/uCNC/src/core/parser.c#L1782) ignores the command

i'm not sure if this is the right approach, but it works and seems to make sense