### PR TITLE
Added EEPROM emulation option on STM32

### DIFF
--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -43,7 +43,7 @@ board = genericSTM32F103VE
 board_build.flash_offset  = 0x7000
 board_upload.offset_address = 0x08007000
 board_build.f_cpu = 72000000L
-build_flags = ${common_stm32.build_flags}  -D BOARDMAP=\"src/hal/boards/stm32/boardmap_mks_robin_nano_v1_2.h\" -D RAM_ONLY_SETTINGS
+build_flags = ${common_stm32.build_flags}  -D BOARDMAP=\"src/hal/boards/stm32/boardmap_mks_robin_nano_v1_2.h\" -D DISABLE_EEPROM_EMULATION
 
 [env:STM32F4-MKS-Robin-Nano-V3_1]
 extends = common_stm32
@@ -51,7 +51,7 @@ board = black_f407vg
 board_build.flash_offset = 0xC000
 board_upload.offset_address = 0x0800C000
 board_build.f_cpu = 168000000L
-build_flags = ${common_stm32.build_flags} -D BOARDMAP=\"src/hal/boards/stm32/boardmap_mks_robin_nano_v3_1.h\" -D HSE_VALUE=8000000L -D RAM_ONLY_SETTINGS
+build_flags = ${common_stm32.build_flags} -D BOARDMAP=\"src/hal/boards/stm32/boardmap_mks_robin_nano_v3_1.h\" -D HSE_VALUE=8000000L -D DISABLE_EEPROM_EMULATION
 
 [env:STM32F4-Blackpill-F401CC]
 extends = common_stm32
@@ -74,7 +74,7 @@ board_upload.offset_address = 0x08008000
 board_upload.maximum_ram_size = 196608
 board_upload.maximum_size = 1048576
 board_build.ldscript = uCNC/src/hal/mcus/stm32f4x/stm32f4x.ld
-build_flags = ${common_stm32.build_flags} -D BOARDMAP=\"src/hal/boards/stm32/boardmap_srk_pro_v1_2.h\" -D HSE_VALUE=8000000 -D RAM_ONLY_SETTINGS -D CUSTOM_PRE_MAIN
+build_flags = ${common_stm32.build_flags} -D BOARDMAP=\"src/hal/boards/stm32/boardmap_srk_pro_v1_2.h\" -D HSE_VALUE=8000000 -D DISABLE_EEPROM_EMULATION -D CUSTOM_PRE_MAIN
 
 [env:STM32F4-Nucleo-F411RE-Shield-V3]
 extends = common_stm32

--- a/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
+++ b/uCNC/src/hal/mcus/stm32f0x/mcu_stm32f0x.c
@@ -868,6 +868,7 @@ uint8_t mcu_eeprom_getc(uint16_t address)
 
 static void mcu_eeprom_erase(uint16_t address)
 {
+#ifndef DISABLE_EEPROM_EMULATION
 	while (FLASH->SR & FLASH_SR_BSY)
 		; // wait while busy
 	// unlock flash if locked
@@ -883,6 +884,7 @@ static void mcu_eeprom_erase(uint16_t address)
 	while (FLASH->SR & FLASH_SR_BSY)
 		; // wait while busy
 	FLASH->CR = 0;
+#endif
 }
 
 void mcu_eeprom_putc(uint16_t address, uint8_t value)
@@ -904,6 +906,7 @@ void mcu_eeprom_putc(uint16_t address, uint8_t value)
 
 void mcu_eeprom_flush()
 {
+#ifndef DISABLE_EEPROM_EMULATION
 	if (stm32_flash_modified)
 	{
 		mcu_eeprom_erase(stm32_flash_current_page);
@@ -939,6 +942,7 @@ void mcu_eeprom_flush()
 		stm32_flash_modified = false;
 		// Restore interrupt flag state.*/
 	}
+#endif
 }
 
 typedef enum spi_port_state_enum
