### PR TITLE
Allow multi GCode line on startup blocks

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -329,6 +329,11 @@ extern "C"
  */
 // #define DISABLE_ENDPROGRAM_LOCK
 
+/**
+ * Allow multiline startup blocks. Multiline startup blocks allow to add a multiple GCode command blocks using the | char as a separator
+ */
+//  #define ENABLE_MULTILINE_STARTUP_BLOCKS
+
 	/**
 	 * Shrink µCNC
 	 * It's possible to shrink µCNC by disable some core features:

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -1102,15 +1102,37 @@ static void cnc_io_dotasks(void)
 #endif
 }
 
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+bool g_is_multilineblock;
+#endif
 void cnc_run_startup_blocks(void)
 {
 	for (uint8_t i = 0; i < STARTUP_BLOCKS_COUNT; i++)
 	{
+		itp_sync();
 		uint16_t address = STARTUP_BLOCK_ADDRESS_OFFSET(i);
 		if (settings_check_startup_gcode(address))
 		{
-			grbl_stream_eeprom(address);
-			cnc_parse_cmd();
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+			uint8_t c = EOL;
+			do
+			{
+#endif
+				grbl_stream_eeprom(address);
+				cnc_parse_cmd();
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+				do
+				{
+					c = mcu_eeprom_getc(address++);
+					if (c == '|')
+					{
+						grbl_stream_start_broadcast();
+						proto_putc('>');
+						break;
+					}
+				} while (c != EOL);
+			} while (c != EOL);
+#endif
 		}
 	}
 

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -531,11 +531,30 @@ static uint8_t parser_grbl_command(void)
 					}
 
 					settings_save(block_address, NULL, UINT16_MAX);
-					// run startup block
-					grbl_stream_start_broadcast();
-					grbl_stream_eeprom(block_address);
-					// checks the command validity
-					error = parser_fetch_command(&next_state, &words, &cmd);
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+					uint16_t address = block_address;
+					uint8_t c = EOL;
+					do
+					{
+#endif
+						// run startup block
+						grbl_stream_start_broadcast();
+						grbl_stream_eeprom(block_address);
+						// checks the command validity
+						error = parser_fetch_command(&next_state, &words, &cmd);
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+						do
+						{
+							c = mcu_eeprom_getc(block_address++);
+							if (c == '|')
+							{
+								break;
+							}
+						} while (c != EOL);
+					} while (c != EOL && error == STATUS_OK);
+					// restore address
+					block_address = address;
+#endif
 					// if uncomment will also check if any gcode rules are violated
 					// allow bad rules for now to fit UNO. Will be catched when trying to execute the line
 					// if (error == STATUS_OK)

--- a/uCNC/src/interface/grbl_stream.c
+++ b/uCNC/src/interface/grbl_stream.c
@@ -216,7 +216,14 @@ static uint16_t stream_eeprom_address;
 static uint8_t stream_eeprom_getc(void)
 {
 	uint8_t c = mcu_eeprom_getc(stream_eeprom_address++);
+#ifdef ENABLE_MULTILINE_STARTUP_BLOCKS
+	if (c == '|')
+	{
+		c = EOL;
+	}
+#endif
 	grbl_stream_putc((c != EOL) ? c : ':');
+
 	return c;
 }
 


### PR DESCRIPTION
- Allow multi GCode line on startup blocks using a | char as a line break