### PR TITLE
allow softlimits to be ignored if $13x distance is 0

### DIFF
--- a/uCNC/src/hal/kinematics/kinematic_cartesian.c
+++ b/uCNC/src/hal/kinematics/kinematic_cartesian.c
@@ -166,14 +166,17 @@ bool kinematics_check_boundaries(float *axis)
 	for (uint8_t i = AXIS_COUNT; i != 0;)
 	{
 		i--;
-#ifdef SET_ORIGIN_AT_HOME_POS
-		float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
-#else
-		float value = axis[i];
-#endif
-		if (value > g_settings.max_distance[i] || value < 0)
+		if (g_settings.max_distance[i]) //ignore any undefined axis
 		{
-			return false;
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
 		}
 	}
 

--- a/uCNC/src/hal/kinematics/kinematic_corexy.c
+++ b/uCNC/src/hal/kinematics/kinematic_corexy.c
@@ -29,7 +29,6 @@
 #define COREXY_EXTRA_AXIS_START 2
 #endif
 
-
 void kinematics_init(void)
 {
 }
@@ -62,9 +61,9 @@ void kinematics_apply_forward(int32_t *steps, float *axis)
 #if (COREXY_AXIS == COREXY_AXIS_XZ)
 	axis[AXIS_X] = (float)(0.5f * (float)(steps[0] + steps[2]) / g_settings.step_per_mm[0]);
 	axis[AXIS_Z] = (float)(0.5f * (float)(steps[0] - steps[2]) / g_settings.step_per_mm[2]);
-  axis[AXIS_Y] = (((float)steps[1]) / g_settings.step_per_mm[1]);
+	axis[AXIS_Y] = (((float)steps[1]) / g_settings.step_per_mm[1]);
 #elif (COREXY_AXIS == COREXY_AXIS_YZ)
-  axis[AXIS_X] = (((float)steps[0]) / g_settings.step_per_mm[0]);
+	axis[AXIS_X] = (((float)steps[0]) / g_settings.step_per_mm[0]);
 	axis[AXIS_Y] = (float)(0.5f * (float)(steps[1] + steps[2]) / g_settings.step_per_mm[1]);
 	axis[AXIS_Z] = (float)(0.5f * (float)(steps[1] - steps[2]) / g_settings.step_per_mm[2]);
 #else
@@ -204,14 +203,17 @@ bool kinematics_check_boundaries(float *axis)
 	for (uint8_t i = AXIS_COUNT; i != 0;)
 	{
 		i--;
-#ifdef SET_ORIGIN_AT_HOME_POS
-		float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
-#else
-		float value = axis[i];
-#endif
-		if (value > g_settings.max_distance[i] || value < 0)
+		if (g_settings.max_distance[i]) // ignore any undefined axis
 		{
-			return false;
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
 		}
 	}
 

--- a/uCNC/src/hal/kinematics/kinematic_delta.c
+++ b/uCNC/src/hal/kinematics/kinematic_delta.c
@@ -148,7 +148,7 @@ static void delta_calc_bounds(void)
 		axis[AXIS_Z] = middlez - sum;
 		kinematics_apply_inverse(axis, r[7]);
 		if (r[0][0] == INT32_MAX || r[1][0] == INT32_MAX || r[2][0] == INT32_MAX || r[3][0] == INT32_MAX ||
-			r[4][0] == INT32_MAX || r[5][0] == INT32_MAX || r[6][0] == INT32_MAX || r[7][0] == INT32_MAX)
+				r[4][0] == INT32_MAX || r[5][0] == INT32_MAX || r[6][0] == INT32_MAX || r[7][0] == INT32_MAX)
 		{
 			sum -= dist;
 			dist *= 0.5;
@@ -204,7 +204,7 @@ int8_t delta_calcAngleYZ(float x0, float y0, float z0, float *theta)
 	float re = g_settings.delta_forearm_length;
 	float rf = g_settings.delta_bicep_length;
 	float y1 = -delta_base_half_f_tg30; // f/2 * tg 30
-	y0 -= delta_effector_half_f_tg30;	// shift center to edge
+	y0 -= delta_effector_half_f_tg30;		// shift center to edge
 	// z = a + b*y
 	float a = fast_flt_div2((x0 * x0 + y0 * y0 + z0 * z0 + rf * rf - re * re - y1 * y1)) / z0;
 	float b = (y1 - y0) / z0;
@@ -343,7 +343,6 @@ uint8_t kinematics_home(void)
 		return error;
 	}
 
-
 #if AXIS_A_HOMING_MASK != 0
 	error = mc_home_axis(AXIS_A_HOMING_MASK, LINACT3_LIMIT_MASK);
 	if (error != STATUS_OK)
@@ -439,6 +438,24 @@ bool kinematics_check_boundaries(float *axis)
 	if (axis[AXIS_Z] < (delta_cuboid_z_min - z_offset) || axis[AXIS_Z] > (delta_cuboid_z_max - z_offset))
 	{
 		return false;
+	}
+
+	// remaining axis
+	for (uint8_t i = AXIS_COUNT; i != 3;)
+	{
+		i--;
+		if (g_settings.max_distance[i]) // ignore any undefined axis
+		{
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
+		}
 	}
 
 	return true;