@@ -1378,7 +1382,7 @@ bool mcu_spi2_bulk_transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t d
 
 void mcu_i2c_stop(bool *stop)
 {
-	//not working (using autostop)
+	// not working (using autostop)
 	while (!(I2C_REG->ISR & I2C_ISR_TC))
 		;
 	I2C_REG->CR2 |= I2C_CR2_STOP;
@@ -1675,7 +1679,6 @@ void I2C_ISR(void)
 #endif
 
 #endif
-
 
 #ifdef MCU_HAS_ONESHOT_TIMER
 

--- a/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
+++ b/uCNC/src/hal/mcus/stm32f1x/mcu_stm32f1x.c
@@ -57,6 +57,11 @@
 #define FLASH_PAGE_OFFSET_MASK (0xFFFF & ~FLASH_PAGE_MASK)
 #endif
 
+#ifdef DISABLE_EEPROM_EMULATION
+#undef FLASH_PAGE_SIZE
+#define FLASH_PAGE_SIZE NVM_STORAGE_SIZE
+#endif
+
 #define READ_FLASH(ram_ptr, flash_ptr) (*ram_ptr = ~(*flash_ptr))
 #define WRITE_FLASH(flash_ptr, ram_ptr) (*flash_ptr = ~(*ram_ptr))
 static uint8_t stm32_flash_page[FLASH_PAGE_SIZE];
@@ -928,6 +933,9 @@ void mcu_dotasks()
 // if not loads it
 static uint16_t mcu_access_flash_page(uint16_t address)
 {
+#ifdef DISABLE_EEPROM_EMULATION
+	return address;
+#else
 	uint16_t address_page = address & FLASH_PAGE_MASK;
 	uint16_t address_offset = address & FLASH_PAGE_OFFSET_MASK;
 	if (stm32_flash_current_page != address_page)
@@ -947,6 +955,7 @@ static uint16_t mcu_access_flash_page(uint16_t address)
 	}
 
 	return address_offset;
+#endif
 }
 
 // Non volatile memory
@@ -954,7 +963,7 @@ uint8_t mcu_eeprom_getc(uint16_t address)
 {
 	if (NVM_STORAGE_SIZE <= address)
 	{
-		DBGMSG("EEPROM invalid address @ %u",address);
+		DBGMSG("EEPROM invalid address @ %u", address);
 		return 0;
 	}
 	uint16_t offset = mcu_access_flash_page(address);
@@ -963,6 +972,7 @@ uint8_t mcu_eeprom_getc(uint16_t address)
 
 static void mcu_eeprom_erase(uint16_t address)
 {
+#ifndef DISABLE_EEPROM_EMULATION
 	while (FLASH->SR & FLASH_SR_BSY)
 		; // wait while busy
 	// unlock flash if locked
@@ -978,13 +988,14 @@ static void mcu_eeprom_erase(uint16_t address)
 	while (FLASH->SR & FLASH_SR_BSY)
 		; // wait while busy
 	FLASH->CR = 0;
+#endif
 }
 
 void mcu_eeprom_putc(uint16_t address, uint8_t value)
 {
 	if (NVM_STORAGE_SIZE <= address)
 	{
-		DBGMSG("EEPROM invalid address @ %u",address);
+		DBGMSG("EEPROM invalid address @ %u", address);
 	}
 
 	uint16_t offset = mcu_access_flash_page(address);
@@ -999,6 +1010,7 @@ void mcu_eeprom_putc(uint16_t address, uint8_t value)
 
 void mcu_eeprom_flush()
 {
+#ifndef DISABLE_EEPROM_EMULATION
 	if (stm32_flash_modified)
 	{
 		mcu_eeprom_erase(stm32_flash_current_page);
@@ -1026,7 +1038,7 @@ void mcu_eeprom_flush()
 				proto_error(42); // STATUS_SETTING_WRITE_FAIL
 			if (FLASH->SR & FLASH_SR_WRPRTERR)
 				proto_error(43); // STATUS_SETTING_PROTECTED_FAIL
-			FLASH->CR = 0;						 // Ensure PG bit is low
+			FLASH->CR = 0;		 // Ensure PG bit is low
 			FLASH->SR = 0;
 			eeprom++;
 			ptr++;
@@ -1034,6 +1046,7 @@ void mcu_eeprom_flush()
 		stm32_flash_modified = false;
 		// Restore interrupt flag state.*/
 	}
+#endif
 }
 
 typedef enum spi_port_state_enum


### PR DESCRIPTION
- added eeprom emulation option on STM32 to separate from RAM_ONLY_SETTINGS
- fixed sector sizes depending on flash size for STM32F4