### PR TITLE
uCNC internal state revision

### DIFF
--- a/docs/Grbl-states.md
+++ b/docs/Grbl-states.md
@@ -1,0 +1,61 @@
+# Grbl states table
+
+|CurrentState|Trigger/Event             |NextState |Notes                                      |
+|------------|--------------------------|----------|-------------------------------------------|
+|Idle        |~ (Cycle Start)           |Run       |Begin executing motion                     |
+|Idle        |$H                        |Home      |Start homing cycle                         |
+|Idle        |$C                        |Check     |Enter parser check mode                    |
+|Idle        |$SLP                      |Sleep     |Enter sleep mode                           |
+|Idle        |Door Open                 |Door      |Enter safety door suspend                  |
+|Idle        |Hard/Soft Limit           |Alarm     |Limit triggered                            |
+|Idle        |Reset                     |Idle/Alarm|Depends on config                          |
+|Idle        |0x84 Safety Door          |Door      |Immediate suspend; spindle/coolant disabled|
+|Idle        |0xA0 Flood Toggle         |Idle      |Coolant modal toggled                      |
+|Idle        |0xA1 Mist Toggle          |Idle      |Mist toggle (if enabled)                   |
+|Run         |!                         |Hold      |Feed hold (decelerate)                     |
+|Run         |Door Open                 |Door      |Door suspend (parking if enabled)          |
+|Run         |M2/M30                    |Idle      |Program end                                |
+|Run         |Hard/Soft Limit           |Alarm     |Immediate stop                             |
+|Run         |Reset                     |Alarm     |Reset while in motion                      |
+|Run         |0x84 Safety Door          |Door      |Decelerate then suspend; parking if enabled|
+|Run         |0x90–0x94 Feed Override   |Run       |Adjust feed override                       |
+|Run         |0x95–0x97 Rapid Override  |Run       |Adjust rapid override                      |
+|Run         |0x99–0x9D Spindle Override|Run       |Adjust spindle override                    |
+|Run         |0xA0 Flood Toggle         |Run       |Coolant modal toggled                      |
+|Run         |0xA1 Mist Toggle          |Run       |Mist toggle (if enabled)                   |
+|Hold        |Decel Complete            |Hold:0    |Hold finished                              |
+|Hold        |~ (Resume)                |Run       |Resume motion                              |
+|Hold        |Door Open                 |Door      |Door suspend                               |
+|Hold        |Reset                     |Alarm     |Reset during hold                          |
+|Hold        |0x84 Safety Door          |Door      |Door supersedes hold                       |
+|Hold        |0x9E Toggle Spindle Stop  |Hold      |Spindle stop override                      |
+|Hold        |0xA0 Flood Toggle         |Hold      |Coolant modal toggled                      |
+|Hold        |0xA1 Mist Toggle          |Hold      |Mist toggle (if enabled)                   |
+|Door        |Door Open During Run      |Door:2    |Parking/hold in progress                   |
+|Door        |Door Still Open           |Door:1    |Stopped but cannot resume                  |
+|Door        |Door Closed               |Door:0    |Ready to resume                            |
+|Door        |~ (Resume)                |Run       |Resume from door state                     |
+|Door        |Reset                     |Alarm     |Reset during door state                    |
+|Check       |$C again                  |Idle/Alarm|Exit check mode (soft reset)               |
+|Check       |Reset                     |Idle/Alarm|Reset behavior                             |
+|Check       |G-code Input              |Check     |Parse only                                 |
+|Home        |Success                   |Idle      |Homing complete                            |
+|Home        |Failure                   |Alarm     |Homing error                               |
+|Home        |Door Open                 |Alarm     |Door during homing                         |
+|Home        |Reset                     |Alarm     |Reset during homing                        |
+|Home        |0x84 Safety Door          |Alarm     |Safety door aborts homing                  |
+|Home        |!                         |Home      |Ignores                                    |
+|Jog         |$J=…                      |Jog       |Jog motion                                 |
+|Jog         |Jog Complete              |Idle      |Return to idle                             |
+|Jog         |Jog Cancel                |Idle      |Planner purge                              |
+|Jog         |0x85 Jog Cancel           |Idle/Door |Cancels jog; Door if ajar                  |
+|Jog         |Hard/Soft Limit           |Alarm     |Jog safety fault                           |
+|Jog         |Door Open                 |Door      |Door suspend                               |
+|Jog         |Reset                     |Alarm     |Reset during jog                           |
+|Jog         |0x84 Safety Door          |Door      |Jog canceled; planner flushed              |
+|Alarm       |$X Unlock                 |Idle      |Unlock alarm                               |
+|Alarm       |$H                        |Home      |Re-home after alarm                        |
+|Alarm       |$SLP                      |Sleep     |Sleep from alarm                           |
+|Alarm       |Reset                     |Alarm/Idle|Depends on cause                           |
+|Sleep       |Alarm                     |Alarm     |Wakes in alarm                             |
+|Sleep       |Any Other Command         |Sleep     |Ignored                                    |

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -235,7 +235,7 @@ extern "C"
  * Uncomment to enable pwm laser tool features
  *
  * **/
-// #define ENABLE_LASER_PWM
+#define ENABLE_LASER_PWM
 
 /**
  * Uncomment to enable laser PPI feature

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -235,7 +235,7 @@ extern "C"
  * Uncomment to enable pwm laser tool features
  *
  * **/
-#define ENABLE_LASER_PWM
+// #define ENABLE_LASER_PWM
 
 /**
  * Uncomment to enable laser PPI feature

--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -442,9 +442,9 @@ extern "C"
  *   Rapid approach -> Slow pull off
  * into a longer and potentially more precise:
  *   Rapid limit find -> Rapid limit clear -> Slow 2nd limit find -> Slow limit clear
- * 
+ *
  * After this the pulloff offset distance is travelled for all axis
- * 
+ *
  * This change makes the code size a bit bigger but might make your
  * homing cycle yield more accurate results.
  * */
@@ -453,9 +453,9 @@ extern "C"
 /**
  * This modifies the behavior to match Grbl homing motion. Note this will force ENABLE_LONG_HOMING_CYCLE
  *  Rapid limit find -> Rapid pull off -> Slow 2nd limit find -> Rapid pull off
- * 
+ *
  *  No final pulloff offset is performed in this mode as the pulloff is performed per axis and on contact
- * 
+ *
  */
 //  #define ENABLE_GRBL_STYLE_HOMING
 
@@ -490,6 +490,11 @@ extern "C"
 	 * If the type of machine supports skew and needs skew correction
 	 *  (defined in the specified kinematics_xxx.h file)
 	 * */
+
+/**
+ * Safety door configurations (in development)
+ */
+// #define ENABLE_SAFETY_DOOR_PARKING
 
 // #define ENABLE_SKEW_COMPENSATION
 #ifdef ENABLE_SKEW_COMPENSATION
@@ -653,6 +658,16 @@ extern "C"
 	 * */
 
 #define EMULATE_GRBL_STARTUP 2
