### PR TITLE
Fix disable behavior of limit switches when LIMIT_[AXIS]_DISABLE is d…

### DIFF
--- a/uCNC/src/cnc_hal_config_helper.h
+++ b/uCNC/src/cnc_hal_config_helper.h
@@ -1746,17 +1746,26 @@ extern "C"
 #endif
 
 // set default limits and step associations
-#if ASSERT_PIN(LIMIT_X) && !defined(LIMIT_X_IO_MASK)
+#ifndef LIMIT_X
+#undef LIMIT_X_IO_MASK
+#define LIMIT_X_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_X) && !defined(LIMIT_X_IO_MASK)
 #define LIMIT_X_IO_MASK STEP0_IO_MASK
 #elif !defined(LIMIT_X_IO_MASK)
 #define LIMIT_X_IO_MASK STEP_UNDEF_IO_MASK
 #endif
-#if ASSERT_PIN(LIMIT_Y) && !defined(LIMIT_Y_IO_MASK) && (AXIS_COUNT > 1)
+#ifndef LIMIT_Y
+#undef LIMIT_Y_IO_MASK
+#define LIMIT_Y_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_Y) && !defined(LIMIT_Y_IO_MASK) && (AXIS_COUNT > 1)
 #define LIMIT_Y_IO_MASK STEP1_IO_MASK
 #elif !defined(LIMIT_Y_IO_MASK)
 #define LIMIT_Y_IO_MASK STEP_UNDEF_IO_MASK
 #endif
-#if ASSERT_PIN(LIMIT_Z) && !defined(LIMIT_Z_IO_MASK) && (AXIS_COUNT > 2)
+#ifndef LIMIT_Z
+#undef LIMIT_Z_IO_MASK
+#define LIMIT_Z_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_Z) && !defined(LIMIT_Z_IO_MASK) && (AXIS_COUNT > 2)
 #define LIMIT_Z_IO_MASK STEP2_IO_MASK
 #elif !defined(LIMIT_Z_IO_MASK)
 #define LIMIT_Z_IO_MASK STEP_UNDEF_IO_MASK
@@ -1776,17 +1785,26 @@ extern "C"
 #elif !defined(LIMIT_C_IO_MASK)
 #define LIMIT_C_IO_MASK STEP_UNDEF_IO_MASK
 #endif
-#if ASSERT_PIN(LIMIT_X2) && !defined(LIMIT_X2_IO_MASK)
+#ifndef LIMIT_X2
+#undef LIMIT_X2_IO_MASK
+#define LIMIT_X2_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_X2) && !defined(LIMIT_X2_IO_MASK)
 #define LIMIT_X2_IO_MASK STEP0_IO_MASK
 #elif !defined(LIMIT_X2_IO_MASK)
 #define LIMIT_X2_IO_MASK STEP_UNDEF_IO_MASK
 #endif
-#if ASSERT_PIN(LIMIT_Y2) && !defined(LIMIT_Y2_IO_MASK)
+#ifndef LIMIT_Y2
+#undef LIMIT_Y2_IO_MASK
+#define LIMIT_Y2_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_Y2) && !defined(LIMIT_Y2_IO_MASK)
 #define LIMIT_Y2_IO_MASK STEP1_IO_MASK
 #elif !defined(LIMIT_Y2_IO_MASK)
 #define LIMIT_Y2_IO_MASK STEP_UNDEF_IO_MASK
 #endif
-#if ASSERT_PIN(LIMIT_Z2) && !defined(LIMIT_Z2_IO_MASK)
+#ifndef LIMIT_Z2
+#undef LIMIT_Z2_IO_MASK
+#define LIMIT_Z2_IO_MASK STEP_UNDEF_IO_MASK
+#elif ASSERT_PIN(LIMIT_Z2) && !defined(LIMIT_Z2_IO_MASK)
 #define LIMIT_Z2_IO_MASK STEP2_IO_MASK
 #elif !defined(LIMIT_Z2_IO_MASK)
 #define LIMIT_Z2_IO_MASK STEP_UNDEF_IO_MASK


### PR DESCRIPTION
## Description

Fixes a bug where the limit switches are not disabled even when `LIMIT_[AXIS]_DISABLE` is defined in `cnc_hal_config.h`. 

### Cause of the Bug
In `cnc_hal_config_helper.h`, the logic assigning `STEP_UNDEF_IO_MASK` to `LIMIT_[AXIS]_IO_MASK` was incorrect, causing the disable configuration to be ignored and the limit switches to remain active.

Because `LIMIT_[AXIS]_IO_MASK` was not set correctly, `LINACT[0-3]_LIMIT_MASK` (which takes multi-motor configurations into account and is defined later) was also configured incorrectly.

### Solution
Modified `cnc_hal_config_helper.h` to correctly assign `STEP_UNDEF_IO_MASK` when `LIMIT_[AXIS]_DISABLE` is defined.

## Tested Board
* **MKS Monster8 V2.0**

## How to Test / Verification Results

### 1. Verification of Pin Status
When defining `#define LIMIT_Z_DISABLE` in `cnc_hal_config.h` and triggering the Z-axis limit switch, sending the `$?` command still reported the Z-axis limit as active (`Pn:PZ`):
```text
<Idle|MPos:5.000,0.000,0.000,0.000,0.000,0.000|FS:0.000,0|Pn:PZ>
```

### 2. Error Reproduction
Furthermore, attempting to home only the X-axis ($HX) under this condition triggered an alarm due to the active Z-axis limit switch:

```text
ALARM:11
error:254
Grbl 1.1f ['$' for help]
[MSG:'$H'|'$X' to unlock]
```

### 3. After the Fix
After applying this fix, Pn:PZ is no longer displayed, the Z-axis limit switch is successfully ignored, and homing other axes ($HX) works perfectly without triggering an alarm.