### PR TITLE
Update stm32.ini

### DIFF
--- a/uCNC/src/hal/boards/stm32/stm32.ini
+++ b/uCNC/src/hal/boards/stm32/stm32.ini
@@ -3,7 +3,7 @@
 ################
 
 [common_stm32]
-platform = platformio/ststm32@^17.5.0
+platform = platformio/ststm32@19.7.1
 ; debug with stlink or cmsis-dap
 ; upload_protocol = cmsis-dap
 debug_tool = stlink


### PR DESCRIPTION
PIO registry as removed several versions of the [platformio/framework-arduinoststm32](https://registry.platformio.org/tools/platformio/framework-arduinoststm32) package, including the one used by the used by the current config. The way to overcome this is to update the base version of the framework.