--- a/uCNC/src/hal/kinematics/kinematic_linear_delta.c
+++ b/uCNC/src/hal/kinematics/kinematic_linear_delta.c
@@ -118,9 +118,9 @@ void kinematics_apply_forward(int32_t *steps, float *axis)
 	// The cross product of the unit x and y is the unit z
 	// float[] ez = vectorCrossProd(ex, ey);
 	float ez[3] = {
-		ex[1] * ey[2] - ex[2] * ey[1],
-		ex[2] * ey[0] - ex[0] * ey[2],
-		ex[0] * ey[1] - ex[1] * ey[0]};
+			ex[1] * ey[2] - ex[2] * ey[1],
+			ex[2] * ey[0] - ex[0] * ey[2],
+			ex[0] * ey[1] - ex[1] * ey[0]};
 
 	// We now have the d, i and j values defined in Wikipedia.
 	// Plug them into the equations defined in Wikipedia for Xnew, Ynew and Znew
@@ -150,7 +150,6 @@ uint8_t kinematics_home(void)
 	{
 		return error;
 	}
-
 
 #if AXIS_A_HOMING_MASK != 0
 	error = mc_home_axis(AXIS_A_HOMING_MASK, LINACT3_LIMIT_MASK);
@@ -234,6 +233,24 @@ bool kinematics_check_boundaries(float *axis)
 		return false;
 	}
 #endif
+
+	// remaining axis
+	for (uint8_t i = AXIS_COUNT; i != 3;)
+	{
+		i--;
+		if (g_settings.max_distance[i]) // ignore any undefined axis
+		{
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
+		}
+	}
 
 	return true;
 }

--- a/uCNC/src/hal/kinematics/kinematic_rtheta.c
+++ b/uCNC/src/hal/kinematics/kinematic_rtheta.c
@@ -39,7 +39,7 @@ void kinematics_init(void)
 	arm_angle_fact = 2.0f * M_PI / g_settings.step_per_mm[0];
 	arm_length_fact = 1 / g_settings.step_per_mm[1];
 	theta_reduction_ratio = g_settings.rtheta_theta_reduction_ratio;
-	theta_reduction_ratio_inv = 1/g_settings.rtheta_theta_reduction_ratio;
+	theta_reduction_ratio_inv = 1 / g_settings.rtheta_theta_reduction_ratio;
 	arm = g_settings.rtheta_arm_length;
 	mc_sync_position();
 }
@@ -155,7 +155,7 @@ uint8_t kinematics_home(void)
 	error = mc_line(target, &block_data);
 	itp_sync();
 #endif
-	
+
 	return error;
 }
 
@@ -173,10 +173,10 @@ bool kinematics_check_boundaries(float *axis)
 	{
 		return true;
 	}
-	
+
 	float distance_to_center_sqr = axis[AXIS_X] * axis[AXIS_X] + axis[AXIS_Y] * axis[AXIS_Y];
 
-	if (distance_to_center_sqr > arm*arm)
+	if (distance_to_center_sqr > arm * arm)
 	{
 		return false;
 	}
@@ -184,14 +184,17 @@ bool kinematics_check_boundaries(float *axis)
 	for (uint8_t i = AXIS_COUNT; i != 2;)
 	{
 		i--;
-#ifdef SET_ORIGIN_AT_HOME_POS
-		float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
-#else
-		float value = axis[i];
-#endif
-		if (value > g_settings.max_distance[i] || value < 0)
+		if (g_settings.max_distance[i]) // ignore any undefined axis
 		{
-			return false;
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
 		}
 	}
 

--- a/uCNC/src/hal/kinematics/kinematic_scara.c
+++ b/uCNC/src/hal/kinematics/kinematic_scara.c
@@ -27,7 +27,6 @@
 #define FULL_TURN_INV 0.0027777777777777778f
 #define DOUBLE_PI_INV (0.5f * M_PI_INV)
 
-
 static float scara_arm_angle_fact[2];
 static float scara_min_distance_to_center_sqr;
 static float scara_max_distance_to_center_sqr;
@@ -172,7 +171,7 @@ uint8_t kinematics_home(void)
 	error = mc_line(target, &block_data);
 	itp_sync();
 #endif
-	
+
 	return error;
 }
 
@@ -190,7 +189,7 @@ bool kinematics_check_boundaries(float *axis)
 	{
 		return true;
 	}
-	
+
 	float distance_to_center_sqr = axis[AXIS_X] * axis[AXIS_X] + axis[AXIS_Y] * axis[AXIS_Y];
 
 	if (distance_to_center_sqr < scara_min_distance_to_center_sqr || distance_to_center_sqr > scara_max_distance_to_center_sqr)
@@ -198,17 +197,21 @@ bool kinematics_check_boundaries(float *axis)
 		return false;
 	}
 
+	// remaining axis
 	for (uint8_t i = AXIS_COUNT; i != 2;)
 	{
 		i--;
-#ifdef SET_ORIGIN_AT_HOME_POS
-		float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
-#else
-		float value = axis[i];
-#endif
-		if (value > g_settings.max_distance[i] || value < 0)
+		if (g_settings.max_distance[i]) // ignore any undefined axis
 		{
-			return false;
+#ifdef SET_ORIGIN_AT_HOME_POS
+			float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+			float value = axis[i];
+#endif
+			if (value > g_settings.max_distance[i] || value < 0)
+			{
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
- allow softlimits to be ignored if $13x distance is 0 (this may not be the applied in all axis). Some kinematics still require some of the settings to be a non 0 value to work properlly