### PR TITLE
ESP8266 wifi crash fix

### DIFF
--- a/uCNC/src/hal/boards/esp8266/esp8266.ini
+++ b/uCNC/src/hal/boards/esp8266/esp8266.ini
@@ -19,7 +19,7 @@ lib_deps =
 		
 build_flags = ${env.build_flags} -D BOARDMAP=\"src/hal/boards/esp8266/boardmap_wemos_d1.h\" -D ENABLE_WIFI
 ; build_type=debug
-; monitor_filters = esp8266_exception_decoder
+monitor_filters = esp8266_exception_decoder
 upload_speed = 256000
 board_build.f_flash = 80000000L
 board_build.f_cpu = 160000000L

--- a/uCNC/src/hal/mcus/esp8266/mcu_esp8266.c
+++ b/uCNC/src/hal/mcus/esp8266/mcu_esp8266.c
@@ -466,13 +466,13 @@ void itp_buffer_dotasks(uint16_t limit)
 	running = false;
 }
 
-IRAM_ATTR void mcu_rtc_isr(void)
+IRAM_ATTR void mcu_rtc_isr(void* arg)
 {
 	mcu_runtime_ms++;
 	mcu_rtc_cb(mcu_runtime_ms);
 	itp_buffer_dotasks(OUT_IO_BUFFER_MINIMAL); // process at most 2ms of motion
-	uint32_t stamp = esp_get_cycle_count() + (ESP8266_CLOCK / 1000);
-	timer0_write(stamp);
+	// uint32_t stamp = esp_get_cycle_count() + (ESP8266_CLOCK / 1000);
+	// timer0_write(stamp);
 }
 
 // modifies the step generation mode
@@ -528,10 +528,12 @@ void mcu_init(void)
 
 	// kick start the RTC
 	// the RTC will start the ITP timer
-	uint32_t stamp = esp_get_cycle_count() + (ESP8266_CLOCK / 1000);
-	timer0_isr_init();
-	timer0_attachInterrupt(mcu_rtc_isr);
-	timer0_write(stamp);
+	// uint32_t stamp = esp_get_cycle_count() + (ESP8266_CLOCK / 1000);
+	// timer0_isr_init();
+	// timer0_attachInterrupt(mcu_rtc_isr);
+	// timer0_write(stamp);
+	os_timer_setfn(&esp8266_rtc_timer, (os_timer_func_t *)&mcu_rtc_isr, NULL);
+	os_timer_arm(&esp8266_rtc_timer, 1, true);
 }
 
 /**

--- a/uCNC/src/hal/mcus/esp8266/mcumap_esp8266.h
+++ b/uCNC/src/hal/mcus/esp8266/mcumap_esp8266.h
@@ -1440,9 +1440,15 @@ extern "C"
 	}
 
 // ISR
-#include <xtensa/corebits.h>
+// #include <xtensa/corebits.h>
 #define mcu_enable_global_isr() xt_rsil(0)
 #define mcu_disable_global_isr() xt_rsil(15)
+#ifndef PS_INTLEVEL_MASK
+#define PS_INTLEVEL_MASK	0x0000000F
+#endif
+#ifndef PS_EXCM_MASK
+#define PS_EXCM_MASK		0x00000010
+#endif
 #define mcu_get_global_isr() ({uint32_t ps; __asm__ __volatile__ ("rsr.ps %0" : "=r" (ps)); ((ps & PS_INTLEVEL_MASK) == 0); })
 #define mcu_in_isr_context() ({uint32_t ps; __asm__ __volatile__ ("rsr.ps %0" : "=r" (ps)); ((ps & PS_EXCM_MASK) == 0); })
 


### PR DESCRIPTION
- revert rtc to os timer since esp8266 wifi events depend on timer0