### PR TITLE
Fixed fall back to default settings when EEPROM load fails

### DIFF
--- a/uCNC/src/interface/grbl_settings.c
+++ b/uCNC/src/interface/grbl_settings.c
@@ -299,6 +299,7 @@ void settings_init(void)
 		settings_reset(true);
 #endif
 		proto_error(STATUS_SETTING_READ_FAIL);
+		rom_memcpy(&g_settings, &default_settings, sizeof(settings_t));
 		proto_cnc_settings();
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the motor fails to operate properly due to unitialized configuration values (resulting in `nan` or division by zero) when EEPROM load fails on startup. 

Following Grbl's behavior, uCNC will now fallback and load the default settings when the EEPROM read fails (error code 7), preventing uninitialized state bugs on hardware with limited or missing EEPROM support.

---

## Technical Details & Bug Symptoms

### Problem
On certain microcontrollers (such as the STM32 series), EEPROM is unavailable by default, which guarantees an EEPROM load failure on startup. 
Without this PR's fix (loading default settings on failure), the global configuration struct `g_settings` remains uninitialized. This results in:
1. `g_settings` `float` variables contains `nan` or `0`.
2. Be executed  multiplications by `nan` and divisions by zero during the initialization process.
3. Crucial variables like `mc_last_target[]` and `parser_last_pos[]` becoming `nan`, which ultimately freezes or breaks motor operations. (IEEE 754 behavior)

### Key Factors
* **`RAM_ONLY_SETTINGS` Macro:** Unless this macro is explicitly defined, the above issue **always** occurs on power-on or hard resets on boards with no EEPROM support.
* **`FORCE_GLOBALS_TO_0` Macro:** Even if this macro is enabled (initializing globals to `0`), it still triggers a division-by-zero error when processing `step_per_mm[]`, leading to the exact same motor failure.

---

## Test Environment

* **Board:** MKS Monster8 V2 (STM32-based)
* Also verified/reproduced the core issue on **MKS Gen_L V2.1**.

---

## Future Improvements & Potential Concerns

During the investigation, I found that the same motor failure (variables turning into `nan`) can also be triggered manually by a user setting critical float configurations to `0.0` via `$` commands.

### Steps to Reproduce via `$` Commands:
```gcode
> $RST=*
ok
> $100=0.0
ok
> G0 x5
ok
> G999    <- Triggers an error to execute division in kinematics_apply_forward()
error:20
(At this point, mc_last_target[0] and parser_last_pos[0] become "nan")
> $100=200.0
> G0 x5
ok       <- The motor does not move, or moves extremely slowly compared to the actual feedrate.
```

### Proposed Solutions for Future Discussion:

To robustly prevent division-by-zero or nan propagation from g_settings, we might need to consider:

Zero-check on division points: Implementing safety checks before divisions (though this might impact execution speed and latency).

Input Validation: Restricting users from configuring critical values to 0 or negative numbers during $ command parsing.

As of July 15, 2026 (master branch), the configuration values ​​used for division are as follows.

```
max_step_rate
step_per_mm[]
rtheta_theta_reduction_ratio
spindle_max_rpm
max_feed_rate
spindle_max_rpm
```

## Additional Context / Notes

In my STM32 environment where EEPROM is unavailable for saving settings, I am utilizing the `sd_card_v2` module with the `ENABLE_SETTINGS_ON_SD_SDCARD` macro enabled.

The fix in this PR has been verified to work perfectly under this SD card setup during the following operations:
* **Startup/Hard Reset:** Boots normally.
* **Delayed SD Insertion:** Inserting the SD card later and explicitly executing `$SL` successfully loads settings.
* **SD Card Removed:** Executing `$SL` after removing the SD card correctly returns error code 7 and falls back to the default settings.

*Note:* Just a small heads-up—if you modify some settings with `$SS` and pull the SD card out after saving, the data can sometimes get corrupted. It's probably just an SD card writing thing, but keep it in mind!