+
+	/**
+	 * Enable advanced Grbl states.
+	 * This enables a couple more states in the status messages besides Alarm, Door, Hold, Check, Home, Jog, Run and Idle. These are:
+	 * Locked - when the controller in in lock state (requires $X or $H to unlock)
+	 * Dwell - when a dwell is being executed
+	 * Probe - used in probing motions and HMapping
+	 */
+
+	// #define ENABLE_EXTRA_GRBL_STATES
 
 	/**
 	 *

--- a/uCNC/src/atomic.h
+++ b/uCNC/src/atomic.h
@@ -79,7 +79,7 @@ extern "C"
 #ifdef __GNUC__
 #ifndef ATOMIC_LOAD_N
 #define ATOMIC_LOAD_N(src, mode) \
-	({__typeof__(*(src)) _res;ATOMIC_CODEBLOCK { _res = *(src); }_res; })
+	({__typeof__(*(src)) _res; ATOMIC_CODEBLOCK { _res = *(src); } _res; })
 #endif
 #ifndef ATOMIC_STORE_N
 #define ATOMIC_STORE_N(dst, val, mode) \

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -576,6 +576,12 @@ void cnc_set_exec_state(uint16_t statemask)
 		}
 	}
 
+	// enforce hold on door
+	if (CHECKFLAG(statemask, EXEC_DOOR))
+	{
+		SETFLAG(statemask, EXEC_HOLD);
+	}
+
 	if (CHECKFLAG(statemask, EXEC_RUN))
 	{
 		cnc_clear_exec_state(EXEC_RESUMING); // auto clears resuming
@@ -635,7 +641,7 @@ void cnc_clear_exec_state(uint16_t statemask)
 	}
 
 	// if releasing from a HOLD state with and active delay in exec
-	if (CHECKFLAG(statemask, EXEC_HOLD) && cnc_get_exec_state(EXEC_HOLD))
+	if (CHECKFLAG(statemask, EXEC_HOLD) && cnc_get_exec_state(EXEC_HOLD) && !planner_buffer_is_empty())
 	{
 		cnc_set_exec_state(EXEC_RESUMING);
 #if TOOL_COUNT > 0
@@ -1113,6 +1119,11 @@ bool cnc_check_interlocking(void)
 			mc_flush_pending_motion();
 			// homing will be cleared inside homing cycle
 			cnc_clear_exec_state(EXEC_SPECIAL_MOTIONS);
+		}
+		cnc_clear_exec_state(EXEC_CANCELING);
+		if (planner_buffer_is_empty())
+		{
+			cnc_clear_exec_state(EXEC_JOG);
 		}
 	}
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -536,7 +536,7 @@ uint8_t cnc_unlock(bool force)
 		// all other alarm flags remain active if any input is still active
 		CLEARFLAG(cnc_state.exec_state, EXEC_POSITION_MAYBE_LOST);
 		// clears all other locking flags
-		cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_HOLD);
+		cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_CONTROLLED_STOP);
 		// signals stepper enable pins
 
 		io_set_steps(g_settings.step_invert_mask);
@@ -561,6 +561,25 @@ uint16_t cnc_get_exec_state(uint16_t statemask)
 
 void cnc_set_exec_state(uint16_t statemask)
 {
+	if (CHECKFLAG(statemask, EXEC_HOLD))
+	{
+		// ignore hold while performing homing (clears for replacement if jogging)
+		if (CHECKFLAG(cnc_state.exec_state, EXEC_HOMING | EXEC_JOG))
+		{
+			CLEARFLAG(statemask, EXEC_HOLD);
+		}
+
+		// if jog is being executed cancel it
+		if (CHECKFLAG(cnc_state.exec_state, EXEC_JOG))
+		{
+			SETFLAG(statemask, EXEC_CANCELING);
+		}
+	}
+
+	if (CHECKFLAG(statemask, EXEC_RUN))
+	{
+		cnc_clear_exec_state(EXEC_RESUMING); // auto clears resuming
+	}
 	SETFLAG(cnc_state.exec_state, statemask);
 }
 
@@ -617,36 +636,40 @@ void cnc_clear_exec_state(uint16_t statemask)
 	// if releasing from a HOLD state with and active delay in exec
 	if (CHECKFLAG(statemask, EXEC_HOLD) && cnc_get_exec_state(EXEC_HOLD))
 	{
-		// skip this if the hold release is for a jog cancel
-		if (!cnc_get_exec_state(EXEC_JOG))
-		{
 #if TOOL_COUNT > 0
-			planner_spindle_ovr_reset();
-			// updated the coolant pins
-			tool_set_coolant(planner_get_coolant());
+		planner_spindle_ovr_reset();
+		// updated the coolant pins
+		tool_set_coolant(planner_get_coolant());
+		if (!planner_buffer_is_empty())
+		{
+			cnc_set_exec_state(EXEC_RESUMING);
+#if (DELAY_ON_RESUME_COOLANT > 0)
+			if (!g_settings.tool_mode)
+			{
+				cnc_dwell_ms(DELAY_ON_RESUME_COOLANT * 1000);
+			}
+#endif
+		}
+		// tries to sync the tool
+		// if something goes wrong the tool can reinstate the HOLD state
+		itp_sync_spindle();
+#if (DELAY_ON_RESUME_SPINDLE > 0)
+		if (!g_settings.tool_mode && cnc_state.loop_state == LOOP_RUNNING)
+		{
 			if (!planner_buffer_is_empty())
 			{
-				cnc_set_exec_state(EXEC_RESUMING);
-#if (DELAY_ON_RESUME_COOLANT > 0)
-				if (!g_settings.tool_mode)
-				{
-					cnc_dwell_ms(DELAY_ON_RESUME_COOLANT * 1000);
-				}
-#endif
+				cnc_dwell_ms(DELAY_ON_RESUME_SPINDLE * 1000);
 			}
-			// tries to sync the tool
-			// if something goes wrong the tool can reinstate the HOLD state
-			itp_sync_spindle();
-#if (DELAY_ON_RESUME_SPINDLE > 0)
-			if (!g_settings.tool_mode && cnc_state.loop_state == LOOP_RUNNING)
-			{
-				if (!planner_buffer_is_empty())
-				{
-					cnc_dwell_ms(DELAY_ON_RESUME_SPINDLE * 1000);
-				}
-			}
+		}
 #endif
 #endif
+	}
+
+	if (CHECKFLAG(statemask, EXEC_RUN))
+	{
+		if (cnc_get_exec_state(EXEC_CANCELING)) // auto clears
+		{
+			SETFLAG(statemask, EXEC_CANCELING);
 		}
 	}
 
@@ -674,6 +697,7 @@ void cnc_dwell_ms(uint32_t milliseconds)
 
 void cnc_reset(void)
 {
+	mcu_controls_changed_cb();
 	// resets all realtime command flags
 	cnc_state.rt_cmd = RT_CMD_CLEAR;
 	cnc_state.feed_ovr_cmd = RT_CMD_CLEAR;
@@ -712,18 +736,15 @@ void cnc_call_rt_command(uint8_t command)
 	case CMD_CODE_RESET:
 		SETFLAG(cnc_state.rt_cmd, RT_CMD_RESET);
 		break;
-	case CMD_CODE_FEED_HOLD:
-		if (!cnc_get_exec_state(EXEC_HOMING))
-		{
-			cnc_set_exec_state(EXEC_HOLD);
-		}
-		__FALL_THROUGH__
 	case CMD_CODE_JOG_CANCEL:
 		if (cnc_get_exec_state(EXEC_JOG))
 		{
-			cnc_set_exec_state(EXEC_HOLD);
 			SETFLAG(cnc_state.rt_cmd, RT_CMD_JOG_CANCEL);
+			cnc_set_exec_state(EXEC_CANCELING);
 		}
+		break;
+	case CMD_CODE_FEED_HOLD:
+		cnc_set_exec_state(EXEC_HOLD);
 		break;
 	case CMD_CODE_REPORT:
 		SETFLAG(cnc_state.rt_cmd, RT_CMD_REPORT);
@@ -737,9 +758,7 @@ void cnc_call_rt_command(uint8_t command)
 #if ASSERT_PIN(SAFETY_DOOR)
 	case CMD_CODE_SAFETY_DOOR:
 		cnc_set_exec_state((EXEC_HOLD | EXEC_DOOR));
-#ifdef ENABLE_SAFETY_DOOR_PARKING
-		SETFLAG(cnc_state.rt_cmd, RT_CMD_DOOR_PARK);
-#endif
+		SETFLAG(cnc_state.rt_cmd, RT_CMD_DOOR_CHANGED);
 		break;
 #endif
 	default:
@@ -818,10 +837,13 @@ void cnc_exec_rt_commands(void)
 			return;
 		}
 
-#ifdef ENABLE_SAFETY_DOOR_PARKING
-		if (CHECKFLAG(command, RT_CMD_DOOR_PARK))
+#if ASSERT_PIN(SAFETY_DOOR)
+		if (CHECKFLAG(command, RT_CMD_DOOR_CHANGED))
 		{
+			proto_feedback(MSG_FEEDBACK_6);
+#ifdef ENABLE_SAFETY_DOOR_PARKING
 			cnc_park();
+#endif
 		}
 #endif
 
@@ -1049,6 +1071,7 @@ bool cnc_check_interlocking(void)
 	{
 		if (!cnc_get_exec_state(EXEC_HOMING)) // if a motion is being performed allow trigger the limit switch alarm
 		{
+#if EMULATE_GRBL_STARTUP <= 2
 			if (cnc_get_exec_state(EXEC_POSITION_MAYBE_LOST))
 			{
 				cnc_alarm(EXEC_ALARM_HARD_LIMIT);
@@ -1057,6 +1080,9 @@ bool cnc_check_interlocking(void)
 			{
 				cnc_alarm(EXEC_ALARM_HARD_LIMIT_NOMOTION);
 			}
+#else
+			cnc_alarm(EXEC_ALARM_HARD_LIMIT);
+#endif
 		}
 
 		return false;
@@ -1098,7 +1124,7 @@ bool cnc_check_interlocking(void)
 		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG | EXEC_PROBING)) // flushes the buffers if motions was homing, jog
 		{
 			flush_motion = true;
-			cnc_clear_exec_state(EXEC_HOLD | EXEC_JOG);
+			cnc_clear_exec_state(EXEC_JOG | EXEC_HOLD);
 		}
 
 		if (flush_motion)
@@ -1255,7 +1281,7 @@ uint8_t cnc_get_status(void)
 		{
 			return EXEC_STATUS_HOLD_PENDING;
 		}
-#ifndef ENABLE_EXTRA_GRBL_STATES
+#ifdef ENABLE_EXTRA_GRBL_STATES
 		if (state & EXEC_RESUMING)
 		{
 			return EXEC_STATUS_HOLD_RESUMING;

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -1078,34 +1078,39 @@ bool cnc_check_interlocking(void)
 			cnc_alarm(EXEC_ALARM_HOMING_FAIL_DOOR);
 			return false;
 		}
-		else if (cnc_get_exec_state(EXEC_RUN)) // if the machined is running
-		{
-			// with the door opened put machine on HOLD
-			cnc_set_exec_state(EXEC_HOLD);
-		}
-		else // if the machined is not moving stop the tool too
-		{
-			cnc_stop(true);
-		}
+		// else if (cnc_get_exec_state(EXEC_RUN)) // if the machined is running
+		// {
+		// 	// with the door opened put machine on HOLD
+		// 	cnc_set_exec_state(EXEC_HOLD);
+		// }
+		// else // if the machined is not moving stop the tool too
+		// {
+		// 	cnc_stop(true);
+		// }
 	}
 #endif
 
 	// an hold condition is active and motion as stopped
-	if (cnc_get_exec_state(EXEC_HOLD) && !cnc_get_exec_state(EXEC_RUN))
+	if (cnc_get_exec_state(EXEC_HOLD | EXEC_RUN) == EXEC_HOLD)
 	{
-		cnc_stop(false); // stop motion
 		bool flush_motion = false;
-		
-		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG)) // flushes the buffers if motions was homing, jog
+#if ASSERT_PIN(SAFETY_DOOR)
+		if (cnc_get_exec_state(EXEC_DOOR))
+			cnc_stop(true); // stop motion
+		else
+#endif
+			cnc_stop(false); // stop motion
+
+		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG | EXEC_PROBING)) // flushes the buffers if motions was homing, jog
 		{
 			flush_motion = true;
 			cnc_clear_exec_state(EXEC_HOLD | EXEC_JOG);
 		}
-		else if (cnc_get_exec_state(EXEC_PROBING)) // if at the end of a sucessful probing
-		{
-			flush_motion = true;
-			cnc_clear_exec_state(EXEC_HOLD);
-		}
+		// else if (cnc_get_exec_state(EXEC_PROBING)) // if at the end of a sucessful probing
+		// {
+		// 	flush_motion = true;
+		// 	cnc_clear_exec_state(EXEC_HOLD);
+		// }
 
 		if (flush_motion)
 		{

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -1100,7 +1100,7 @@ bool cnc_check_interlocking(void)
 	}
 #endif
 
-	// some motion stopped
+	// motion stopped
 	if (!cnc_get_exec_state(EXEC_RUNNING) && cnc_get_exec_state(EXEC_SPECIAL_MOTIONS))
 	{
 		bool flush_motion = cnc_get_exec_state(EXEC_CANCELING);
@@ -1118,7 +1118,7 @@ bool cnc_check_interlocking(void)
 			// flush all pending commands and motions
 			mc_flush_pending_motion();
 			// homing will be cleared inside homing cycle
-			cnc_clear_exec_state(EXEC_SPECIAL_MOTIONS);
+			cnc_clear_exec_state((EXEC_JOG | EXEC_HOMING | EXEC_PROBING));
 		}
 		cnc_clear_exec_state(EXEC_CANCELING);
 		if (planner_buffer_is_empty())
@@ -1245,15 +1245,20 @@ uint8_t cnc_get_status(void)
 	if (state & EXEC_DOOR)
 	{
 		uint8_t controls = io_get_controls();
-		if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
+		if (state & EXEC_RUN)
 		{
-			return ((state & EXEC_RUN) ? EXEC_STATUS_DOOR_OPENED_PAUSING : EXEC_STATUS_DOOR_OPENED);
+			return EXEC_STATUS_DOOR_OPENED_PAUSING;
+		}
+		else if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
+		{
+			return EXEC_STATUS_DOOR_OPENED;
 		}
 		else
 		{
 			return ((state & EXEC_RUNNING) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
 		}
 	}
+
 #endif
 
 	if (state & EXEC_HOMING)

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -305,9 +305,7 @@ void cnc_store_motion(void)
 	planner_store();
 	mc_store();
 	// reset planner and sync systems
-	itp_clear();
-	planner_clear();
-	mc_sync_position();
+	mc_clear(false);
 	// clear the current hold state (if not set previosly)
 	if (!prevholdstate)
 	{
@@ -335,9 +333,7 @@ void cnc_restore_motion(void)
 	}
 
 	// reset planner and sync systems
-	itp_clear();
-	planner_clear();
-	mc_sync_position();
+	mc_clear(false);
 
 	// restore the motion controller, planner and parser
 	mc_restore();
@@ -406,9 +402,7 @@ uint8_t cnc_home(void)
 #endif
 	// sync's the motion control with the real time position
 	// this flushes the homing motion before returning from error or home success
-	itp_clear();
-	planner_clear();
-	mc_sync_position();
+	mc_clear(false);
 
 	// disables homing and reenables limits alarm messages
 	cnc_clear_exec_state(EXEC_HOMING);
@@ -630,15 +624,16 @@ void cnc_clear_exec_state(uint16_t statemask)
 			planner_spindle_ovr_reset();
 			// updated the coolant pins
 			tool_set_coolant(planner_get_coolant());
-#if (DELAY_ON_RESUME_COOLANT > 0)
-			if (!g_settings.tool_mode)
+			if (!planner_buffer_is_empty())
 			{
-				if (!planner_buffer_is_empty())
+				cnc_set_exec_state(EXEC_RESUMING);
+#if (DELAY_ON_RESUME_COOLANT > 0)
+				if (!g_settings.tool_mode)
 				{
 					cnc_dwell_ms(DELAY_ON_RESUME_COOLANT * 1000);
 				}
-			}
 #endif
+			}
 			// tries to sync the tool
 			// if something goes wrong the tool can reinstate the HOLD state
 			itp_sync_spindle();
@@ -690,8 +685,7 @@ void cnc_reset(void)
 
 	// clear all systems
 	grbl_stream_clear();
-	itp_clear();
-	planner_clear();
+	mc_clear(false);
 	kinematics_init();
 	parser_init();
 	mc_init();
@@ -1025,7 +1019,7 @@ void cnc_check_fault_systems(void)
 
 bool cnc_check_interlocking(void)
 {
-	// check all flags
+	// check all flags, update states and perform actions
 
 	// an existing KILL condition can be due to:
 	// - ESTOP trigger
@@ -1106,21 +1100,10 @@ bool cnc_check_interlocking(void)
 			flush_motion = true;
 			cnc_clear_exec_state(EXEC_HOLD | EXEC_JOG);
 		}
-		// else if (cnc_get_exec_state(EXEC_PROBING)) // if at the end of a sucessful probing
-		// {
-		// 	flush_motion = true;
-		// 	cnc_clear_exec_state(EXEC_HOLD);
-		// }
 
 		if (flush_motion)
 		{
-			itp_clear();
-			// clears the buffer but conserves the tool data
-			while (!planner_buffer_is_empty())
-			{
-				planner_discard_block();
-			}
-			mc_sync_position();
+			mc_clear(true);
 			parser_sync_position();
 			// flush all pending commands and motions
 			mc_flush_pending_motion();
@@ -1135,6 +1118,11 @@ bool cnc_check_interlocking(void)
 		{
 			cnc_clear_exec_state(EXEC_JOG);
 		}
+	}
+
+	if (cnc_get_exec_state(EXEC_RUN))
+	{
+		cnc_clear_exec_state(EXEC_RESUMING);
 	}
 
 	return true;
@@ -1256,14 +1244,24 @@ uint8_t cnc_get_status(void)
 		}
 		else
 		{
-			return ((state & EXEC_RUN) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
+			return ((state & (EXEC_RUN | EXEC_RESUMING)) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
 		}
 	}
 #endif
 
 	if (state & EXEC_HOLD)
 	{
-		return ((state & EXEC_RUN) ? EXEC_STATUS_HOLD_PENDING : EXEC_STATUS_HOLD);
+		if ((state & EXEC_RUN))
+		{
+			return EXEC_STATUS_HOLD_PENDING;
+		}
+#ifndef ENABLE_EXTRA_GRBL_STATES
+		if (state & EXEC_RESUMING)
+		{
+			return EXEC_STATUS_HOLD_RESUMING;
+		}
+#endif
+		return EXEC_STATUS_HOLD;
 	}
 
 	if (state & EXEC_HOMING)
@@ -1281,7 +1279,7 @@ uint8_t cnc_get_status(void)
 		return EXEC_STATUS_PROBING;
 	}
 
-	if ((state & EXEC_RUN))
+	if ((state & (EXEC_RUN | EXEC_RESUMING)))
 	{
 		return EXEC_STATUS_RUNNING;
 	}

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -580,6 +580,7 @@ void cnc_set_exec_state(uint16_t statemask)
 	{
 		cnc_clear_exec_state(EXEC_RESUMING); // auto clears resuming
 	}
+	
 	SETFLAG(cnc_state.exec_state, statemask);
 }
 
@@ -663,14 +664,6 @@ void cnc_clear_exec_state(uint16_t statemask)
 		}
 #endif
 #endif
-	}
-
-	if (CHECKFLAG(statemask, EXEC_RUN))
-	{
-		if (cnc_get_exec_state(EXEC_CANCELING)) // auto clears
-		{
-			SETFLAG(statemask, EXEC_CANCELING);
-		}
 	}
 
 	CLEARFLAG(cnc_state.exec_state, statemask);
@@ -1098,34 +1091,19 @@ bool cnc_check_interlocking(void)
 			cnc_alarm(EXEC_ALARM_HOMING_FAIL_DOOR);
 			return false;
 		}
-		// else if (cnc_get_exec_state(EXEC_RUN)) // if the machined is running
-		// {
-		// 	// with the door opened put machine on HOLD
-		// 	cnc_set_exec_state(EXEC_HOLD);
-		// }
-		// else // if the machined is not moving stop the tool too
-		// {
-		// 	cnc_stop(true);
-		// }
 	}
 #endif
 
-	// an hold condition is active and motion as stopped
-	if (cnc_get_exec_state(EXEC_HOLD | EXEC_RUN) == EXEC_HOLD)
+	// some motion stopped
+	if (!cnc_get_exec_state(EXEC_RUN) && cnc_get_exec_state(EXEC_JOG | EXEC_HOLD | EXEC_HOMING | EXEC_PROBING))
 	{
-		bool flush_motion = false;
+		bool flush_motion = cnc_get_exec_state(EXEC_CANCELING);
 #if ASSERT_PIN(SAFETY_DOOR)
 		if (cnc_get_exec_state(EXEC_DOOR))
 			cnc_stop(true); // stop motion
 		else
 #endif
 			cnc_stop(false); // stop motion
-
-		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG | EXEC_PROBING)) // flushes the buffers if motions was homing, jog
-		{
-			flush_motion = true;
-			cnc_clear_exec_state(EXEC_JOG | EXEC_HOLD);
-		}
 
 		if (flush_motion)
 		{
@@ -1134,15 +1112,7 @@ bool cnc_check_interlocking(void)
 			// flush all pending commands and motions
 			mc_flush_pending_motion();
 			// homing will be cleared inside homing cycle
-		}
-	}
-
-	// end of JOG
-	if (cnc_get_exec_state(EXEC_JOG | EXEC_HOLD) == EXEC_JOG)
-	{
-		if (itp_is_empty() && planner_buffer_is_empty())
-		{
-			cnc_clear_exec_state(EXEC_JOG);
+			cnc_clear_exec_state(EXEC_JOG | EXEC_HOLD | EXEC_HOMING | EXEC_CANCELING);
 		}
 	}
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -536,7 +536,7 @@ uint8_t cnc_unlock(bool force)
 		// all other alarm flags remain active if any input is still active
 		CLEARFLAG(cnc_state.exec_state, EXEC_POSITION_MAYBE_LOST);
 		// clears all other locking flags
-		cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_CONTROLLED_STOP);
+		cnc_clear_exec_state(EXEC_GCODE_LOCKED | EXEC_STOPPING);
 		// signals stepper enable pins
 
 		io_set_steps(g_settings.step_invert_mask);
@@ -580,7 +580,7 @@ void cnc_set_exec_state(uint16_t statemask)
 	{
 		cnc_clear_exec_state(EXEC_RESUMING); // auto clears resuming
 	}
-	
+
 	SETFLAG(cnc_state.exec_state, statemask);
 }
 
@@ -637,13 +637,13 @@ void cnc_clear_exec_state(uint16_t statemask)
 	// if releasing from a HOLD state with and active delay in exec
 	if (CHECKFLAG(statemask, EXEC_HOLD) && cnc_get_exec_state(EXEC_HOLD))
 	{
+		cnc_set_exec_state(EXEC_RESUMING);
 #if TOOL_COUNT > 0
 		planner_spindle_ovr_reset();
 		// updated the coolant pins
 		tool_set_coolant(planner_get_coolant());
 		if (!planner_buffer_is_empty())
 		{
-			cnc_set_exec_state(EXEC_RESUMING);
 #if (DELAY_ON_RESUME_COOLANT > 0)
 			if (!g_settings.tool_mode)
 			{
@@ -1095,7 +1095,7 @@ bool cnc_check_interlocking(void)
 #endif
 
 	// some motion stopped
-	if (!cnc_get_exec_state(EXEC_RUN) && cnc_get_exec_state(EXEC_JOG | EXEC_HOLD | EXEC_HOMING | EXEC_PROBING))
+	if (!cnc_get_exec_state(EXEC_RUNNING) && cnc_get_exec_state(EXEC_SPECIAL_MOTIONS))
 	{
 		bool flush_motion = cnc_get_exec_state(EXEC_CANCELING);
 #if ASSERT_PIN(SAFETY_DOOR)
@@ -1112,7 +1112,7 @@ bool cnc_check_interlocking(void)
 			// flush all pending commands and motions
 			mc_flush_pending_motion();
 			// homing will be cleared inside homing cycle
-			cnc_clear_exec_state(EXEC_JOG | EXEC_HOLD | EXEC_HOMING | EXEC_CANCELING);
+			cnc_clear_exec_state(EXEC_SPECIAL_MOTIONS);
 		}
 	}
 
@@ -1240,10 +1240,21 @@ uint8_t cnc_get_status(void)
 		}
 		else
 		{
-			return ((state & (EXEC_RUN | EXEC_RESUMING)) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
+			return ((state & EXEC_RUNNING) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
 		}
 	}
 #endif
+
+	if (state & EXEC_HOMING)
+	{
+		return EXEC_STATUS_HOMING;
+	}
+
+	// always return probing (even while doing the controlled stop after probe sucess)
+	if (state & EXEC_PROBING)
+	{
+		return EXEC_STATUS_PROBING;
+	}
 
 	if (state & EXEC_HOLD)
 	{
@@ -1260,22 +1271,12 @@ uint8_t cnc_get_status(void)
 		return EXEC_STATUS_HOLD;
 	}
 
-	if (state & EXEC_HOMING)
-	{
-		return EXEC_STATUS_HOMING;
-	}
-
 	if (state & EXEC_JOG)
 	{
 		return EXEC_STATUS_JOGGING;
 	}
 
-	if (state & EXEC_PROBING)
-	{
-		return EXEC_STATUS_PROBING;
-	}
-
-	if ((state & (EXEC_RUN | EXEC_RESUMING)))
+	if (state & EXEC_RUNNING)
 	{
 		return EXEC_STATUS_RUNNING;
 	}

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -556,7 +556,8 @@ uint8_t cnc_unlock(bool force)
 
 uint16_t cnc_get_exec_state(uint16_t statemask)
 {
-	return CHECKFLAG(cnc_state.exec_state, statemask);
+	uint16_t state = ATOMIC_LOAD_N(&cnc_state.exec_state, __ATOMIC_ACQUIRE);
+	return (state & statemask);
 }
 
 void cnc_set_exec_state(uint16_t statemask)
@@ -587,7 +588,7 @@ void cnc_set_exec_state(uint16_t statemask)
 		cnc_clear_exec_state(EXEC_RESUMING); // auto clears resuming
 	}
 
-	SETFLAG(cnc_state.exec_state, statemask);
+	ATOMIC_FETCH_OR(&cnc_state.exec_state, statemask, __ATOMIC_ACQ_REL);
 }
 
 void cnc_clear_exec_state(uint16_t statemask)
@@ -672,7 +673,7 @@ void cnc_clear_exec_state(uint16_t statemask)
 #endif
 	}
 
-	CLEARFLAG(cnc_state.exec_state, statemask);
+	ATOMIC_FETCH_AND(&cnc_state.exec_state, ~statemask, __ATOMIC_ACQ_REL);
 }
 
 // executes delay
@@ -1061,6 +1062,8 @@ bool cnc_check_interlocking(void)
 		{
 			cnc_alarm(EXEC_ALARM_ABORT_CYCLE);
 		}
+
+		cnc_stop(true);
 		return false;
 	}
 
@@ -1104,26 +1107,25 @@ bool cnc_check_interlocking(void)
 	if (!cnc_get_exec_state(EXEC_RUNNING) && cnc_get_exec_state(EXEC_SPECIAL_MOTIONS))
 	{
 		bool flush_motion = cnc_get_exec_state(EXEC_CANCELING);
+		if (flush_motion || planner_buffer_is_empty())
+		{
 #if ASSERT_PIN(SAFETY_DOOR)
-		if (cnc_get_exec_state(EXEC_DOOR))
-			cnc_stop(true); // stop motion
-		else
+			if (cnc_get_exec_state(EXEC_DOOR))
+				cnc_stop(true); // stop motion
+			else
 #endif
-			cnc_stop(false); // stop motion
+				cnc_stop(false); // stop motion
 
-		if (flush_motion)
-		{
-			mc_clear(true);
-			parser_sync_position();
-			// flush all pending commands and motions
-			mc_flush_pending_motion();
-			// homing will be cleared inside homing cycle
-			cnc_clear_exec_state((EXEC_JOG | EXEC_HOMING | EXEC_PROBING));
-		}
-		cnc_clear_exec_state(EXEC_CANCELING);
-		if (planner_buffer_is_empty())
-		{
-			cnc_clear_exec_state(EXEC_JOG);
+			if (flush_motion)
+			{
+				mc_clear(true);
+				parser_sync_position();
+				// flush all pending commands and motions
+				mc_flush_pending_motion();
+				// homing will be cleared inside homing cycle
+				cnc_clear_exec_state((EXEC_JOG | EXEC_HOMING | EXEC_PROBING));
+			}
+			cnc_clear_exec_state(EXEC_JOG | EXEC_CANCELING);
 		}
 	}
 

--- a/uCNC/src/cnc.c
+++ b/uCNC/src/cnc.c
@@ -35,7 +35,7 @@
 typedef struct
 {
 	// uint8_t system_state;		//signals if CNC is system_state and gcode can run
-	volatile uint8_t exec_state;
+	volatile uint16_t exec_state;
 	uint8_t loop_state;
 	volatile uint8_t rt_cmd;
 	volatile uint8_t feed_ovr_cmd;
@@ -292,7 +292,7 @@ void cnc_store_motion(void)
 {
 #ifdef ENABLE_MOTION_CONTROL_PLANNER_HIJACKING
 	// set hold and wait for motion to stop
-	uint8_t prevholdstate = cnc_get_exec_state(EXEC_HOLD);
+	uint16_t prevholdstate = cnc_get_exec_state(EXEC_HOLD);
 	cnc_set_exec_state(EXEC_HOLD);
 	while (!itp_is_empty() && cnc_get_exec_state(EXEC_RUN))
 	{
@@ -324,7 +324,7 @@ void cnc_restore_motion(void)
 {
 #ifdef ENABLE_MOTION_CONTROL_PLANNER_HIJACKING
 	// set hold and wait for motion to stop
-	uint8_t prevholdstate = cnc_get_exec_state(EXEC_HOLD);
+	uint16_t prevholdstate = cnc_get_exec_state(EXEC_HOLD);
 	cnc_set_exec_state(EXEC_HOLD);
 	while (!itp_is_empty())
 	{
@@ -560,17 +560,17 @@ uint8_t cnc_unlock(bool force)
 	return UNLOCK_OK;
 }
 
-uint8_t cnc_get_exec_state(uint8_t statemask)
+uint16_t cnc_get_exec_state(uint16_t statemask)
 {
 	return CHECKFLAG(cnc_state.exec_state, statemask);
 }
 
-void cnc_set_exec_state(uint8_t statemask)
+void cnc_set_exec_state(uint16_t statemask)
 {
 	SETFLAG(cnc_state.exec_state, statemask);
 }
 
-void cnc_clear_exec_state(uint8_t statemask)
+void cnc_clear_exec_state(uint16_t statemask)
 {
 #ifndef DISABLE_ALL_CONTROLS
 	uint8_t controls = io_get_controls();
@@ -743,6 +743,9 @@ void cnc_call_rt_command(uint8_t command)
 #if ASSERT_PIN(SAFETY_DOOR)
 	case CMD_CODE_SAFETY_DOOR:
 		cnc_set_exec_state((EXEC_HOLD | EXEC_DOOR));
+#ifdef ENABLE_SAFETY_DOOR_PARKING
+		SETFLAG(cnc_state.rt_cmd, RT_CMD_DOOR_PARK);
+#endif
 		break;
 #endif
 	default:
@@ -821,6 +824,13 @@ void cnc_exec_rt_commands(void)
 			return;
 		}
 
+#ifdef ENABLE_SAFETY_DOOR_PARKING
+		if (CHECKFLAG(command, RT_CMD_DOOR_PARK))
+		{
+			cnc_park();
+		}
+#endif
+
 		if (CHECKFLAG(command, RT_CMD_JOG_CANCEL))
 		{
 			while (grbl_stream_available())
@@ -831,12 +841,22 @@ void cnc_exec_rt_commands(void)
 					proto_error(STATUS_JOG_CANCELED);
 				}
 			}
-			return;
 		}
 
 		if (CHECKFLAG(command, RT_CMD_CYCLE_START))
 		{
-			cnc_clear_exec_state(EXEC_HOLD | EXEC_DOOR);
+#ifdef ENABLE_SAFETY_DOOR_PARKING
+			bool is_door = !!cnc_get_exec_state(EXEC_DOOR);
+#endif
+			cnc_clear_exec_state(EXEC_HOLD);
+#ifdef ENABLE_SAFETY_DOOR_PARKING
+			// if door was cleared succesfully
+			if (cnc_get_exec_state(EXEC_DOOR))
+			{
+				cnc_unpark();
+			}
+#endif
+			cnc_clear_exec_state(EXEC_DOOR);
 		}
 
 		if (CHECKFLAG(command, RT_CMD_REPORT))
@@ -1074,8 +1094,20 @@ bool cnc_check_interlocking(void)
 	if (cnc_get_exec_state(EXEC_HOLD) && !cnc_get_exec_state(EXEC_RUN))
 	{
 		cnc_stop(false); // stop motion
+		bool flush_motion = false;
+		
+		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG)) // flushes the buffers if motions was homing, jog
+		{
+			flush_motion = true;
+			cnc_clear_exec_state(EXEC_HOLD | EXEC_JOG);
+		}
+		else if (cnc_get_exec_state(EXEC_PROBING)) // if at the end of a sucessful probing
+		{
+			flush_motion = true;
+			cnc_clear_exec_state(EXEC_HOLD);
+		}
 
-		if (cnc_get_exec_state(EXEC_HOMING | EXEC_JOG)) // flushes the buffers if motions was homing or jog
+		if (flush_motion)
 		{
 			itp_clear();
 			// clears the buffer but conserves the tool data
@@ -1088,7 +1120,6 @@ bool cnc_check_interlocking(void)
 			// flush all pending commands and motions
 			mc_flush_pending_motion();
 			// homing will be cleared inside homing cycle
-			cnc_clear_exec_state(EXEC_HOLD | EXEC_JOG);
 		}
 	}
 
@@ -1184,4 +1215,76 @@ void cnc_run_startup_blocks(void)
 
 	// reset streams
 	grbl_stream_change(NULL);
+}
+
+uint8_t cnc_get_status(void)
+{
+	if (cnc_has_alarm())
+	{
+		return EXEC_STATUS_ALARM;
+	}
+
+	if (cnc_get_exec_state(EXEC_POSITION_MAYBE_LOST))
+	{
+		return ((!cnc_get_exec_state(EXEC_HOMING)) ? EXEC_STATUS_LOCKED : EXEC_STATUS_HOMING);
+	}
+
+	if (mc_get_checkmode())
+	{
+		return EXEC_STATUS_CHECK;
+	}
+
+	uint16_t state = cnc_get_exec_state(EXEC_ALLACTIVE);
+
+	if (state & EXEC_LIMITS)
+	{
+		return ((!cnc_get_exec_state(EXEC_HOMING)) ? EXEC_STATUS_ALARM : EXEC_STATUS_HOMING);
+	}
+
+#if ASSERT_PIN(SAFETY_DOOR)
+	if (state & EXEC_DOOR)
+	{
+		uint8_t controls = io_get_controls();
+		if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
+		{
+			return ((state & EXEC_RUN) ? EXEC_STATUS_DOOR_OPENED_PAUSING : EXEC_STATUS_DOOR_OPENED);
+		}
+		else
+		{
+			return ((state & EXEC_RUN) ? EXEC_STATUS_DOOR_CLOSED_RESUMING : EXEC_STATUS_DOOR_CLOSED);
+		}
+	}
+#endif
+
+	if (state & EXEC_HOLD)
+	{
+		return ((state & EXEC_RUN) ? EXEC_STATUS_HOLD_PENDING : EXEC_STATUS_HOLD);
+	}
+
+	if (state & EXEC_HOMING)
+	{
+		return EXEC_STATUS_HOMING;
+	}
+
+	if (state & EXEC_JOG)
+	{
+		return EXEC_STATUS_JOGGING;
+	}
+
+	if (state & EXEC_PROBING)
+	{
+		return EXEC_STATUS_PROBING;
+	}
+
+	if ((state & EXEC_RUN))
+	{
+		return EXEC_STATUS_RUNNING;
+	}
+
+	if (state & EXEC_DWELL)
+	{
+		return EXEC_STATUS_DWELL;
+	}
+
+	return EXEC_STATUS_IDLE;
 }

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -28,9 +28,10 @@ extern "C"
 #define RT_CMD_CLEAR 0
 
 #define RT_CMD_RESET 1
-#define RT_CMD_JOG_CANCEL 2
-#define RT_CMD_CYCLE_START 4
-#define RT_CMD_REPORT 8
+#define RT_CMD_DOOR_PARK 2
+#define RT_CMD_JOG_CANCEL 4
+#define RT_CMD_CYCLE_START 8
+#define RT_CMD_REPORT 16
 
 // feed_ovr_cmd
 #define RT_CMD_FEED_100 1
@@ -53,40 +54,25 @@ extern "C"
 
 /**
  * Flags and state changes
- *
- * EXEC_KILL
- * Set by cnc_alarm.
- * Cleared by reset or unlock depending on the the alarm priority. Cannot be cleared if ESTOP is pressed.
- *
- * EXEC_LIMITS
- * Set when at a transition of a limit switch from inactive to the active state.
- * Cleared by reset or unlock. Not affected by the limit switch state.
- *
- * EXEC_POSITION_MAYBE_LOST
- * Set when the interpolator is abruptly stopped causing the position to be lost.
- * Cleared by homing or unlock.
- *
- * EXEC_DOOR
- * Set with when the safety door pin is active or the safety door command is called.
- * Cleared by cycle resume, unlock or reset. If the door is opened it will remain active
- *
  */
 // current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0											   // All flags cleared
