### PR TITLE
Fix compilation error in core/planner.c when FORCE_GLOBALS_TO_0 is en…

### DIFF
--- a/uCNC/src/core/planner.c
+++ b/uCNC/src/core/planner.c
@@ -302,10 +302,8 @@ static void planner_buffer_clear(void)
 void planner_init(void)
 {
 #ifdef FORCE_GLOBALS_TO_0
-#if TOOL_COUNT > 0
-	planner_state.planner_spindle = 0;
-	planner_state.coolant = 0;
-#endif
+	memset(planner_data, 0, sizeof(planner_data));
+	memset(&g_planner_state, 0, sizeof(g_planner_state));
 #endif
 	planner_buffer_clear();
 	planner_feed_ovr(100);


### PR DESCRIPTION
## Description

This PR fixes a compilation error that occurs in `core/planner.c` when the `FORCE_GLOBALS_TO_0` macro is enabled.

### Cause
The error was caused by an attempt to initialize a variable that appears to have been defined in an older version of the codebase but is no longer present.

### Changes Made
- Removed the obsolete initialization code that caused the compilation failure.
- Added the initialization code for  variables used in the current version.