-#define EXEC_RUN 1											   // Motions are being executed
-#define EXEC_HOLD 2											   // Feed hold is active
-#define EXEC_JOG 4											   // Jogging in execution
-#define EXEC_HOMING 8										   // Homing in execution
-#define EXEC_DOOR 16										   // Safety door open
-#define EXEC_POSITION_MAYBE_LOST 32							   // Machine is not homed or lost position due to abrupt stop
-#define EXEC_LIMITS 64										   // Limits hit
-#define EXEC_KILL 128										   // Emergency stop
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)			   // Limit switch is active during a homing motion
-#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)	   // Interlocking check failed
-#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)	   // System alarms
-#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD) // System reset locked
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)  // Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 255									   // All states
+#define EXEC_IDLE 0x0000											   // All flags cleared
+#define EXEC_RUN 0x0001												   // Motion being executed
+#define EXEC_DWELL 0x0002											   // Dwell being executed
+#define EXEC_PROBING 0x0004											   // Probing being executed
+#define EXEC_HOLD 0x0008											   // Feed hold is active
+#define EXEC_JOG 0x0010												   // Jogging in execution
+#define EXEC_HOMING 0x0020											   // Homing in execution
+#define EXEC_DOOR 0x0100											   // The safety door was opened and the parking and hold is being executed
+#define EXEC_LIMITS 0x0200											   // The limits were hit
+#define EXEC_POSITION_MAYBE_LOST 0x4000								   // Machine is not homed or lost position due to abrupt stop
+#define EXEC_KILL 0x8000											   // Emergency stop
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)					   // Limit switch is active during a homing motion
+#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)			   // Interlocking check failed
+#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL) // System alarms
+#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD)		   // System reset locked
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)		   // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 0xFFFF										   // All states
 
 // unlock result codes
 #define UNLOCK_OK 0
@@ -175,13 +161,18 @@ extern "C"
 	void cnc_dwell_ms(uint32_t miliseconds);
 	void cnc_store_motion(void);
 	void cnc_restore_motion(void);
+#ifdef ENABLE_SAFETY_DOOR_PARKING
+	void cnc_park(void);
+	void cnc_unpark(void);
+#endif
 	uint8_t cnc_parse_cmd(void);
 	bool cnc_check_interlocking(void);
 
-	uint8_t cnc_get_exec_state(uint8_t statemask);
-	void cnc_set_exec_state(uint8_t statemask);
-	void cnc_clear_exec_state(uint8_t statemask);
+	uint16_t cnc_get_exec_state(uint16_t statemask);
+	void cnc_set_exec_state(uint16_t statemask);
+	void cnc_clear_exec_state(uint16_t statemask);
 	void cnc_call_rt_command(uint8_t command);
+	uint8_t cnc_get_status(void);
 
 #ifdef ENABLE_MAIN_LOOP_MODULES
 	// generates a default delegate, event and handler hook
@@ -189,12 +180,12 @@ extern "C"
 	DECL_EVENT_HANDLER(cnc_reset);
 	// event_cnc_dotasks_handler
 	DECL_EVENT_HANDLER(cnc_dotasks);
-	#ifndef modules_dotasks
-	#define modules_dotasks() EVENT_INVOKE(cnc_dotasks, NULL)
-	#endif
-	#ifndef cnc_modules_dotasks
-	#define cnc_modules_dotasks() modules_dotasks()
-	#endif
+#ifndef modules_dotasks
+#define modules_dotasks() EVENT_INVOKE(cnc_dotasks, NULL)
+#endif
+#ifndef cnc_modules_dotasks
+#define cnc_modules_dotasks() modules_dotasks()
+#endif
 	// event_cnc_io_dotasks_handler
 	DECL_EVENT_HANDLER(cnc_io_dotasks);
 	// event_cnc_stop_handler

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -56,28 +56,30 @@ extern "C"
  * Flags and state changes
  */
 // current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0x0000																				 // All flags cleared
-#define EXEC_RUN 0x0001																					 // Motion being executed
-#define EXEC_DWELL 0x0002																				 // Dwell being executed
-#define EXEC_PROBING 0x0004																				 // Probing being executed
-#define EXEC_HOLD 0x0008																				 // User controlled stop
-#define EXEC_CANCELING 0x0010																			 // Similar to hold (controlled stop) but auto-clears (probe success, jog canceling, etc..)
-#define EXEC_RESUMING 0x0020																			 // Resuming from any holding condition (door, hold, etc..)
-#define EXEC_JOG 0x0040																					 // Jogging in execution
-#define EXEC_HOMING 0x0080																				 // Homing in execution
-#define EXEC_DOOR 0x0100																				 // The safety door was opened and the parking and hold is being executed
-#define EXEC_LIMITS 0x0200																				 // The limits were hit
-#define EXEC_POSITION_MAYBE_LOST 0x4000																	 // Machine is not homed or lost position due to abrupt stop
-#define EXEC_KILL 0x8000																				 // Emergency stop
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)														 // Limit switch is active during a homing motion
-#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)												 // Interlocking check failed
-#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)									 // System alarms
-#define EXEC_CONTROLLED_STOP (EXEC_HOLD | EXEC_CANCELING)												 // performs a controlled stop
-#define EXEC_MOTIONS (EXEC_RUN | EXEC_DWELL | EXEC_PROBING | EXEC_HOLD | EXEC_CANCELING | EXEC_RESUMING) // Any motion state
-#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)										 // System reset locked
-#define EXEC_JOG_LOCKED (EXEC_ALARM | EXEC_DOOR)														 // Jog is locked by an alarm or any special motion state
-#define EXEC_GCODE_LOCKED (EXEC_JOG_LOCKED | EXEC_JOG)													 // Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 0xFFFF																			 // All states
+#define EXEC_IDLE 0x0000														 // All flags cleared
+#define EXEC_RUN 0x0001															 // Motion being executed
+#define EXEC_DWELL 0x0002														 // Dwell being executed
+#define EXEC_PROBING 0x0004														 // Probing being executed
+#define EXEC_HOLD 0x0008														 // User controlled stop
+#define EXEC_CANCELING 0x0010													 // Similar to hold (controlled stop) but auto-clears (probe success, jog canceling, etc..)
+#define EXEC_RESUMING 0x0020													 // Resuming from any holding condition (door, hold, etc..)
+#define EXEC_JOG 0x0040															 // Jogging in execution
+#define EXEC_HOMING 0x0080														 // Homing in execution
+#define EXEC_DOOR 0x0100														 // The safety door was opened and the parking and hold is being executed
+#define EXEC_LIMITS 0x0200														 // The limits were hit
+#define EXEC_POSITION_MAYBE_LOST 0x4000											 // Machine is not homed or lost position due to abrupt stop
+#define EXEC_KILL 0x8000														 // Emergency stop
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)								 // Limit switch is active during a homing motion
+#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)						 // Interlocking check failed
+#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)			 // System alarms
+#define EXEC_STOPPING (EXEC_HOLD | EXEC_CANCELING)								 // performs a controlled stop
+#define EXEC_RUNNING (EXEC_RUN | EXEC_RESUMING)									 // System running
+#define EXEC_MOTIONS (EXEC_RUNNING | EXEC_STOPPING | EXEC_DWELL | EXEC_PROBING)	 // Any motion state
+#define EXEC_SPECIAL_MOTIONS (EXEC_JOG | EXEC_HOMING | EXEC_PROBING | EXEC_DOOR) // Special motion modes
+#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)				 // System reset locked
+#define EXEC_JOG_LOCKED (EXEC_ALARM | EXEC_DOOR)								 // Jog is locked by an alarm or any special motion state
+#define EXEC_GCODE_LOCKED (EXEC_JOG_LOCKED | EXEC_JOG)							 // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 0xFFFF													 // All states
 
 // unlock result codes
 #define UNLOCK_OK 0

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -56,23 +56,25 @@ extern "C"
  * Flags and state changes
  */
 // current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0x0000											   // All flags cleared
-#define EXEC_RUN 0x0001												   // Motion being executed
-#define EXEC_DWELL 0x0002											   // Dwell being executed
-#define EXEC_PROBING 0x0004											   // Probing being executed
-#define EXEC_HOLD 0x0008											   // Feed hold is active
-#define EXEC_JOG 0x0010												   // Jogging in execution
-#define EXEC_HOMING 0x0020											   // Homing in execution
-#define EXEC_DOOR 0x0100											   // The safety door was opened and the parking and hold is being executed
-#define EXEC_LIMITS 0x0200											   // The limits were hit
-#define EXEC_POSITION_MAYBE_LOST 0x4000								   // Machine is not homed or lost position due to abrupt stop
-#define EXEC_KILL 0x8000											   // Emergency stop
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)					   // Limit switch is active during a homing motion
-#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)			   // Interlocking check failed
-#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL) // System alarms
-#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_HOLD)		   // System reset locked
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)		   // Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 0xFFFF										   // All states
+#define EXEC_IDLE 0x0000																						 // All flags cleared
+#define EXEC_RUN 0x0001																							 // Motion being executed
+#define EXEC_DWELL 0x0002																						 // Dwell being executed
+#define EXEC_PROBING 0x0004																						 // Probing being executed
+#define EXEC_HOLD 0x0008																						 // Feed hold is active
+#define EXEC_RESUMING 0x0010																					 // Resuming from any holding condition (door, hold, etc..)
+#define EXEC_JOG 0x0020																							 // Jogging in execution
+#define EXEC_HOMING 0x0040																						 // Homing in execution
+#define EXEC_DOOR 0x0100																						 // The safety door was opened and the parking and hold is being executed
+#define EXEC_LIMITS 0x0200																						 // The limits were hit
+#define EXEC_POSITION_MAYBE_LOST 0x4000																			 // Machine is not homed or lost position due to abrupt stop
+#define EXEC_KILL 0x8000																						 // Emergency stop
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)																 // Limit switch is active during a homing motion
+#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)														 // Interlocking check failed
+#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)											 // System alarms
+#define EXEC_MOTIONS (EXEC_RUN | EXEC_DWELL | EXEC_PROBING | EXEC_HOLD | EXEC_RESUMING | EXEC_JOG | EXEC_HOMING) // Any motion state
+#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)												 // System reset locked
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)													 // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 0xFFFF																					 // All states
 
 // unlock result codes
 #define UNLOCK_OK 0

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -72,7 +72,7 @@ extern "C"
 #define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)								 // Limit switch is active during a homing motion
 #define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)						 // Interlocking check failed
 #define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)			 // System alarms
-#define EXEC_STOPPING (EXEC_HOLD | EXEC_CANCELING)								 // performs a controlled stop
+#define EXEC_STOPPING (EXEC_DOOR | EXEC_HOLD | EXEC_CANCELING)								 // performs a controlled stop
 #define EXEC_RUNNING (EXEC_RUN | EXEC_RESUMING)									 // System running
 #define EXEC_MOTIONS (EXEC_RUNNING | EXEC_STOPPING | EXEC_DWELL | EXEC_PROBING)	 // Any motion state
 #define EXEC_SPECIAL_MOTIONS (EXEC_JOG | EXEC_HOMING | EXEC_PROBING | EXEC_DOOR) // Special motion modes

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -28,7 +28,7 @@ extern "C"
 #define RT_CMD_CLEAR 0
 
 #define RT_CMD_RESET 1
-#define RT_CMD_DOOR_PARK 2
+#define RT_CMD_DOOR_CHANGED 2
 #define RT_CMD_JOG_CANCEL 4
 #define RT_CMD_CYCLE_START 8
 #define RT_CMD_REPORT 16
@@ -56,25 +56,27 @@ extern "C"
  * Flags and state changes
  */
 // current cnc states (multiple can be active/overlapped at the same time)
-#define EXEC_IDLE 0x0000																						 // All flags cleared
-#define EXEC_RUN 0x0001																							 // Motion being executed
-#define EXEC_DWELL 0x0002																						 // Dwell being executed
-#define EXEC_PROBING 0x0004																						 // Probing being executed
-#define EXEC_HOLD 0x0008																						 // Feed hold is active
-#define EXEC_RESUMING 0x0010																					 // Resuming from any holding condition (door, hold, etc..)
-#define EXEC_JOG 0x0020																							 // Jogging in execution
-#define EXEC_HOMING 0x0040																						 // Homing in execution
-#define EXEC_DOOR 0x0100																						 // The safety door was opened and the parking and hold is being executed
-#define EXEC_LIMITS 0x0200																						 // The limits were hit
-#define EXEC_POSITION_MAYBE_LOST 0x4000																			 // Machine is not homed or lost position due to abrupt stop
-#define EXEC_KILL 0x8000																						 // Emergency stop
-#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)																 // Limit switch is active during a homing motion
-#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)														 // Interlocking check failed
-#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)											 // System alarms
-#define EXEC_MOTIONS (EXEC_RUN | EXEC_DWELL | EXEC_PROBING | EXEC_HOLD | EXEC_RESUMING | EXEC_JOG | EXEC_HOMING) // Any motion state
-#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)												 // System reset locked
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)													 // Gcode is locked by an alarm or any special motion state
-#define EXEC_ALLACTIVE 0xFFFF																					 // All states
+#define EXEC_IDLE 0x0000																				 // All flags cleared
+#define EXEC_RUN 0x0001																					 // Motion being executed
+#define EXEC_DWELL 0x0002																				 // Dwell being executed
+#define EXEC_PROBING 0x0004																				 // Probing being executed
+#define EXEC_HOLD 0x0008																				 // User controlled stop
+#define EXEC_CANCELING 0x0010																			 // Similar to hold (controlled stop) but auto-clears (probe success, jog canceling, etc..)
+#define EXEC_RESUMING 0x0020																			 // Resuming from any holding condition (door, hold, etc..)
+#define EXEC_JOG 0x0040																					 // Jogging in execution
+#define EXEC_HOMING 0x0080																				 // Homing in execution
+#define EXEC_DOOR 0x0100																				 // The safety door was opened and the parking and hold is being executed
+#define EXEC_LIMITS 0x0200																				 // The limits were hit
+#define EXEC_POSITION_MAYBE_LOST 0x4000																	 // Machine is not homed or lost position due to abrupt stop
+#define EXEC_KILL 0x8000																				 // Emergency stop
+#define EXEC_HOMING_HIT (EXEC_HOMING | EXEC_LIMITS)														 // Limit switch is active during a homing motion
+#define EXEC_INTERLOCKING_FAIL (EXEC_LIMITS | EXEC_KILL)												 // Interlocking check failed
+#define EXEC_ALARM (EXEC_POSITION_MAYBE_LOST | EXEC_INTERLOCKING_FAIL)									 // System alarms
+#define EXEC_CONTROLLED_STOP (EXEC_HOLD | EXEC_CANCELING)												 // performs a controlled stop
+#define EXEC_MOTIONS (EXEC_RUN | EXEC_DWELL | EXEC_PROBING | EXEC_HOLD | EXEC_CANCELING | EXEC_RESUMING) // Any motion state
+#define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)										 // System reset locked
+#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)											 // Gcode is locked by an alarm or any special motion state
+#define EXEC_ALLACTIVE 0xFFFF																			 // All states
 
 // unlock result codes
 #define UNLOCK_OK 0

--- a/uCNC/src/cnc.h
+++ b/uCNC/src/cnc.h
@@ -75,7 +75,8 @@ extern "C"
 #define EXEC_CONTROLLED_STOP (EXEC_HOLD | EXEC_CANCELING)												 // performs a controlled stop
 #define EXEC_MOTIONS (EXEC_RUN | EXEC_DWELL | EXEC_PROBING | EXEC_HOLD | EXEC_CANCELING | EXEC_RESUMING) // Any motion state
 #define EXEC_RESET_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_MOTIONS)										 // System reset locked
-#define EXEC_GCODE_LOCKED (EXEC_ALARM | EXEC_DOOR | EXEC_JOG)											 // Gcode is locked by an alarm or any special motion state
+#define EXEC_JOG_LOCKED (EXEC_ALARM | EXEC_DOOR)														 // Jog is locked by an alarm or any special motion state
+#define EXEC_GCODE_LOCKED (EXEC_JOG_LOCKED | EXEC_JOG)													 // Gcode is locked by an alarm or any special motion state
 #define EXEC_ALLACTIVE 0xFFFF																			 // All states
 
 // unlock result codes

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -466,7 +466,7 @@ void itp_run(void)
 		float current_speed = fast_flt_sqrt(itp_cur_plan_block->entry_feed_sqr);
 
 		// if an hold is active forces to deaccelerate
-		if (cnc_get_exec_state(EXEC_HOLD))
+		if (cnc_get_exec_state(EXEC_CONTROLLED_STOP))
 		{
 			// forces deacceleration by overriding the profile juntion points
 			accel_until = remaining_steps;
@@ -642,7 +642,7 @@ void itp_run(void)
 			// speed can't be negative
 			itp_cur_plan_block->entry_feed_sqr = 0;
 
-			if (cnc_get_exec_state(EXEC_HOLD))
+			if (cnc_get_exec_state(EXEC_CONTROLLED_STOP))
 			{
 				return;
 			}
@@ -757,7 +757,7 @@ void itp_run(void)
 #endif
 		remaining_steps -= segm_steps;
 
-		if (remaining_steps == accel_until && !cnc_get_exec_state(EXEC_HOLD)) // resets float additions error
+		if (remaining_steps == accel_until && !cnc_get_exec_state(EXEC_CONTROLLED_STOP)) // resets float additions error
 		{
 			itp_cur_plan_block->entry_feed_sqr = fast_flt_pow2(junction_speed);
 		}
@@ -1333,7 +1333,7 @@ MCU_CALLBACK void mcu_step_cb(void)
 void itp_start(bool is_synched)
 {
 	// starts the step isr if is stopped and there are segments to execute
-	if (!cnc_get_exec_state(EXEC_RUN | EXEC_HOLD | EXEC_ALARM) && !itp_sgm_is_empty()) // exec state is not hold or alarm and not already running
+	if (!cnc_get_exec_state(EXEC_RUN | EXEC_CONTROLLED_STOP | EXEC_ALARM) && !itp_sgm_is_empty()) // exec state is not hold or alarm and not already running
 	{
 		// check if the start is controlled by synched motion before start
 		if (!is_synched)

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -466,7 +466,7 @@ void itp_run(void)
 		float current_speed = fast_flt_sqrt(itp_cur_plan_block->entry_feed_sqr);
 
 		// if an hold is active forces to deaccelerate
-		if (cnc_get_exec_state(EXEC_CONTROLLED_STOP))
+		if (cnc_get_exec_state(EXEC_STOPPING))
 		{
 			// forces deacceleration by overriding the profile juntion points
 			accel_until = remaining_steps;
@@ -642,7 +642,7 @@ void itp_run(void)
 			// speed can't be negative
 			itp_cur_plan_block->entry_feed_sqr = 0;
 
-			if (cnc_get_exec_state(EXEC_CONTROLLED_STOP))
+			if (cnc_get_exec_state(EXEC_STOPPING))
 			{
 				return;
 			}
@@ -757,7 +757,7 @@ void itp_run(void)
 #endif
 		remaining_steps -= segm_steps;
 
-		if (remaining_steps == accel_until && !cnc_get_exec_state(EXEC_CONTROLLED_STOP)) // resets float additions error
+		if (remaining_steps == accel_until && !cnc_get_exec_state(EXEC_STOPPING)) // resets float additions error
 		{
 			itp_cur_plan_block->entry_feed_sqr = fast_flt_pow2(junction_speed);
 		}
@@ -1333,7 +1333,7 @@ MCU_CALLBACK void mcu_step_cb(void)
 void itp_start(bool is_synched)
 {
 	// starts the step isr if is stopped and there are segments to execute
-	if (!cnc_get_exec_state(EXEC_RUN | EXEC_CONTROLLED_STOP | EXEC_ALARM) && !itp_sgm_is_empty()) // exec state is not hold or alarm and not already running
+	if (!cnc_get_exec_state(EXEC_RUN | EXEC_STOPPING | EXEC_ALARM) && !itp_sgm_is_empty()) // exec state is not hold or alarm and not already running
 	{
 		// check if the start is controlled by synched motion before start
 		if (!is_synched)

--- a/uCNC/src/core/interpolator.c
+++ b/uCNC/src/core/interpolator.c
@@ -838,7 +838,7 @@ MCU_CALLBACK void itp_stop(void)
 	// safer to make the stoping condition block
 	ATOMIC_CODEBLOCK
 	{
-		uint8_t state = cnc_get_exec_state(EXEC_ALLACTIVE);
+		uint16_t state = cnc_get_exec_state(EXEC_ALLACTIVE);
 
 		// any stop command while running triggers an HALT alarm
 		if (state & EXEC_RUN)

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -256,7 +256,7 @@ MCU_IO_CALLBACK void mcu_probe_changed_cb(void)
 
 	// instead of stopping the machine does a controlled stop (hold)
 	// itp_stop();
-	cnc_set_exec_state(EXEC_HOLD | EXEC_RESUMING);
+	cnc_set_exec_state(EXEC_CANCELING);
 #endif
 }
 

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -480,7 +480,7 @@ void io_enable_probe(void)
 
 void io_disable_probe(void)
 {
-	cnc_clear_exec_state(EXEC_PROBING | EXEC_HOLD); // clear probe and pending hold to stop probing motion
+	cnc_clear_exec_state(EXEC_PROBING | EXEC_STOPPING); // clear probe and pending hold to stop probing motion
 #ifdef PROBE_ENABLE_CUSTOM_CALLBACK
 	if (io_probe_custom_disable)
 	{

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -450,6 +450,7 @@ io_probe_action_cb io_probe_custom_disable = NULL;
 
 void io_enable_probe(void)
 {
+	cnc_set_exec_state(EXEC_PROBING);
 #ifdef PROBE_ENABLE_CUSTOM_CALLBACK
 	if (io_probe_custom_enable)
 	{
@@ -471,6 +472,7 @@ void io_enable_probe(void)
 
 void io_disable_probe(void)
 {
+	cnc_clear_exec_state(EXEC_PROBING);
 #ifdef PROBE_ENABLE_CUSTOM_CALLBACK
 	if (io_probe_custom_disable)
 	{

--- a/uCNC/src/core/io_control.c
+++ b/uCNC/src/core/io_control.c
@@ -146,7 +146,11 @@ MCU_IO_CALLBACK void mcu_limits_changed_cb(void)
 			itp_lock_stepper(0); // unlocks axis
 #endif
 			cnc_stop(false);
+#if EMULATE_GRBL_STARTUP <= 2
 			cnc_set_exec_state(EXEC_LIMITS);
+#else
+			cnc_set_exec_state(EXEC_LIMITS | EXEC_POSITION_MAYBE_LOST);
+#endif
 #ifdef ENABLE_IO_ALARM_DEBUG
 			io_alarm_limits = limits;
 #endif
@@ -202,6 +206,10 @@ MCU_IO_CALLBACK void mcu_controls_changed_cb(void)
 		io_alarm_controls = controls;
 #endif
 	}
+	if (CHECKFLAG(changed, SAFETY_DOOR_MASK))
+	{
+		cnc_call_rt_command(CMD_CODE_SAFETY_DOOR);
+	}
 #endif
 #if ASSERT_PIN(FHOLD)
 	if (CHECKFLAG(controls, FHOLD_MASK))
@@ -248,7 +256,7 @@ MCU_IO_CALLBACK void mcu_probe_changed_cb(void)
 
 	// instead of stopping the machine does a controlled stop (hold)
 	// itp_stop();
-	cnc_set_exec_state(EXEC_HOLD);
+	cnc_set_exec_state(EXEC_HOLD | EXEC_RESUMING);
 #endif
 }
 
@@ -472,7 +480,7 @@ void io_enable_probe(void)
 
 void io_disable_probe(void)
 {
-	cnc_clear_exec_state(EXEC_PROBING);
+	cnc_clear_exec_state(EXEC_PROBING | EXEC_HOLD); // clear probe and pending hold to stop probing motion
 #ifdef PROBE_ENABLE_CUSTOM_CALLBACK
 	if (io_probe_custom_disable)
 	{

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -857,8 +857,7 @@ bool mc_home_motion(uint8_t axis_mask, bool is_origin_search, bool fast_mode)
 
 	// Flush buffers and stop motion
 	cnc_stop(false);
-	itp_clear();
-	planner_clear();
+	mc_clear(false);
 
 	// Motion completed successfully
 	return true;
@@ -910,8 +909,7 @@ bool mc_home_motion_pulloff(uint8_t axis_mask, bool fast_mode)
 
 	// Flush buffers and stop motion
 	cnc_stop(false);
-	itp_clear();
-	planner_clear();
+	mc_clear(false);
 
 	// Motion completed successfully
 	return true;
@@ -1084,12 +1082,7 @@ uint8_t mc_probe(float *target, uint8_t flags, motion_data_t *block_data)
 		;
 	// disables the probe
 	io_disable_probe();
-	itp_clear();
-	// clears the buffer but conserves the tool data
-	while (!planner_buffer_is_empty())
-	{
-		planner_discard_block();
-	}
+	mc_clear(true);
 	// clears hold
 	cnc_clear_exec_state(EXEC_HOLD);
 
@@ -1409,3 +1402,21 @@ void mc_restore(void)
 	memcpy(mc_last_target, mc_last_target_copy, sizeof(mc_last_target));
 }
 #endif
+
+void mc_clear(bool preserve_tool)
+{
+	itp_clear();
+	if (preserve_tool)
+	{
+		// clears the buffer but conserves the tool data
+		while (!planner_buffer_is_empty())
+		{
+			planner_discard_block();
+		}
+	}
+	else
+	{
+		planner_clear();
+	}
+	mc_sync_position();
+}

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -847,6 +847,7 @@ bool mc_home_motion(uint8_t axis_mask, bool is_origin_search, bool fast_mode)
 	{
 		return false;
 	}
+	
 	mc_line(target, &block_data);
 	itp_sync();
 	if (cnc_get_exec_state(EXEC_HOMING_HIT) != EXEC_HOMING_HIT)
@@ -972,7 +973,7 @@ uint8_t mc_home_axis(uint8_t axis_mask, uint8_t axis_limit)
 			return STATUS_CRITICAL_FAIL;
 		}
 
-		cnc_delay_ms(g_settings.debounce_ms); // adds a delay before reading io pin (debounce)
+		cnc_dwell_ms(g_settings.debounce_ms); // adds a delay before reading io pin (debounce)
 		limits_flags = io_get_limits();
 
 		// the wrong switch was activated bails
@@ -988,10 +989,10 @@ uint8_t mc_home_axis(uint8_t axis_mask, uint8_t axis_limit)
 		{
 			return STATUS_CRITICAL_FAIL;
 		}
-		io_enable_limits(); // temporary limits disable
 
-		cnc_delay_ms(g_settings.debounce_ms); // adds a delay before reading io pin (debounce)
-		limits_flags = io_get_raw_limits();
+		cnc_dwell_ms(g_settings.debounce_ms); // adds a delay before reading io pin (debounce)
+		io_enable_limits(); // temporary limits disable
+		limits_flags = io_get_raw_limits(); // get the raw (unfiltered values)
 
 		// all limits should be cleared
 		if (limits_flags)

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -763,8 +763,10 @@ uint8_t mc_dwell(motion_data_t *block_data)
 {
 	if (!mc_checkmode) // check mode (gcode simulation) doesn't send code to planner
 	{
+		cnc_set_exec_state(EXEC_DWELL);
 		mc_update_tools(block_data);
 		cnc_dwell_ms(block_data->dwell);
+		cnc_clear_exec_state(EXEC_DWELL);
 	}
 
 	return STATUS_OK;
@@ -1126,7 +1128,7 @@ void mc_sync_position(void)
 uint8_t mc_incremental_jog(float *target_offset, motion_data_t *block_data)
 {
 	float new_target[AXIS_COUNT];
-	uint8_t state = cnc_get_exec_state(EXEC_ALLACTIVE);
+	uint16_t state = cnc_get_exec_state(EXEC_ALLACTIVE);
 
 	if ((state & ~EXEC_JOG) || cnc_has_alarm()) // if any other than idle or jog discards the command
 	{

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -1083,8 +1083,6 @@ uint8_t mc_probe(float *target, uint8_t flags, motion_data_t *block_data)
 	// disables the probe
 	io_disable_probe();
 	mc_clear(true);
-	// clears hold
-	cnc_clear_exec_state(EXEC_HOLD);
 
 	// sync the position of the motion control
 	mc_sync_position();

--- a/uCNC/src/core/motion_control.c
+++ b/uCNC/src/core/motion_control.c
@@ -852,6 +852,7 @@ bool mc_home_motion(uint8_t axis_mask, bool is_origin_search, bool fast_mode)
 	if (cnc_get_exec_state(EXEC_HOMING_HIT) != EXEC_HOMING_HIT)
 	{
 		// Home finding failed
+		cnc_set_exec_state(EXEC_POSITION_MAYBE_LOST);
 		return false;
 	}
 

--- a/uCNC/src/core/motion_control.h
+++ b/uCNC/src/core/motion_control.h
@@ -93,6 +93,7 @@ extern "C"
 #endif
 
 	void mc_init(void);
+	void mc_clear(bool preserve_tool);
 	bool mc_get_checkmode(void);
 	bool mc_toogle_checkmode(void);
 

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -205,13 +205,13 @@ uint8_t parser_read_command(void)
 	{
 		is_jogging = true;
 	}
-	else if (cnc_get_exec_state(~(EXEC_RUN | EXEC_HOLD)) || cnc_has_alarm()) // if any other than idle, run or hold discards the command
+	else if (cnc_get_exec_state(EXEC_GCODE_LOCKED) || cnc_has_alarm()) // if any other than idle, run or hold discards the command
 	{
 		parser_discard_command();
 		return STATUS_SYSTEM_GC_LOCK;
 	}
 
-	if (cnc_get_exec_state(EXEC_JOG) && !is_jogging) // error if trying to do a normal move with jog active
+	if (cnc_get_exec_state(EXEC_JOG_LOCKED) && !is_jogging) // error if trying to do a normal move with jog active
 	{
 		return STATUS_SYSTEM_GC_LOCK;
 	}
@@ -2096,11 +2096,6 @@ static uint8_t parser_gcode_command(bool is_jogging)
 		return result;
 	}
 
-	if (is_jogging)
-	{
-		cnc_set_exec_state(EXEC_JOG);
-	}
-
 	// validates command
 	result = parser_validate_command(&next_state, &words, &cmd);
 	if (result != STATUS_OK)
@@ -2137,6 +2132,9 @@ static uint8_t parser_gcode_command(bool is_jogging)
 			parser_reset(false);
 		}
 #endif
+	}
+	else{
+		cnc_set_exec_state(EXEC_JOG);
 	}
 
 	return result;

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -2098,6 +2098,10 @@ static uint8_t parser_gcode_command(bool is_jogging)
 		parser_discard_command();
 		return result;
 	}
+	
+	if(is_jogging){
+		cnc_set_exec_state(EXEC_JOG);
+	}
 
 	// validates command
 	result = parser_validate_command(&next_state, &words, &cmd);
@@ -2135,9 +2139,6 @@ static uint8_t parser_gcode_command(bool is_jogging)
 			parser_reset(false);
 		}
 #endif
-	}
-	else{
-		cnc_set_exec_state(EXEC_JOG);
 	}
 
 	return result;

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -1225,7 +1225,7 @@ static uint8_t parser_validate_command(parser_state_t *new_state, parser_words_t
 		}
 
 		// group 5 - feed rate mode
-		if (requires_feed && has_axis && !cmd->group_extended)
+		if (requires_feed && has_axis && !cmd->group_extended || cnc_get_exec_state(EXEC_JOG))
 		{
 			if (!CHECKFLAG(cmd->words, GCODE_WORD_F))
 			{

--- a/uCNC/src/core/parser.c
+++ b/uCNC/src/core/parser.c
@@ -2051,6 +2051,9 @@ static uint8_t parser_exec_command(parser_state_t *new_state, parser_words_t *wo
 		{
 			cnc_stop(true);
 			proto_feedback(MSG_FEEDBACK_8);
+			#ifndef DISABLE_ENDPROGRAM_LOCK
+			cnc_set_exec_state(EXEC_POSITION_MAYBE_LOST);
+			#endif
 		}
 	}
 

--- a/uCNC/src/core/planner.c
+++ b/uCNC/src/core/planner.c
@@ -576,7 +576,7 @@ void planner_spindle_ovr(uint8_t value)
 
 void planner_spindle_ovr_toggle(void)
 {
-	if (cnc_get_exec_state(EXEC_HOLD | EXEC_DOOR | EXEC_RUN) == EXEC_HOLD) // only available if a TRUE hold is active
+	if (cnc_get_exec_state(EXEC_MOTIONS | EXEC_DOOR) == EXEC_HOLD) // only available if a TRUE hold is active
 	{
 		uint8_t newstate = spindle_override ^ g_planner_state.state_flags.bit.spindle_running;
 		if (newstate)
@@ -589,7 +589,7 @@ void planner_spindle_ovr_toggle(void)
 
 void planner_spindle_ovr_reset(void)
 {
-	if (cnc_get_exec_state(EXEC_HOLD | EXEC_DOOR | EXEC_RUN) == EXEC_HOLD) // only available if a TRUE hold is active
+	if (cnc_get_exec_state(EXEC_MOTIONS | EXEC_DOOR) == EXEC_HOLD) // only available if a TRUE hold is active
 	{
 		if (g_planner_state.state_flags.bit.spindle_running && spindle_override)
 		{

--- a/uCNC/src/hal/boards/avr/boardmap_uno.h
+++ b/uCNC/src/hal/boards/avr/boardmap_uno.h
@@ -61,20 +61,20 @@ extern "C"
 #define DIR0_PORT D // assigns DIR0 port
 
 // Setup limit pins
-#define LIMIT_Z_BIT 4	 // assigns LIMIT_Z pin
+#define LIMIT_Z_BIT 4  // assigns LIMIT_Z pin
 #define LIMIT_Z_PORT B // assigns LIMIT_Z port
-#define LIMIT_Z_ISR 4	 // assigns LIMIT_Z ISR
-											 // #define LIMIT_Y2_BIT 4 //Z and second Y limit share the pin
-											 // #define LIMIT_Y2_PORT B //Z and second Y limit share the pin
-											 // #define LIMIT_Y2_ISR 0 //Z and second Y limit share the pin
+#define LIMIT_Z_ISR 4  // assigns LIMIT_Z ISR
+					   // #define LIMIT_Y2_BIT 4 //Z and second Y limit share the pin
+					   // #define LIMIT_Y2_PORT B //Z and second Y limit share the pin
+					   // #define LIMIT_Y2_ISR 0 //Z and second Y limit share the pin
 
-#define LIMIT_Y_BIT 2	 // assigns LIMIT_Y pin
+#define LIMIT_Y_BIT 2  // assigns LIMIT_Y pin
 #define LIMIT_Y_PORT B // assigns LIMIT_Y port
-#define LIMIT_Y_ISR 2	 // assigns LIMIT_Y ISR
+#define LIMIT_Y_ISR 2  // assigns LIMIT_Y ISR
 
-#define LIMIT_X_BIT 1	 // assigns LIMIT_X pin
+#define LIMIT_X_BIT 1  // assigns LIMIT_X pin
 #define LIMIT_X_PORT B // assigns LIMIT_X port
-#define LIMIT_X_ISR 1	 // assigns LIMIT_X ISR
+#define LIMIT_X_ISR 1  // assigns LIMIT_X ISR
 
 // Setup probe pin
 #define PROBE_BIT 5
@@ -185,6 +185,10 @@ extern "C"
 
 #ifndef DISABLE_SAFE_SETTINGS
 #define DISABLE_SAFE_SETTINGS
+#endif
+
+#ifndef DISABLE_PATH_MODES
+#define DISABLE_PATH_MODES
 #endif
 
 // required to recuce code size

--- a/uCNC/src/hal/boards/avr/boardmap_uno.h
+++ b/uCNC/src/hal/boards/avr/boardmap_uno.h
@@ -183,6 +183,10 @@ extern "C"
 #define PRINT_FTM_MINIMAL
 #endif
 
+#ifndef DISABLE_SAFE_SETTINGS
+#define DISABLE_SAFE_SETTINGS
+#endif
+
 // required to recuce code size
 #define DISABLE_ITP_STEP_GEN_OPTIMIZATIONS
 #define DISABLE_COORDINATES_SYSTEM_RAM

--- a/uCNC/src/interface/grbl_interface.h
+++ b/uCNC/src/interface/grbl_interface.h
@@ -165,16 +165,17 @@ extern "C"
 #define EXEC_STATUS_DWELL 2					// status code waiting for dwell
 #define EXEC_STATUS_RUNNING 3				// status code gcode running
 #define EXEC_STATUS_JOGGING 4				// status code jogging motion
-#define EXEC_STATUS_HOLD 5					// status code holding enabled (no motion)
-#define EXEC_STATUS_HOLD_PENDING 6			// status code holding enabled (in motion)
-#define EXEC_STATUS_HOMING 7				// status code homing motion
-#define EXEC_STATUS_DOOR_CLOSED 8			// status code holding enabled (no motion) from safety door (safety door no longer active)
-#define EXEC_STATUS_DOOR_OPENED 9			// status code holding enabled (in motion) from safety door (safety door no longer active)
-#define EXEC_STATUS_DOOR_OPENED_PAUSING 10	// status code holding enabled (in motion) from safety door (safety door still active)
-#define EXEC_STATUS_DOOR_CLOSED_RESUMING 11 // status code holding enabled (in motion) from safety door (safety door still active)
-#define EXEC_STATUS_CHECK 12				// status code check mode
-#define EXEC_STATUS_LOCKED 13				// status code gcode locked
-#define EXEC_STATUS_ALARM 14				// status code alarm mode
+#define EXEC_STATUS_HOLD 10					// status code holding enabled (stopped)
+#define EXEC_STATUS_HOLD_PENDING 11			// status code holding enabled (pausing)
+#define EXEC_STATUS_HOLD_RESUMING 12		// status code holding enabled (resuming)
+#define EXEC_STATUS_HOMING 20				// status code homing motion
+#define EXEC_STATUS_DOOR_CLOSED 30			// status code holding enabled (stopped) from safety door (safety door no longer active)
+#define EXEC_STATUS_DOOR_OPENED 31			// status code holding enabled (stopped) from safety door (safety door no longer active)
+#define EXEC_STATUS_DOOR_OPENED_PAUSING 32	// status code holding enabled (pausing) from safety door (safety door still active)
+#define EXEC_STATUS_DOOR_CLOSED_RESUMING 33 // status code holding enabled (resuming) from safety door (safety door still active)
+#define EXEC_STATUS_CHECK 40				// status code check mode
+#define EXEC_STATUS_LOCKED 50				// status code gcode locked
+#define EXEC_STATUS_ALARM 60				// status code alarm mode
 
 #ifndef DISABLE_SAFE_SETTINGS
 #define EXEC_ALARM_SETTINGS_READ_ERROR -3

--- a/uCNC/src/interface/grbl_interface.h
+++ b/uCNC/src/interface/grbl_interface.h
@@ -83,9 +83,9 @@ extern "C"
 #define STATUS_GCODE_INVALID_TARGET 33
 #define STATUS_GCODE_ARC_RADIUS_ERROR 34
 #define STATUS_GCODE_NO_OFFSETS_IN_PLANE 35
-#define STATUS_GCODE_UNUSED_WORDS 36					 //
+#define STATUS_GCODE_UNUSED_WORDS 36		   //
 #define STATUS_GCODE_G43_DYNAMIC_AXIS_ERROR 37 //
-#define STATUS_GCODE_MAX_VALUE_EXCEEDED 38		 //
+#define STATUS_GCODE_MAX_VALUE_EXCEEDED 38	   //
 // additional codes
 #define STATUS_BAD_COMMENT_FORMAT 39
 #define STATUS_INVALID_TOOL 40
@@ -144,21 +144,37 @@ extern "C"
 #define EXEC_ALARM_EMERGENCY_STOP -126
 #define EXEC_ALARM_NOALARM 0
 // Grbl alarm codes. Valid values (1-255). Zero is reserved for the reset alarm.
-#define EXEC_ALARM_HARD_LIMIT 1										 // hard limits hit while in motion other then homing
-#define EXEC_ALARM_SOFT_LIMIT 2										 // target is off bounds of the machine kinematics
-#define EXEC_ALARM_ABORT_CYCLE 3									 // an abort command was issued
-#define EXEC_ALARM_PROBE_FAIL_INITIAL 4						 // probe was already triggered and was not able to initialize probing
-#define EXEC_ALARM_PROBE_FAIL_CONTACT 5						 // probe failed to triggered before reaching the limit target
-#define EXEC_ALARM_HOMING_FAIL_RESET 6						 // homing was aborted by a reset command
-#define EXEC_ALARM_HOMING_FAIL_DOOR 7							 // door was opened during homing motion
-#define EXEC_ALARM_HOMING_FAIL_PULLOFF 8					 // homing limits failed to normalize after retract by pull-distance
-#define EXEC_ALARM_HOMING_FAIL_APPROACH 9					 // homing limits failed make initial contact
-#define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10		 // homing limits failed make initial contact (self squaring)
-#define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11		 // homing could not start since one of the limits was already triggered
-#define EXEC_ALARM_SPINDLE_SYNC_FAIL 12						 // failed to achieve spindle sync speed
-#define EXEC_ALARM_HARD_LIMIT_NOMOTION 13					 // hard limits were triggered without any motion (position was not lost)
+#define EXEC_ALARM_HARD_LIMIT 1					   // hard limits hit while in motion other then homing
+#define EXEC_ALARM_SOFT_LIMIT 2					   // target is off bounds of the machine kinematics
+#define EXEC_ALARM_ABORT_CYCLE 3				   // an abort command was issued
+#define EXEC_ALARM_PROBE_FAIL_INITIAL 4			   // probe was already triggered and was not able to initialize probing
+#define EXEC_ALARM_PROBE_FAIL_CONTACT 5			   // probe failed to triggered before reaching the limit target
+#define EXEC_ALARM_HOMING_FAIL_RESET 6			   // homing was aborted by a reset command
+#define EXEC_ALARM_HOMING_FAIL_DOOR 7			   // door was opened during homing motion
+#define EXEC_ALARM_HOMING_FAIL_PULLOFF 8		   // homing limits failed to normalize after retract by pull-distance
+#define EXEC_ALARM_HOMING_FAIL_APPROACH 9		   // homing limits failed make initial contact
+#define EXEC_ALARM_HOMING_FAIL_DUAL_APPROACH 10	   // homing limits failed make initial contact (self squaring)
+#define EXEC_ALARM_HOMING_FAIL_LIMIT_ACTIVE 11	   // homing could not start since one of the limits was already triggered
+#define EXEC_ALARM_SPINDLE_SYNC_FAIL 12			   // failed to achieve spindle sync speed
+#define EXEC_ALARM_HARD_LIMIT_NOMOTION 13		   // hard limits were triggered without any motion (position was not lost)
 #define EXEC_ALARM_PLASMA_THC_ARC_START_FAILURE 14 // failed to start arc with plasma THC
-#define EXEC_ALARM_ATC_ERROR 15 // an error ocurrer while executing a tool change via the tool changer gcode
+#define EXEC_ALARM_ATC_ERROR 15					   // an error ocurrer while executing a tool change via the tool changer gcode
+
+#define EXEC_STATUS_IDLE 0					// status code idle
+#define EXEC_STATUS_PROBING 1				// status code doing probe motion
+#define EXEC_STATUS_DWELL 2					// status code waiting for dwell
+#define EXEC_STATUS_RUNNING 3				// status code gcode running
+#define EXEC_STATUS_JOGGING 4				// status code jogging motion
+#define EXEC_STATUS_HOLD 5					// status code holding enabled (no motion)
+#define EXEC_STATUS_HOLD_PENDING 6			// status code holding enabled (in motion)
+#define EXEC_STATUS_HOMING 7				// status code homing motion
+#define EXEC_STATUS_DOOR_CLOSED 8			// status code holding enabled (no motion) from safety door (safety door no longer active)
+#define EXEC_STATUS_DOOR_OPENED 9			// status code holding enabled (in motion) from safety door (safety door no longer active)
+#define EXEC_STATUS_DOOR_OPENED_PAUSING 10	// status code holding enabled (in motion) from safety door (safety door still active)
+#define EXEC_STATUS_DOOR_CLOSED_RESUMING 11 // status code holding enabled (in motion) from safety door (safety door still active)
+#define EXEC_STATUS_CHECK 12				// status code check mode
+#define EXEC_STATUS_LOCKED 13				// status code gcode locked
+#define EXEC_STATUS_ALARM 14				// status code alarm mode
 
 #ifndef DISABLE_SAFE_SETTINGS
 #define EXEC_ALARM_SETTINGS_READ_ERROR -3
@@ -218,6 +234,11 @@ extern "C"
 #define MSG_STATUS_RUN __romstr__("Run")
 #define MSG_STATUS_IDLE __romstr__("Idle")
 #define MSG_STATUS_CHECK __romstr__("Check")
+#ifdef ENABLE_EXTRA_GRBL_STATES
+#define MSG_STATUS_LOCKED __romstr__("Locked")
+#define MSG_STATUS_PROBE __romstr__("Probe")
+#define MSG_STATUS_DWELL __romstr__("Dwell")
+#endif
 
 #if AXIS_COUNT == 1
 #define MSG_AXIS "%1f,0,0"

--- a/uCNC/src/interface/grbl_protocol.c
+++ b/uCNC/src/interface/grbl_protocol.c
@@ -412,92 +412,96 @@ void proto_status(void)
 	uint8_t controls = io_get_controls();
 	uint8_t limits = io_get_raw_limits();
 	bool probe = io_get_probe();
-	uint8_t state = cnc_get_exec_state(0xFF);
-	uint8_t filter = 0x80;
-	while (!(state & filter) && filter)
-	{
-		filter >>= 1;
-	}
-
-	state &= filter;
-
+	uint8_t state = cnc_get_status();
 	proto_putc('<');
-	if (cnc_has_alarm())
+	bool pending = false;
+	bool door_opened = false;
+
+	switch (state)
 	{
-		proto_puts(MSG_STATUS_ALARM);
-	}
-	else if (mc_get_checkmode())
-	{
-		proto_puts(MSG_STATUS_CHECK);
-	}
-	else
-	{
-		switch (state)
-		{
-#if ASSERT_PIN(SAFETY_DOOR)
-		case EXEC_DOOR:
-			proto_puts(MSG_STATUS_DOOR);
-			proto_putc(':');
-			if (CHECKFLAG(controls, SAFETY_DOOR_MASK))
-			{
-				if (cnc_get_exec_state(EXEC_RUN))
-				{
-					proto_putc('2');
-				}
-				else
-				{
-					proto_putc('1');
-				}
-			}
-			else
-			{
-				if (cnc_get_exec_state(EXEC_RUN))
-				{
-					proto_putc('3');
-				}
-				else
-				{
-					proto_putc('0');
-				}
-			}
-			break;
+	case EXEC_STATUS_ALARM:
+#ifndef ENABLE_EXTRA_GRBL_STATES
+	case EXEC_STATUS_LOCKED:
 #endif
-		case EXEC_POSITION_MAYBE_LOST:
-		case EXEC_LIMITS:
-			if (!cnc_get_exec_state(EXEC_HOMING))
-			{
-				proto_puts(MSG_STATUS_ALARM);
-			}
-			else
-			{
-				proto_puts(MSG_STATUS_HOME);
-			}
-			break;
-		case EXEC_HOLD:
-			proto_puts(MSG_STATUS_HOLD);
-			proto_putc(':');
-			if (cnc_get_exec_state(EXEC_RUN))
-			{
-				proto_putc('1');
-			}
-			else
-			{
-				proto_putc('0');
-			}
-			break;
-		case EXEC_HOMING:
-			proto_puts(MSG_STATUS_HOME);
-			break;
-		case EXEC_JOG:
-			proto_puts(MSG_STATUS_JOG);
-			break;
-		case EXEC_RUN:
-			proto_puts(MSG_STATUS_RUN);
-			break;
-		default:
-			proto_puts(MSG_STATUS_IDLE);
-			break;
+		proto_puts(MSG_STATUS_ALARM);
+		break;
+#ifdef ENABLE_EXTRA_GRBL_STATES
+	case EXEC_STATUS_LOCKED:
+		proto_puts(MSG_STATUS_LOCKED);
+		break;
+#endif
+	case EXEC_STATUS_CHECK:
+		proto_puts(MSG_STATUS_CHECK);
+		break;
+#if ASSERT_PIN(SAFETY_DOOR)
+	case EXEC_STATUS_DOOR_OPENED_PAUSING:
+		pending = true;
+		__FALL_THROUGH__
+	case EXEC_STATUS_DOOR_OPENED:
+		proto_puts(MSG_STATUS_DOOR);
+		proto_putc(':');
+		if (pending)
+		{
+			proto_putc('2');
 		}
+		else
+		{
+			proto_putc('1');
+		}
+		break;
+	case EXEC_STATUS_DOOR_CLOSED_RESUMING:
+		pending = true;
+		__FALL_THROUGH__
+	case EXEC_STATUS_DOOR_CLOSED:
+		proto_puts(MSG_STATUS_DOOR);
+		proto_putc(':');
+		if (pending)
+		{
+			proto_putc('3');
+		}
+		else
+		{
+			proto_putc('0');
+		}
+		break;
+#endif
+	case EXEC_STATUS_HOMING:
+		proto_puts(MSG_STATUS_HOME);
+		break;
+	case EXEC_STATUS_HOLD_PENDING:
+		pending = true;
+		__FALL_THROUGH__
+	case EXEC_STATUS_HOLD:
+		proto_puts(MSG_STATUS_HOLD);
+		proto_putc(':');
+		if (pending)
+		{
+			proto_putc('1');
+		}
+		else
+		{
+			proto_putc('0');
+		}
+		break;
+	case EXEC_STATUS_JOGGING:
+		proto_puts(MSG_STATUS_JOG);
+		break;
+	case EXEC_STATUS_DWELL:
+#ifdef ENABLE_EXTRA_GRBL_STATES
+		proto_puts(MSG_STATUS_DWELL);
+		break;
+#endif
+	case EXEC_STATUS_PROBING:
+#ifdef ENABLE_EXTRA_GRBL_STATES
+		proto_puts(MSG_STATUS_PROBE);
+		break;
+#endif
+	case EXEC_STATUS_RUNNING:
+		proto_puts(MSG_STATUS_RUN);
+		break;
+	case EXEC_STATUS_IDLE:
+		proto_puts(MSG_STATUS_IDLE);
+		break;
 	}
 
 	proto_putc('|');

--- a/uCNC/src/interface/grbl_protocol.c
+++ b/uCNC/src/interface/grbl_protocol.c
@@ -414,8 +414,6 @@ void proto_status(void)
 	bool probe = io_get_probe();
 	uint8_t state = cnc_get_status();
 	proto_putc('<');
-	bool pending = false;
-	bool door_opened = false;
 
 	switch (state)
 	{
@@ -435,53 +433,23 @@ void proto_status(void)
 		break;
 #if ASSERT_PIN(SAFETY_DOOR)
 	case EXEC_STATUS_DOOR_OPENED_PAUSING:
-		pending = true;
-		__FALL_THROUGH__
 	case EXEC_STATUS_DOOR_OPENED:
-		proto_puts(MSG_STATUS_DOOR);
-		proto_putc(':');
-		if (pending)
-		{
-			proto_putc('2');
-		}
-		else
-		{
-			proto_putc('1');
-		}
-		break;
 	case EXEC_STATUS_DOOR_CLOSED_RESUMING:
-		pending = true;
-		__FALL_THROUGH__
 	case EXEC_STATUS_DOOR_CLOSED:
 		proto_puts(MSG_STATUS_DOOR);
 		proto_putc(':');
-		if (pending)
-		{
-			proto_putc('3');
-		}
-		else
-		{
-			proto_putc('0');
-		}
 		break;
 #endif
 	case EXEC_STATUS_HOMING:
 		proto_puts(MSG_STATUS_HOME);
 		break;
-	case EXEC_STATUS_HOLD_PENDING:
-		pending = true;
-		__FALL_THROUGH__
 	case EXEC_STATUS_HOLD:
+	case EXEC_STATUS_HOLD_PENDING:
+#ifdef ENABLE_EXTRA_GRBL_STATES
+	case EXEC_STATUS_HOLD_RESUMING:
+#endif
 		proto_puts(MSG_STATUS_HOLD);
 		proto_putc(':');
-		if (pending)
-		{
-			proto_putc('1');
-		}
-		else
-		{
-			proto_putc('0');
-		}
 		break;
 	case EXEC_STATUS_JOGGING:
 		proto_puts(MSG_STATUS_JOG);
@@ -501,6 +469,35 @@ void proto_status(void)
 		break;
 	case EXEC_STATUS_IDLE:
 		proto_puts(MSG_STATUS_IDLE);
+		break;
+	}
+
+	switch (state)
+	{
+#if ASSERT_PIN(SAFETY_DOOR)
+	case EXEC_STATUS_DOOR_OPENED_PAUSING:
+		proto_putc('2');
+		break;
+	case EXEC_STATUS_DOOR_OPENED:
+		proto_putc('1');
+		break;
+	case EXEC_STATUS_DOOR_CLOSED_RESUMING:
+		proto_putc('3');
+		break;
+	case EXEC_STATUS_DOOR_CLOSED:
+		proto_putc('0');
+		break;
+#endif
+#ifdef ENABLE_EXTRA_GRBL_STATES
+	case EXEC_STATUS_HOLD_RESUMING:
+		proto_putc('2');
+		break;
+#endif
+	case EXEC_STATUS_HOLD_PENDING:
+		proto_putc('1');
+		break;
+	case EXEC_STATUS_HOLD:
+		proto_putc('0');
 		break;
 	}
 


### PR DESCRIPTION
General revision to the µCNC internal control state and interlocking checking. This allows better state tracking and solves some status message bugs.
The changes include:
   - Internal states revision (8bit to 16bit)
   - added 3 new extended Grbl states (optional) (Dweel, Probe, Locked, Hold:2 - Resuming from hold)
   - Added skeleton for Security Door Parking
